### PR TITLE
fix: stabilize resume pointer and freeze category totals

### DIFF
--- a/tests/test_state_manager_resume_ptr.py
+++ b/tests/test_state_manager_resume_ptr.py
@@ -1,0 +1,25 @@
+import pytest
+
+from utils.fixed_enhanced_state_manager import FixedEnhancedStateManager
+
+
+def test_set_get_resumption_ptr(tmp_path):
+    sm = FixedEnhancedStateManager("test", base_path=tmp_path)
+    sm.set_resumption_ptr(1, 5)
+    assert sm.get_resumption_ptr() == (1, 5)
+    # regression attempts should not decrease pointer
+    sm.set_resumption_ptr(0, 10)
+    assert sm.get_resumption_ptr() == (1, 5)
+    sm.set_resumption_ptr(1, 3)
+    assert sm.get_resumption_ptr() == (1, 5)
+    sm.set_resumption_ptr(2, 1)
+    assert sm.get_resumption_ptr() == (2, 1)
+
+
+def test_compute_supplier_config_hash_consistent(tmp_path):
+    sm = FixedEnhancedStateManager("test", base_path=tmp_path)
+    urls1 = ["b", "a"]
+    urls2 = ["a", "b"]
+    h1 = sm.compute_supplier_config_hash(urls1)
+    h2 = sm.compute_supplier_config_hash(urls2)
+    assert h1 == h2

--- a/tools/configurable_supplier_scraper.py
+++ b/tools/configurable_supplier_scraper.py
@@ -12,7 +12,7 @@ import re
 import asyncio
 import time
 import json
-import random # For jitter in retries
+import random  # For jitter in retries
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, Any, List, Optional, Union
@@ -23,6 +23,7 @@ import aiohttp
 # Playwright imports with graceful fallback
 try:
     from playwright.async_api import async_playwright, Browser, BrowserContext, Page
+
     PLAYWRIGHT_AVAILABLE = True
 except ImportError:
     PLAYWRIGHT_AVAILABLE = False
@@ -31,6 +32,7 @@ except ImportError:
 # Import centralized browser manager
 try:
     from utils.browser_manager import get_browser_manager, get_page_for_url
+
     BROWSER_MANAGER_AVAILABLE = True
 except ImportError:
     # Fallback if browser manager not available
@@ -40,13 +42,15 @@ except ImportError:
 
 # Load environment variables
 from dotenv import load_dotenv
+
 load_dotenv()
 
 # Import config loader for supplier selector configuration
 import sys
+
 # Add both parent directory and config directory to path for standalone execution
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'config'))
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "config"))
 
 try:
     from config.supplier_config_loader import load_supplier_selectors, get_domain_from_url
@@ -54,20 +58,26 @@ except ImportError:
     try:
         # Alternative path when run from tools directory
         import sys
-        sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'config'))
+
+        sys.path.append(os.path.join(os.path.dirname(__file__), "..", "config"))
         from supplier_config_loader import load_supplier_selectors, get_domain_from_url
     except ImportError:
         # Final fallback - define minimal functions
         def load_supplier_selectors(domain: str):
             """Fallback function to load selectors"""
             return {}
+
         def get_domain_from_url(url: str):
             """Fallback function to get domain from URL"""
             from urllib.parse import urlparse
+
             return urlparse(url).netloc.replace("www.", "")
 
+
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 log = logging.getLogger(__name__)
 
 # Constants
@@ -84,9 +94,16 @@ class ConfigurableSupplierScraper:
     Features include full JavaScript support, dynamic content handling, and flexible selectors.
     """
 
-    def __init__(self, ai_client: Optional[Any] = None, openai_model_name: str = None, 
-                 headless: bool = False, use_shared_chrome: bool = True, 
-                 auth_callback: Optional[callable] = None, browser_manager=None):
+    def __init__(
+        self,
+        ai_client: Optional[Any] = None,
+        openai_model_name: str = None,
+        headless: bool = False,
+        use_shared_chrome: bool = True,
+        auth_callback: Optional[callable] = None,
+        browser_manager=None,
+        state_manager=None,
+    ):
         """
         Initialize the configurable supplier scraper with Playwright.
 
@@ -99,33 +116,41 @@ class ConfigurableSupplierScraper:
         """
         # Load system configuration first
         self.system_config = self._load_system_config()
-        
+
         # Browser management - prefer passed BrowserManager first, then check availability
         self.browser_manager = browser_manager
-        self.use_browser_manager = (browser_manager is not None) or (BROWSER_MANAGER_AVAILABLE and use_shared_chrome)
+        self.use_browser_manager = (browser_manager is not None) or (
+            BROWSER_MANAGER_AVAILABLE and use_shared_chrome
+        )
         self.playwright = None
         self.browser: Optional[Browser] = None
         self.context: Optional[BrowserContext] = None
-        
+
         # Progress tracking callback
         self.progress_callback = None
-        
+        # Optional state manager for debounced saves
+        self.state_manager = state_manager
+
         # Authentication callback for multi-tier authentication integration
         self.auth_callback = auth_callback
-        
+
         self.headless = headless
         self.use_shared_chrome = use_shared_chrome
         # Note: CDP endpoint dynamically determined by browser_manager (IPv6/IPv4 dual-stack)
-        self.cdp_endpoint = "http://localhost:9222"  # Fallback only - browser_manager handles actual connections
-        
+        self.cdp_endpoint = (
+            "http://localhost:9222"  # Fallback only - browser_manager handles actual connections
+        )
+
         # PHASE 1: Add session management for aiohttp
         self._session = None
-        
+
         if self.use_browser_manager:
             log.info("🔧 ConfigurableSupplierScraper will use centralized BrowserManager")
         else:
-            log.info("⚠️ Using legacy browser management (BrowserManager not available or disabled)")
-        
+            log.info(
+                "⚠️ Using legacy browser management (BrowserManager not available or disabled)"
+            )
+
         # AI client for fallback extraction with dynamic config loading
         self.ai_client = ai_client
         self.openai_model = openai_model_name or self._get_ai_model_from_config()
@@ -137,20 +162,22 @@ class ConfigurableSupplierScraper:
         # Cache for loaded selector configurations
         self.loaded_selector_configs: Dict[str, Dict[str, Any]] = {}
         self.supplier_config = {}
-        
+
         # Setup debug logging to logs/debug/ directory
         self._setup_debug_logging()
-        
+
         log.info(f"[CONFIG] Initialized with AI model: {self.openai_model}")
         log.info(f"[TARGET] Extraction targets loaded: {list(self.extraction_targets.keys())}")
-        log.info(f"[ASSIST] Discovery assistance enabled: {self.discovery_assistance.get('enabled', False)}")
+        log.info(
+            f"[ASSIST] Discovery assistance enabled: {self.discovery_assistance.get('enabled', False)}"
+        )
 
     def _setup_debug_logging(self):
         """Setup debug logging to logs/debug/supplier_scraping_debug_YYYYMMDD.log"""
         # DISABLED: This was overriding the main script's logging configuration
         # The main script (run_custom_poundwholesale.py) already sets up proper logging
         return
-        
+
         # try:
         #     # Import path manager for standardized logging
         #     import sys
@@ -164,54 +191,56 @@ class ConfigurableSupplierScraper:
         #         # Fallback path setup
         #         log.warning("Could not import path_manager, using fallback logging")
         #         return
-            
+
         #     # Create debug log file with current date and time for separate runs
         #     from datetime import datetime
         #     date_time_str = datetime.now().strftime('%Y%m%d_%H%M%S')
         #     debug_log_path = get_log_path("debug", f"supplier_scraping_debug_{date_time_str}.log")
-            
+
         #     # Add file handler to logger
         #     debug_handler = logging.FileHandler(debug_log_path)
         #     debug_handler.setLevel(logging.DEBUG)
         #     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
         #     debug_handler.setFormatter(formatter)
-            
+
         #     # Add handler to both module logger and class logger
         #     log.addHandler(debug_handler)
         #     log.setLevel(logging.DEBUG)
-            
+
         #     log.debug(f"Debug logging initialized - writing to {debug_log_path}")
         #     log.debug(f"Headless mode: {self.headless}")
-            
+
         # except Exception as e:
         #     log.warning(f"Failed to setup debug logging: {e}")
-    
+
     def _load_system_config(self) -> Dict[str, Any]:
         """Load system configuration from system_config.json"""
         try:
-            config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config", "system_config.json")
-            with open(config_path, 'r', encoding='utf-8') as f:
+            config_path = os.path.join(
+                os.path.dirname(os.path.dirname(__file__)), "config", "system_config.json"
+            )
+            with open(config_path, "r", encoding="utf-8") as f:
                 config = json.load(f)
                 log.info(f"✅ Loaded system configuration from {config_path}")
                 return config
         except Exception as e:
             log.error(f"❌ Failed to load system configuration: {e}")
             return {}
-    
+
     def _get_ai_model_from_config(self) -> str:
         """Get AI model name from system configuration"""
         ai_config = self.system_config.get("ai_selector_extraction", {})
         model = ai_config.get("ai_model", OPENAI_MODEL_NAME_DEFAULT)
         log.debug(f"AI model from config: {model}")
         return model
-    
+
     def _get_extraction_targets_from_config(self) -> Dict[str, List[str]]:
         """Get extraction targets from system configuration"""
         ai_config = self.system_config.get("ai_selector_extraction", {})
         targets = ai_config.get("extraction_targets", {})
         log.debug(f"Extraction targets from config: {targets}")
         return targets
-    
+
     def _get_discovery_assistance_from_config(self) -> Dict[str, Any]:
         """Get discovery assistance configuration"""
         discovery_config = self.system_config.get("discovery_assistance", {})
@@ -227,32 +256,37 @@ class ConfigurableSupplierScraper:
             Browser: The Playwright browser instance from BrowserManager
         """
         if not PLAYWRIGHT_AVAILABLE:
-            raise RuntimeError("Playwright not available. Install with: pip install playwright && playwright install")
-            
+            raise RuntimeError(
+                "Playwright not available. Install with: pip install playwright && playwright install"
+            )
+
         log.info("🔧 ConfigurableSupplierScraper connecting via BrowserManager singleton")
         try:
             # Always use the BrowserManager singleton for consistency
             from utils.browser_manager import BrowserManager
+
             browser_manager = BrowserManager.get_instance()
-            
+
             # Store reference to browser manager for later use
             self.browser_manager = browser_manager
             self.use_browser_manager = True
-            
+
             # Ensure browser manager is properly launched
-            if not hasattr(browser_manager, 'browser') or not browser_manager.browser:
+            if not hasattr(browser_manager, "browser") or not browser_manager.browser:
                 # Default to port 9222 if not specified
-                cdp_port = getattr(self, 'chrome_debug_port', 9222)
+                cdp_port = getattr(self, "chrome_debug_port", 9222)
                 await browser_manager.launch_browser(cdp_port=cdp_port)
-            
+
             # Get the shared browser instance
             self.browser = browser_manager.browser
             log.info("✅ ConfigurableSupplierScraper connected via BrowserManager singleton")
-            
+
             return self.browser
         except Exception as e:
             log.error(f"❌ ConfigurableSupplierScraper failed to connect via BrowserManager: {e}")
-            log.error("Ensure Chrome is running with --remote-debugging-port=9222 and BrowserManager is properly initialized")
+            log.error(
+                "Ensure Chrome is running with --remote-debugging-port=9222 and BrowserManager is properly initialized"
+            )
             raise
 
     async def _get_context(self) -> BrowserContext:
@@ -266,18 +300,18 @@ class ConfigurableSupplierScraper:
             browser = await self._ensure_browser()
             self.context = await browser.new_context(
                 user_agent=USER_AGENT,
-                viewport={'width': 1920, 'height': 1080},
-                locale='en-US',
-                timezone_id='America/New_York',
+                viewport={"width": 1920, "height": 1080},
+                locale="en-US",
+                timezone_id="America/New_York",
                 extra_http_headers={
-                    'Accept-Language': 'en-US,en;q=0.9',
-                    'Accept-Encoding': 'gzip, deflate, br',
-                    'Cache-Control': 'max-age=0',
-                    'Sec-Fetch-Dest': 'document',
-                    'Sec-Fetch-Mode': 'navigate',
-                    'Sec-Fetch-Site': 'none',
-                    'Upgrade-Insecure-Requests': '1'
-                }
+                    "Accept-Language": "en-US,en;q=0.9",
+                    "Accept-Encoding": "gzip, deflate, br",
+                    "Cache-Control": "max-age=0",
+                    "Sec-Fetch-Dest": "document",
+                    "Sec-Fetch-Mode": "navigate",
+                    "Sec-Fetch-Site": "none",
+                    "Upgrade-Insecure-Requests": "1",
+                },
             )
             log.debug("Created new browser context with realistic settings")
         return self.context
@@ -285,15 +319,16 @@ class ConfigurableSupplierScraper:
     async def _get_session(self):
         """
         Get or create an aiohttp session for URL validation and lightweight HTTP requests.
-        
+
         Returns:
             aiohttp.ClientSession: Session instance for HTTP requests
         """
         if self._session is None:
             import aiohttp
+
             self._session = aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT),
-                headers={'User-Agent': USER_AGENT}
+                headers={"User-Agent": USER_AGENT},
             )
             log.debug("Created new aiohttp session for HTTP requests")
         return self._session
@@ -316,7 +351,7 @@ class ConfigurableSupplierScraper:
             page = None
             try:
                 log.info(f"Fetching page content from: {url} (attempt {attempt + 1}/{retry_count})")
-                
+
                 # Always use BrowserManager for page creation
                 try:
                     if self.browser_manager:
@@ -325,18 +360,21 @@ class ConfigurableSupplierScraper:
                     else:
                         # Fallback to get BrowserManager instance
                         from utils.browser_manager import BrowserManager
+
                         browser_manager = BrowserManager.get_instance()
                         page = await browser_manager.get_page()
                         log.info(f"🔧 Using BrowserManager singleton page for {url}")
                 except Exception as e:
                     log.error(f"❌ Failed to get page from BrowserManager: {e}")
-                    raise RuntimeError("Cannot get page from BrowserManager - browser management centralization required")
-                
+                    raise RuntimeError(
+                        "Cannot get page from BrowserManager - browser management centralization required"
+                    )
+
                 # Add random delay to mimic human behavior
                 if attempt > 0:
                     human_delay = random.uniform(1.0, 3.0)
                     await asyncio.sleep(human_delay)
-                
+
                 # Navigate to page with timeout (skip if BrowserManager already navigated)
                 response = None
                 if self.use_browser_manager and page.url == url:
@@ -349,61 +387,76 @@ class ConfigurableSupplierScraper:
                         response = await page.goto(
                             url,
                             timeout=REQUEST_TIMEOUT * 1000,  # Playwright uses milliseconds
-                            wait_until='domcontentloaded'  # Wait for DOM to be ready
+                            wait_until="domcontentloaded",  # Wait for DOM to be ready
                         )
                     except Exception as nav_error:
                         log.warning(f"Navigation failed for {url}: {nav_error}")
                         response = None
-                    
+
                 if response is None:
                     log.warning(f"No response received for {url} (attempt {attempt + 1})")
                     continue
-                    
+
                 # Check for rate limiting or blocks (skip if using BrowserManager)
-                if hasattr(response, 'status'):
+                if hasattr(response, "status"):
                     if response.status == 429:
                         retry_after = 5  # Default wait time
-                        log.warning(f"Rate limited (429) for {url}. Waiting {retry_after}s before retry.")
+                        log.warning(
+                            f"Rate limited (429) for {url}. Waiting {retry_after}s before retry."
+                        )
                         await asyncio.sleep(retry_after)
                         continue
                     elif response.status >= 400:
                         log.warning(f"HTTP {response.status} for {url} (attempt {attempt + 1})")
                         if response.status in [403, 503]:  # Possible bot detection
-                            wait_time = (2 ** attempt) + random.uniform(2.0, 5.0)
-                            log.info(f"Possible bot detection, waiting {wait_time:.2f}s before retry...")
+                            wait_time = (2**attempt) + random.uniform(2.0, 5.0)
+                            log.info(
+                                f"Possible bot detection, waiting {wait_time:.2f}s before retry..."
+                            )
                             await asyncio.sleep(wait_time)
                             continue
                 else:
                     # BrowserManager case - assume successful navigation
                     log.info(f"🔧 BrowserManager navigation assumed successful for {url}")
-                    
+
                     try:
                         # Wait for page to be fully loaded (handles dynamic content)
-                        await page.wait_for_load_state('networkidle', timeout=10000)
-                        
+                        await page.wait_for_load_state("networkidle", timeout=10000)
+
                         # Get page content
                         html_content = await page.content()
-                        
+
                         # Validate content
                         if not html_content or len(html_content) < 500:
-                            log.warning(f"Suspiciously small response size ({len(html_content)} bytes) for {url}.")
-                            if "<html" not in html_content.lower() or "<body" not in html_content.lower():
-                                log.warning(f"Response from {url} doesn't appear to be valid HTML. Retrying if attempts left.")
+                            log.warning(
+                                f"Suspiciously small response size ({len(html_content)} bytes) for {url}."
+                            )
+                            if (
+                                "<html" not in html_content.lower()
+                                or "<body" not in html_content.lower()
+                            ):
+                                log.warning(
+                                    f"Response from {url} doesn't appear to be valid HTML. Retrying if attempts left."
+                                )
                                 if attempt < retry_count - 1:
                                     await asyncio.sleep(2 * (attempt + 1))
                                 continue
-                        
-                        log.info(f"Successfully fetched content from {url} (Size: {len(html_content)} bytes)")
+
+                        log.info(
+                            f"Successfully fetched content from {url} (Size: {len(html_content)} bytes)"
+                        )
                         return html_content
-                        
+
                     except Exception as nav_error:
-                        log.error(f"Navigation error for {url} (attempt {attempt + 1}): {nav_error}")
+                        log.error(
+                            f"Navigation error for {url} (attempt {attempt + 1}): {nav_error}"
+                        )
                         # Don't immediately retry on navigation errors, let the outer retry logic handle it
                         raise nav_error
 
             except Exception as e:
                 log.error(f"Error fetching {url} (attempt {attempt + 1}): {e}")
-                
+
             finally:
                 # Only close page if NOT using BrowserManager (BrowserManager handles page lifecycle)
                 if page and not self.use_browser_manager:
@@ -413,7 +466,7 @@ class ConfigurableSupplierScraper:
                         log.warning(f"Error closing page: {close_error}")
 
             if attempt < retry_count - 1:
-                wait_time = (2 ** attempt) + random.uniform(0.5, 1.5)
+                wait_time = (2**attempt) + random.uniform(0.5, 1.5)
                 log.info(f"Retrying {url} in {wait_time:.2f}s...")
                 await asyncio.sleep(wait_time)
 
@@ -423,320 +476,417 @@ class ConfigurableSupplierScraper:
     async def fetch_html(self, url: str) -> Optional[str]:
         """Alias for get_page_content for compatibility."""
         return await self.get_page_content(url)
-    
+
     def set_progress_callback(self, callback_func):
         """Set progress tracking callback for workflow integration"""
         self.progress_callback = callback_func
 
-    async def scrape_products_from_url(self, url: str, max_products: int = 50, product_accumulator: List[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    async def scrape_products_from_url(
+        self, url: str, max_products: int = 50, product_accumulator: List[Dict[str, Any]] = None
+    ) -> List[Dict[str, Any]]:
         """Enhanced method to scrape products with pagination and individual product page visits.
         MEMORY LEAK FIX: Added aggressive memory management for supplier scraping.
-        
+
         Args:
             url: Category URL to scrape
             max_products: Maximum products to extract
             product_accumulator: Optional list to append products to in real-time for progress tracking
         """
         log.info(f"Starting enhanced scraping from {url} with memory management")
-        
+
         # MEMORY LEAK FIX: Initialize memory tracking
-        if hasattr(self, 'browser_manager') and self.browser_manager:
+        if hasattr(self, "browser_manager") and self.browser_manager:
             memory_info = await self.browser_manager.get_total_system_memory_usage()
             if memory_info:
-                log.info(f"🧠 Pre-scraping Memory: Chrome={memory_info.get('chrome_memory_mb', 0)}MB, Python={memory_info.get('python_memory_mb', 0)}MB, System={memory_info.get('memory_usage_percent', 0):.1f}%")
-        
+                log.info(
+                    f"🧠 Pre-scraping Memory: Chrome={memory_info.get('chrome_memory_mb', 0)}MB, Python={memory_info.get('python_memory_mb', 0)}MB, System={memory_info.get('memory_usage_percent', 0):.1f}%"
+                )
+
         # Step 1: Set page limiter to 60 products per page
         await self._set_page_limiter(url)
-        
+
         # Step 2: Collect all product URLs from all paginated pages
         all_product_urls = await self._collect_all_product_urls(url, max_products)
-        
+
         if not all_product_urls:
             log.warning(f"No product URLs found across all pages for {url}")
             return []
-        
+
         log.info(f"Found {len(all_product_urls)} total product URLs across all pages")
-        
+
         # 🚨 SURGICAL FIX: Store discovered count for state manager integration
         self.last_discovered_count = len(all_product_urls)
-        
+
         # EFFICIENCY IMPROVEMENT: Filter URLs against cache AND linking map to avoid unnecessary page visits
         try:
             from utils.url_cache_filter import get_cached_url_manager
-            
+
             # Get output root from system config (same as used elsewhere in workflow)
             output_root = "OUTPUTS"
-            if hasattr(self, 'system_config') and self.system_config:
+            if hasattr(self, "system_config") and self.system_config:
                 output_root = self.system_config.get("output_root", "OUTPUTS")
-            
+
             # Initialize URL cache manager and load existing cache
             url_manager = get_cached_url_manager(output_root)
-            
+
             # Determine supplier name for cache loading
-            domain = get_domain_from_url(url) if hasattr(self, 'get_domain_from_url') else None
+            domain = get_domain_from_url(url) if hasattr(self, "get_domain_from_url") else None
             if not domain:
                 from urllib.parse import urlparse
+
                 domain = urlparse(url).netloc.replace("www.", "")
-            
+
             # Load existing cache URLs
             loaded_count = url_manager.load_supplier_cache_urls(domain)
             log.info(f"🚀 URL Cache: Loaded {loaded_count} cached URLs for efficiency filtering")
-            
+
             # 🚨 CRITICAL FIX: Load linking map URLs to catch already-processed products
             # 🚨 SURGICAL FIX #5: ENSURE CONSISTENT METHOD USAGE - Use proper linking map path
             # Get the proper linking map path that matches the main workflow's expectation
             supplier_name = domain  # Use domain as supplier name
             output_root_path = Path(output_root)
-            linking_map_path = output_root_path / "FBA_ANALYSIS" / "linking_maps" / supplier_name / "linking_map.json"
-            
+            linking_map_path = (
+                output_root_path
+                / "FBA_ANALYSIS"
+                / "linking_maps"
+                / supplier_name
+                / "linking_map.json"
+            )
+
             linking_loaded_count = url_manager.load_linking_map_urls(str(linking_map_path))
-            log.info(f"🚀 URL Linking Map: Loaded {linking_loaded_count} processed URLs from {linking_map_path}")
-            
+            log.info(
+                f"🚀 URL Linking Map: Loaded {linking_loaded_count} processed URLs from {linking_map_path}"
+            )
+
             # Filter URLs to only include those not in cache OR linking map
             original_count = len(all_product_urls)
             all_product_urls = url_manager.filter_new_urls(all_product_urls)
             filtered_count = len(all_product_urls)
-            
-            log.info(f"✅ URL Pre-filtering: {filtered_count} new URLs need processing, {original_count - filtered_count} already cached")
-            
+
+            log.info(
+                f"✅ URL Pre-filtering: {filtered_count} new URLs need processing, {original_count - filtered_count} already cached"
+            )
+
             if filtered_count == 0:
                 log.info("🎯 All URLs are already cached/processed - no new products to scrape!")
                 return []  # Return empty list if all URLs are cached
-            
+
         except Exception as filter_error:
             log.warning(f"⚠️ URL pre-filtering failed: {filter_error} - continuing with all URLs")
             # Continue with original URL list if filtering fails
-        
+
         # Step 3: Visit individual product pages to extract detailed data
         products = []  # Local list for return value
         # Use product_accumulator for real-time updates if provided
         base_url = f"{urlparse(url).scheme}://{urlparse(url).netloc}"
-        
+
         # MEMORY LEAK FIX: Track memory and implement cleanup intervals
         memory_check_interval = 50  # Check memory every 50 products
         cleanup_interval = 100  # Force cleanup every 100 products
-        
+
         for i, product_url in enumerate(all_product_urls[:max_products]):
             try:
                 # 🚨 PROACTIVE AUTHENTICATION CHECK: Verify login every 25 products to prevent pricing failures
                 if i > 0 and i % 25 == 0:
                     try:
-                        if hasattr(self, 'browser_manager') and self.browser_manager:
-                            from tools.supplier_authentication_service import SupplierAuthenticationService
+                        if hasattr(self, "browser_manager") and self.browser_manager:
+                            from tools.supplier_authentication_service import (
+                                SupplierAuthenticationService,
+                            )
                             from config.system_config_loader import SystemConfigLoader
-                            
+
                             page = await self.browser_manager.get_page()
                             if page:
                                 auth_service = SupplierAuthenticationService(self.browser_manager)
                                 config_loader = SystemConfigLoader()
-                                credentials = config_loader.get_credentials('poundwholesale.co.uk')
-                                
+                                credentials = config_loader.get_credentials("poundwholesale.co.uk")
+
                                 if credentials:
-                                    log.info(f"🔐 PROACTIVE AUTH CHECK: Verifying login at product {i+1}")
-                                    authenticated = await auth_service.ensure_authenticated_session(page, credentials)
-                                    
+                                    log.info(
+                                        f"🔐 PROACTIVE AUTH CHECK: Verifying login at product {i+1}"
+                                    )
+                                    authenticated = await auth_service.ensure_authenticated_session(
+                                        page, credentials
+                                    )
+
                                     if not authenticated:
-                                        log.error(f"❌ PROACTIVE AUTH FAILED: Login expired at product {i+1} - attempting re-authentication")
+                                        log.error(
+                                            f"❌ PROACTIVE AUTH FAILED: Login expired at product {i+1} - attempting re-authentication"
+                                        )
                                     else:
-                                        log.debug(f"✅ PROACTIVE AUTH OK: Login verified at product {i+1}")
+                                        log.debug(
+                                            f"✅ PROACTIVE AUTH OK: Login verified at product {i+1}"
+                                        )
                     except Exception as proactive_auth_error:
-                        log.warning(f"⚠️ Proactive authentication check failed: {proactive_auth_error}")
-                
+                        log.warning(
+                            f"⚠️ Proactive authentication check failed: {proactive_auth_error}"
+                        )
+
                 # 🚨 FIX A-2: REMOVED MEMORY GUARD - Allow infinite processing
                 # Regular memory monitoring and cleanup (without stopping)
                 if i > 0 and i % memory_check_interval == 0:
-                    if hasattr(self, 'browser_manager') and self.browser_manager:
+                    if hasattr(self, "browser_manager") and self.browser_manager:
                         memory_healthy = await self.browser_manager.memory_check_with_cleanup(i)
                         if not memory_healthy:
-                            log.warning(f"⚠️ MEMORY PRESSURE: High memory usage at product {i} - cleanup performed but continuing")
+                            log.warning(
+                                f"⚠️ MEMORY PRESSURE: High memory usage at product {i} - cleanup performed but continuing"
+                            )
                             # Removed break - system continues processing
-                
+
                 # MEMORY LEAK FIX: Force cleanup every 100 products
                 if i > 0 and i % cleanup_interval == 0:
-                    if hasattr(self, 'browser_manager') and self.browser_manager:
+                    if hasattr(self, "browser_manager") and self.browser_manager:
                         await self.browser_manager.force_memory_cleanup()
                         log.info(f"🧹 Forced memory cleanup after product {i}")
-                
-                log.info(f"Visiting product page {i+1}/{len(all_product_urls[:max_products])}: {product_url}")
-                
+
+                log.info(
+                    f"Visiting product page {i+1}/{len(all_product_urls[:max_products])}: {product_url}"
+                )
+
                 # Get individual product page content
                 product_html = await self.get_page_content(product_url)
                 if not product_html:
                     log.warning(f"Failed to fetch product page: {product_url}")
                     continue
-                
+
                 # MEMORY LEAK FIX: Use context manager for BeautifulSoup to ensure cleanup
                 soup = None
                 try:
-                    soup = BeautifulSoup(product_html, 'html.parser')
-                    
+                    soup = BeautifulSoup(product_html, "html.parser")
+
                     # Extract core product data from individual product page
-                    title = self._extract_text_by_selector(soup, ["h1.page-title .base", "[data-ui-id='page-title-wrapper']"])
+                    title = self._extract_text_by_selector(
+                        soup, ["h1.page-title .base", "[data-ui-id='page-title-wrapper']"]
+                    )
                     # CRITICAL FIX: Use configurable price extraction instead of hardcoded selectors
                     price = await self.extract_price(soup, product_html, product_url)
-                    ean = self._extract_text_by_selector(soup, [".value.attribute-code-product_barcode"])
-                    sku = self._extract_text_by_selector(soup, [".value.attribute-code-sku", "[itemprop='sku']"])
-                    availability = self._extract_text_by_selector(soup, [".stock.available", ".stock.unavailable"])
-                    
+                    ean = self._extract_text_by_selector(
+                        soup, [".value.attribute-code-product_barcode"]
+                    )
+                    sku = self._extract_text_by_selector(
+                        soup, [".value.attribute-code-sku", "[itemprop='sku']"]
+                    )
+                    availability = self._extract_text_by_selector(
+                        soup, [".stock.available", ".stock.unavailable"]
+                    )
+
                     # Get image from product page or fallback to placeholder
-                    image_url = self._extract_image_by_selector(soup, ["img.product-image-photo", ".product-image img"])
-                    
+                    image_url = self._extract_image_by_selector(
+                        soup, ["img.product-image-photo", ".product-image img"]
+                    )
+
                     # Create product data
                     product = {
-                        'title': title,
-                        'price': price,
-                        'url': product_url,
-                        'ean': ean,
-                        'sku': sku,
-                        'availability': availability,
-                        'image_url': image_url,
-                        'source_url': url,
-                        'scraped_at': datetime.now().isoformat()
+                        "title": title,
+                        "price": price,
+                        "url": product_url,
+                        "ean": ean,
+                        "sku": sku,
+                        "availability": availability,
+                        "image_url": image_url,
+                        "source_url": url,
+                        "scraped_at": datetime.now().isoformat(),
                     }
-                    
+
                     # Authentication evaluation for multi-tier authentication system
                     if self.auth_callback:
                         try:
                             # Call authentication callback with price and product index
-                            await self.auth_callback(price, i+1)
+                            await self.auth_callback(price, i + 1)
                         except Exception as auth_error:
-                            log.warning(f"🔐 Authentication callback error for product {i+1}: {auth_error}")
-                    
+                            log.warning(
+                                f"🔐 Authentication callback error for product {i+1}: {auth_error}"
+                            )
+
                     # Only include products with valid data and apply price filtering
                     if title and price:
                         # Apply price filtering if max_price is configured
                         try:
                             price_float = float(price)
-                            max_price = getattr(self, 'max_price', 20.0)  # Default from system config
-                            if hasattr(self, 'system_config') and self.system_config:
-                                max_price = self.system_config.get('processing_limits', {}).get('max_price_gbp', 20.0)
-                            
+                            max_price = getattr(
+                                self, "max_price", 20.0
+                            )  # Default from system config
+                            if hasattr(self, "system_config") and self.system_config:
+                                max_price = self.system_config.get("processing_limits", {}).get(
+                                    "max_price_gbp", 20.0
+                                )
+
                             if price_float <= max_price:
                                 products.append(product)  # Always add to local return list
-                                
+
                                 # 🚨 DEFINITIVE FIX: Add to shared accumulator for real-time progress tracking
                                 if product_accumulator is not None:
                                     product_accumulator.append(product)
-                                    log.info(f"🔄 REAL-TIME: Added product {i+1} to shared accumulator (total: {len(product_accumulator)})")
-                                    
+                                    log.info(
+                                        f"🔄 REAL-TIME: Added product {i+1} to shared accumulator (total: {len(product_accumulator)})"
+                                    )
+
                                     # 🧹 MEMORY LEAK FIX: Clear local products list periodically to prevent memory accumulation
                                     if len(products) > 100:  # Clear every 100 products
-                                        log.info(f"🧹 Clearing local products list to prevent memory leak ({len(products)} items)")
+                                        log.info(
+                                            f"🧹 Clearing local products list to prevent memory leak ({len(products)} items)"
+                                        )
                                         products.clear()
                                         import gc
+
                                         gc.collect()
-                                
-                                log.info(f"✅ Extracted product {i+1}: {title} - £{price} (EAN: {ean or 'N/A'})")
-                                
+
+                                log.info(
+                                    f"✅ Extracted product {i+1}: {title} - £{price} (EAN: {ean or 'N/A'})"
+                                )
+
                                 # EFFICIENCY IMPROVEMENT: Update URL cache with newly processed URL
                                 try:
-                                    if 'url_manager' in locals():
+                                    if "url_manager" in locals():
                                         url_manager.add_url_to_cache(product_url)
-                                        log.debug(f"🔄 Updated URL cache with new product: {product_url}")
+                                        log.debug(
+                                            f"🔄 Updated URL cache with new product: {product_url}"
+                                        )
                                 except Exception as cache_update_error:
-                                    log.debug(f"⚠️ Failed to update URL cache: {cache_update_error}")
-                                
+                                    log.debug(
+                                        f"⚠️ Failed to update URL cache: {cache_update_error}"
+                                    )
+
                             else:
-                                log.info(f"🛑 PRICE FILTER: Excluding '{title}' - £{price} > £{max_price} limit")
+                                log.info(
+                                    f"🛑 PRICE FILTER: Excluding '{title}' - £{price} > £{max_price} limit"
+                                )
                         except (ValueError, TypeError):
                             # Keep products with invalid/missing prices for now
                             products.append(product)
                             if product_accumulator is not None:
                                 product_accumulator.append(product)
                             log.warning(f"⚠️ Invalid price for '{title}': {price}")
-                            
+
                             # EFFICIENCY IMPROVEMENT: Update URL cache even for invalid price products
                             try:
-                                if 'url_manager' in locals():
+                                if "url_manager" in locals():
                                     url_manager.add_url_to_cache(product_url)
-                                    log.debug(f"🔄 Updated URL cache with invalid price product: {product_url}")
+                                    log.debug(
+                                        f"🔄 Updated URL cache with invalid price product: {product_url}"
+                                    )
                             except Exception as cache_update_error:
                                 log.debug(f"⚠️ Failed to update URL cache: {cache_update_error}")
-                        
+
                         # Call progress callback AFTER successful product extraction
                         if self.progress_callback:
-                            self.progress_callback('supplier_extraction', i+1, len(all_product_urls[:max_products]), product_url, product)
-                            
+                            self.progress_callback(
+                                "supplier_extraction",
+                                i + 1,
+                                len(all_product_urls[:max_products]),
+                                product_url,
+                                product,
+                            )
+
                     else:
                         log.warning(f"⚠️ Skipping product {i+1} - missing title or price")
-                        
+
                         # 🚨 CRITICAL FIX: Authentication check when price extraction fails
                         if not price:
-                            log.warning(f"🔍 Price extraction failed for product {i+1} - checking authentication")
-                            
+                            log.warning(
+                                f"🔍 Price extraction failed for product {i+1} - checking authentication"
+                            )
+
                             # Trigger authentication check when pricing fails
                             try:
-                                if hasattr(self, 'browser_manager') and self.browser_manager:
-                                    from tools.supplier_authentication_service import SupplierAuthenticationService
-                                    
+                                if hasattr(self, "browser_manager") and self.browser_manager:
+                                    from tools.supplier_authentication_service import (
+                                        SupplierAuthenticationService,
+                                    )
+
                                     # Get current page for authentication check
                                     page = await self.browser_manager.get_page()
                                     if page:
                                         # Check if we're still authenticated
-                                        auth_service = SupplierAuthenticationService(self.browser_manager)
-                                        
+                                        auth_service = SupplierAuthenticationService(
+                                            self.browser_manager
+                                        )
+
                                         # Get credentials (you may need to pass these from the workflow)
                                         from config.system_config_loader import SystemConfigLoader
+
                                         config_loader = SystemConfigLoader()
-                                        credentials = config_loader.get_credentials('poundwholesale.co.uk')
-                                        
+                                        credentials = config_loader.get_credentials(
+                                            "poundwholesale.co.uk"
+                                        )
+
                                         if credentials:
-                                            log.info(f"🔐 AUTHENTICATION CHECK: Verifying login status for product {i+1}")
-                                            authenticated = await auth_service.ensure_authenticated_session(page, credentials)
-                                            
+                                            log.info(
+                                                f"🔐 AUTHENTICATION CHECK: Verifying login status for product {i+1}"
+                                            )
+                                            authenticated = (
+                                                await auth_service.ensure_authenticated_session(
+                                                    page, credentials
+                                                )
+                                            )
+
                                             if not authenticated:
-                                                log.error(f"❌ AUTHENTICATION FAILED: Login expired during product extraction at product {i+1}")
-                                                log.info("🔄 RECOMMENDATION: Restart system or manually re-authenticate")
+                                                log.error(
+                                                    f"❌ AUTHENTICATION FAILED: Login expired during product extraction at product {i+1}"
+                                                )
+                                                log.info(
+                                                    "🔄 RECOMMENDATION: Restart system or manually re-authenticate"
+                                                )
                                             else:
-                                                log.info(f"✅ AUTHENTICATION OK: Login still valid, price extraction issue may be selector-related")
+                                                log.info(
+                                                    f"✅ AUTHENTICATION OK: Login still valid, price extraction issue may be selector-related"
+                                                )
                                         else:
-                                            log.warning("⚠️ No credentials available for authentication check")
+                                            log.warning(
+                                                "⚠️ No credentials available for authentication check"
+                                            )
                                     else:
                                         log.warning("⚠️ No page available for authentication check")
                                 else:
-                                    log.warning("⚠️ No browser manager available for authentication check")
-                                    
+                                    log.warning(
+                                        "⚠️ No browser manager available for authentication check"
+                                    )
+
                             except Exception as auth_error:
                                 log.warning(f"⚠️ Authentication check failed: {auth_error}")
-                                
-                            log.debug(f"🔍 Price extraction failed for product {i+1} - authentication check completed")
-                        
-                    
+
+                            log.debug(
+                                f"🔍 Price extraction failed for product {i+1} - authentication check completed"
+                            )
+
                 except Exception as product_error:
                     log.error(f"❌ Error processing individual product {i+1}: {product_error}")
-                    
+
                 finally:
                     # MEMORY LEAK FIX: Explicitly clear BeautifulSoup object and HTML content
                     if soup:
                         soup.clear()
                         soup = None
                     product_html = None  # Clear HTML content from memory
-                    
+
                     # MEMORY LEAK FIX: Force garbage collection every 25 products
                     if i > 0 and i % 25 == 0:
                         import gc
+
                         collected = gc.collect()
                         log.debug(f"🗑️ Garbage collected {collected} objects after product {i}")
-                
+
                 # Skip to next product if there was an error
                 continue
-                
+
             except Exception as outer_error:
                 log.error(f"❌ Outer loop error for product {i+1}: {outer_error}")
                 continue
-        
+
         # MEMORY LEAK FIX: Final memory status logging
-        if hasattr(self, 'browser_manager') and self.browser_manager:
+        if hasattr(self, "browser_manager") and self.browser_manager:
             final_memory = await self.browser_manager.get_total_system_memory_usage()
             if final_memory:
-                log.info(f"🧠 Post-scraping Memory: Chrome={final_memory.get('chrome_memory_mb', 0)}MB, Python={final_memory.get('python_memory_mb', 0)}MB, System={final_memory.get('memory_usage_percent', 0):.1f}%")
-        
+                log.info(
+                    f"🧠 Post-scraping Memory: Chrome={final_memory.get('chrome_memory_mb', 0)}MB, Python={final_memory.get('python_memory_mb', 0)}MB, System={final_memory.get('memory_usage_percent', 0):.1f}%"
+                )
+
         log.info(f"Successfully extracted {len(products)} products from {url}")
         return products
 
     # DISABLED: scrape_products_from_url_filtered method - confirmed broken and leads to extraction failures
     # This filtered variation breaks the pipeline per project memory requirements
-    # Use standard scrape_products_from_url method with pre-filtered URLs passed externally  
+    # Use standard scrape_products_from_url method with pre-filtered URLs passed externally
     # Method scrape_products_from_url_filtered disabled - confirmed broken per project memory
     # Use scrape_products_from_url instead
 
@@ -750,282 +900,365 @@ class ConfigurableSupplierScraper:
             product_accumulator: Optional list to append products to in real-time for progress tracking
             filtered_urls: Pre-filtered list of URLs that need full extraction
         """
-        log.info(f"Starting filtered scraping from {url} with {len(filtered_urls) if filtered_urls else 0} pre-filtered URLs")
-        
+        log.info(
+            f"Starting filtered scraping from {url} with {len(filtered_urls) if filtered_urls else 0} pre-filtered URLs"
+        )
+
         if not filtered_urls:
             log.info("No URLs need full extraction - returning empty list")
             return []
-        
+
         # MEMORY LEAK FIX: Initialize memory tracking
-        if hasattr(self, 'browser_manager') and self.browser_manager:
+        if hasattr(self, "browser_manager") and self.browser_manager:
             memory_info = await self.browser_manager.get_total_system_memory_usage()
             if memory_info:
-                log.info(f"🧠 Pre-scraping Memory: Chrome={memory_info.get('chrome_memory_mb', 0)}MB, Python={memory_info.get('python_memory_mb', 0)}MB, System={memory_info.get('memory_usage_percent', 0):.1f}%")
-        
+                log.info(
+                    f"🧠 Pre-scraping Memory: Chrome={memory_info.get('chrome_memory_mb', 0)}MB, Python={memory_info.get('python_memory_mb', 0)}MB, System={memory_info.get('memory_usage_percent', 0):.1f}%"
+                )
+
         # Step 1: Set page limiter to 60 products per page
         await self._set_page_limiter(url)
-        
+
         # Step 2: Use pre-filtered URLs instead of collecting all URLs
         all_product_urls = filtered_urls[:max_products]
-        
+
         log.info(f"Using {len(all_product_urls)} pre-filtered URLs for extraction")
-        
+
         # 🚨 SURGICAL FIX: Store discovered count for state manager integration
         self.last_discovered_count = len(all_product_urls)
-        
+
         # Step 3: Visit individual product pages to extract detailed data
         products = []  # Local list for return value
         # Use product_accumulator for real-time updates if provided
         base_url = f"{urlparse(url).scheme}://{urlparse(url).netloc}"
-        
+
         # MEMORY LEAK FIX: Track memory and implement cleanup intervals
         memory_check_interval = 50  # Check memory every 50 products
         cleanup_interval = 100  # Force cleanup every 100 products
-        
+
         for i, product_url in enumerate(all_product_urls):
             try:
                 # 🚨 PROACTIVE AUTHENTICATION CHECK: Verify login every 25 products to prevent pricing failures
                 if i > 0 and i % 25 == 0:
                     try:
-                        if hasattr(self, 'browser_manager') and self.browser_manager:
-                            from tools.supplier_authentication_service import SupplierAuthenticationService
+                        if hasattr(self, "browser_manager") and self.browser_manager:
+                            from tools.supplier_authentication_service import (
+                                SupplierAuthenticationService,
+                            )
                             from config.system_config_loader import SystemConfigLoader
-                            
+
                             page = await self.browser_manager.get_page()
                             if page:
                                 auth_service = SupplierAuthenticationService(self.browser_manager)
                                 config_loader = SystemConfigLoader()
-                                credentials = config_loader.get_credentials('poundwholesale.co.uk')
-                                
+                                credentials = config_loader.get_credentials("poundwholesale.co.uk")
+
                                 if credentials:
-                                    log.info(f"🔐 PROACTIVE AUTH CHECK: Verifying login at product {i+1}")
-                                    authenticated = await auth_service.ensure_authenticated_session(page, credentials)
-                                    
+                                    log.info(
+                                        f"🔐 PROACTIVE AUTH CHECK: Verifying login at product {i+1}"
+                                    )
+                                    authenticated = await auth_service.ensure_authenticated_session(
+                                        page, credentials
+                                    )
+
                                     if not authenticated:
-                                        log.error(f"❌ PROACTIVE AUTH FAILED: Login expired at product {i+1} - attempting re-authentication")
+                                        log.error(
+                                            f"❌ PROACTIVE AUTH FAILED: Login expired at product {i+1} - attempting re-authentication"
+                                        )
                                     else:
-                                        log.debug(f"✅ PROACTIVE AUTH OK: Login verified at product {i+1}")
+                                        log.debug(
+                                            f"✅ PROACTIVE AUTH OK: Login verified at product {i+1}"
+                                        )
                     except Exception as proactive_auth_error:
-                        log.warning(f"⚠️ Proactive authentication check failed: {proactive_auth_error}")
-                
+                        log.warning(
+                            f"⚠️ Proactive authentication check failed: {proactive_auth_error}"
+                        )
+
                 # Regular memory monitoring and cleanup (without stopping)
                 if i > 0 and i % memory_check_interval == 0:
-                    if hasattr(self, 'browser_manager') and self.browser_manager:
+                    if hasattr(self, "browser_manager") and self.browser_manager:
                         memory_healthy = await self.browser_manager.memory_check_with_cleanup(i)
                         if not memory_healthy:
-                            log.warning(f"⚠️ MEMORY PRESSURE: High memory usage at product {i} - cleanup performed but continuing")
-                
+                            log.warning(
+                                f"⚠️ MEMORY PRESSURE: High memory usage at product {i} - cleanup performed but continuing"
+                            )
+
                 # MEMORY LEAK FIX: Force cleanup every 100 products
                 if i > 0 and i % cleanup_interval == 0:
-                    if hasattr(self, 'browser_manager') and self.browser_manager:
+                    if hasattr(self, "browser_manager") and self.browser_manager:
                         await self.browser_manager.force_memory_cleanup()
                         log.info(f"🧹 Forced memory cleanup after product {i}")
-                
+
                 log.info(f"Visiting product page {i+1}/{len(all_product_urls)}: {product_url}")
-                
+
                 # Get individual product page content
                 product_html = await self.get_page_content(product_url)
                 if not product_html:
                     log.warning(f"Failed to fetch product page: {product_url}")
                     continue
-                
+
                 # MEMORY LEAK FIX: Use context manager for BeautifulSoup to ensure cleanup
                 soup = None
                 try:
-                    soup = BeautifulSoup(product_html, 'html.parser')
-                    
+                    soup = BeautifulSoup(product_html, "html.parser")
+
                     # Extract core product data from individual product page
-                    title = self._extract_text_by_selector(soup, ["h1.page-title .base", "[data-ui-id='page-title-wrapper']"])
+                    title = self._extract_text_by_selector(
+                        soup, ["h1.page-title .base", "[data-ui-id='page-title-wrapper']"]
+                    )
                     # CRITICAL FIX: Use configurable price extraction instead of hardcoded selectors
                     price = await self.extract_price(soup, product_html, product_url)
-                    ean = self._extract_text_by_selector(soup, [".value.attribute-code-product_barcode"])
-                    sku = self._extract_text_by_selector(soup, [".value.attribute-code-sku", "[itemprop='sku']"])
-                    availability = self._extract_text_by_selector(soup, [".stock.available", ".stock.unavailable"])
-                    
+                    ean = self._extract_text_by_selector(
+                        soup, [".value.attribute-code-product_barcode"]
+                    )
+                    sku = self._extract_text_by_selector(
+                        soup, [".value.attribute-code-sku", "[itemprop='sku']"]
+                    )
+                    availability = self._extract_text_by_selector(
+                        soup, [".stock.available", ".stock.unavailable"]
+                    )
+
                     # Get image from product page or fallback to placeholder
-                    image_url = self._extract_image_by_selector(soup, ["img.product-image-photo", ".product-image img"])
-                    
+                    image_url = self._extract_image_by_selector(
+                        soup, ["img.product-image-photo", ".product-image img"]
+                    )
+
                     # Create product data
                     product = {
-                        'title': title,
-                        'price': price,
-                        'url': product_url,
-                        'ean': ean,
-                        'sku': sku,
-                        'availability': availability,
-                        'image_url': image_url,
-                        'source_url': url,
-                        'scraped_at': datetime.now().isoformat()
+                        "title": title,
+                        "price": price,
+                        "url": product_url,
+                        "ean": ean,
+                        "sku": sku,
+                        "availability": availability,
+                        "image_url": image_url,
+                        "source_url": url,
+                        "scraped_at": datetime.now().isoformat(),
                     }
-                    
+
                     # Authentication evaluation for multi-tier authentication system
                     if self.auth_callback:
                         try:
                             # Call authentication callback with price and product index
-                            await self.auth_callback(price, i+1)
+                            await self.auth_callback(price, i + 1)
                         except Exception as auth_error:
-                            log.warning(f"🔐 Authentication callback error for product {i+1}: {auth_error}")
-                    
+                            log.warning(
+                                f"🔐 Authentication callback error for product {i+1}: {auth_error}"
+                            )
+
                     # Only include products with valid data and apply price filtering
                     if title and price:
                         # Apply price filtering if max_price is configured
                         try:
                             price_float = float(price)
-                            max_price = getattr(self, 'max_price', 20.0)  # Default from system config
-                            if hasattr(self, 'system_config') and self.system_config:
-                                max_price = self.system_config.get('processing_limits', {}).get('max_price_gbp', 20.0)
-                            
+                            max_price = getattr(
+                                self, "max_price", 20.0
+                            )  # Default from system config
+                            if hasattr(self, "system_config") and self.system_config:
+                                max_price = self.system_config.get("processing_limits", {}).get(
+                                    "max_price_gbp", 20.0
+                                )
+
                             if price_float <= max_price:
                                 products.append(product)  # Always add to local return list
-                                
+
                                 # 🚨 DEFINITIVE FIX: Add to shared accumulator for real-time progress tracking
                                 if product_accumulator is not None:
                                     product_accumulator.append(product)
-                                    log.info(f"🔄 REAL-TIME: Added product {i+1} to shared accumulator (total: {len(product_accumulator)})")
-                                    
+                                    log.info(
+                                        f"🔄 REAL-TIME: Added product {i+1} to shared accumulator (total: {len(product_accumulator)})"
+                                    )
+
                                     # 🧹 MEMORY LEAK FIX: Clear local products list periodically to prevent memory accumulation
                                     if len(products) > 100:  # Clear every 100 products
-                                        log.info(f"🧹 Clearing local products list to prevent memory leak ({len(products)} items)")
+                                        log.info(
+                                            f"🧹 Clearing local products list to prevent memory leak ({len(products)} items)"
+                                        )
                                         products.clear()
                                         import gc
+
                                         gc.collect()
-                                
-                                log.info(f"✅ Extracted product {i+1}: {title} - £{price} (EAN: {ean or 'N/A'})")
-                                
+
+                                log.info(
+                                    f"✅ Extracted product {i+1}: {title} - £{price} (EAN: {ean or 'N/A'})"
+                                )
+
                             else:
-                                log.info(f"🛑 PRICE FILTER: Excluding '{title}' - £{price} > £{max_price} limit")
+                                log.info(
+                                    f"🛑 PRICE FILTER: Excluding '{title}' - £{price} > £{max_price} limit"
+                                )
                         except (ValueError, TypeError):
                             # Keep products with invalid/missing prices for now
                             products.append(product)
                             if product_accumulator is not None:
                                 product_accumulator.append(product)
                             log.warning(f"⚠️ Invalid price for '{title}': {price}")
-                        
+
                         # Call progress callback AFTER successful product extraction
                         if self.progress_callback:
-                            self.progress_callback('supplier_extraction', i+1, len(all_product_urls), product_url, product)
-                            
+                            self.progress_callback(
+                                "supplier_extraction",
+                                i + 1,
+                                len(all_product_urls),
+                                product_url,
+                                product,
+                            )
+
                     else:
                         log.warning(f"⚠️ Skipping product {i+1} - missing title or price")
-                        
+
                         # 🚨 CRITICAL FIX: Authentication check when price extraction fails
                         if not price:
-                            log.warning(f"🔍 Price extraction failed for product {i+1} - checking authentication")
-                            
+                            log.warning(
+                                f"🔍 Price extraction failed for product {i+1} - checking authentication"
+                            )
+
                             # Trigger authentication check when pricing fails
                             try:
-                                if hasattr(self, 'browser_manager') and self.browser_manager:
-                                    from tools.supplier_authentication_service import SupplierAuthenticationService
-                                    
+                                if hasattr(self, "browser_manager") and self.browser_manager:
+                                    from tools.supplier_authentication_service import (
+                                        SupplierAuthenticationService,
+                                    )
+
                                     # Get current page for authentication check
                                     page = await self.browser_manager.get_page()
                                     if page:
                                         # Check if we're still authenticated
-                                        auth_service = SupplierAuthenticationService(self.browser_manager)
-                                        
+                                        auth_service = SupplierAuthenticationService(
+                                            self.browser_manager
+                                        )
+
                                         # Get credentials (you may need to pass these from the workflow)
                                         from config.system_config_loader import SystemConfigLoader
+
                                         config_loader = SystemConfigLoader()
-                                        credentials = config_loader.get_credentials('poundwholesale.co.uk')
-                                        
+                                        credentials = config_loader.get_credentials(
+                                            "poundwholesale.co.uk"
+                                        )
+
                                         if credentials:
-                                            log.info(f"🔐 AUTHENTICATION CHECK: Verifying login status for product {i+1}")
-                                            authenticated = await auth_service.ensure_authenticated_session(page, credentials)
-                                            
+                                            log.info(
+                                                f"🔐 AUTHENTICATION CHECK: Verifying login status for product {i+1}"
+                                            )
+                                            authenticated = (
+                                                await auth_service.ensure_authenticated_session(
+                                                    page, credentials
+                                                )
+                                            )
+
                                             if not authenticated:
-                                                log.error(f"❌ AUTHENTICATION FAILED: Login expired during product extraction at product {i+1}")
-                                                log.info("🔄 RECOMMENDATION: Restart system or manually re-authenticate")
+                                                log.error(
+                                                    f"❌ AUTHENTICATION FAILED: Login expired during product extraction at product {i+1}"
+                                                )
+                                                log.info(
+                                                    "🔄 RECOMMENDATION: Restart system or manually re-authenticate"
+                                                )
                                             else:
-                                                log.info(f"✅ AUTHENTICATION OK: Login still valid, price extraction issue may be selector-related")
+                                                log.info(
+                                                    f"✅ AUTHENTICATION OK: Login still valid, price extraction issue may be selector-related"
+                                                )
                                         else:
-                                            log.warning("⚠️ No credentials available for authentication check")
+                                            log.warning(
+                                                "⚠️ No credentials available for authentication check"
+                                            )
                                     else:
                                         log.warning("⚠️ No page available for authentication check")
                                 else:
-                                    log.warning("⚠️ No browser manager available for authentication check")
-                                    
+                                    log.warning(
+                                        "⚠️ No browser manager available for authentication check"
+                                    )
+
                             except Exception as auth_error:
                                 log.warning(f"⚠️ Authentication check failed: {auth_error}")
-                                
-                            log.debug(f"🔍 Price extraction failed for product {i+1} - authentication check completed")
-                        
-                    
+
+                            log.debug(
+                                f"🔍 Price extraction failed for product {i+1} - authentication check completed"
+                            )
+
                 except Exception as product_error:
                     log.error(f"❌ Error processing individual product {i+1}: {product_error}")
-                    
+
                 finally:
                     # MEMORY LEAK FIX: Explicitly clear BeautifulSoup object and HTML content
                     if soup:
                         soup.clear()
                         soup = None
                     product_html = None  # Clear HTML content from memory
-                    
+
                     # MEMORY LEAK FIX: Force garbage collection every 25 products
                     if i > 0 and i % 25 == 0:
                         import gc
+
                         collected = gc.collect()
                         log.debug(f"🗑️ Garbage collected {collected} objects after product {i}")
-                
+
                 # Skip to next product if there was an error
                 continue
-                
+
             except Exception as outer_error:
                 log.error(f"❌ Outer loop error for product {i+1}: {outer_error}")
                 continue
-        
+
         # MEMORY LEAK FIX: Final memory status logging
+
     # Use standard scrape_products_from_url method with pre-filtered URLs passed externally
     # Method scrape_products_from_url_filtered disabled - confirmed broken per project memory
     # Use scrape_products_from_url instead
 
     # Original broken method removed to prevent syntax errors
 
-    async def scrape_products_from_prefiltered_urls(self, filtered_urls: List[str], category_url: str = None, product_accumulator: List = None) -> List[Dict]:
+    async def scrape_products_from_prefiltered_urls(
+        self, filtered_urls: List[str], category_url: str = None, product_accumulator: List = None
+    ) -> List[Dict]:
         """
         Extract products from pre-filtered URLs only - no URL collection phase.
-        
-        This method respects the filtering contract: when filtering says N products need 
+
+        This method respects the filtering contract: when filtering says N products need
         full extraction, we process exactly those N and only those N.
-        
+
         Args:
             filtered_urls: Pre-filtered list of URLs that need full extraction
             category_url: Category URL for context (logging only)
             product_accumulator: Optional list to append products to in real-time
-            
+
         Returns:
             List of extracted product dictionaries
         """
         if not filtered_urls:
             log.info("✅ No URLs need full extraction - returning empty list")
             return []
-        
+
         log.info(f"🎯 FILTERED EXTRACTION: Processing {len(filtered_urls)} pre-approved URLs")
-        
+
         products = []
         for i, product_url in enumerate(filtered_urls):
             try:
                 log.info(f"🔍 Extracting product {i+1}/{len(filtered_urls)}: {product_url}")
-                
+
                 # Get product page content
                 product_html = await self.get_page_content(product_url)
                 if not product_html:
                     log.warning(f"❌ Failed to fetch: {product_url}")
                     continue
-                
+
                 # Extract product data
-                soup = BeautifulSoup(product_html, 'html.parser')
+                soup = BeautifulSoup(product_html, "html.parser")
                 product = await self._extract_product_data_from_soup(soup, product_url)
-                
+
                 if product:
                     products.append(product)
                     if product_accumulator is not None:
                         product_accumulator.append(product)
                     else:
                         # Accumulator sanity check - critical breadcrumb for "why didn't it save?" debugging
-                        log.warning("Prefiltered path: no product_accumulator; periodic saves may not trigger.")
+                        log.warning(
+                            "Prefiltered path: no product_accumulator; periodic saves may not trigger."
+                        )
 
                     # Trigger per-product progress so N-cadence saves fire
-                    if getattr(self, "progress_callback", None) and callable(self.progress_callback):
+                    if getattr(self, "progress_callback", None) and callable(
+                        self.progress_callback
+                    ):
                         try:
                             self.progress_callback(
                                 "supplier_extraction",
@@ -1034,41 +1267,64 @@ class ConfigurableSupplierScraper:
                                 product_url,
                                 product,
                             )
+                            if getattr(self, "state_manager", None):
+                                try:
+                                    self.state_manager.save_debounced(note="progress")
+                                except Exception as cb_err:
+                                    log.warning(f"⚠️ save_debounced failed at {i+1}: {cb_err}")
+                            else:
+                                log.warning(
+                                    "Prefiltered path: state_manager missing; progress not persisted."
+                                )
                         except Exception as cb_err:
                             log.warning(f"⚠️ progress_callback failed at {i+1}: {cb_err}")
                     else:
-                        log.warning("Prefiltered path: no progress_callback bound; periodic saves may not trigger.")
-                        
-                    log.info(f"✅ Extracted: {product.get('title', 'N/A')} - £{product.get('price', 'N/A')}")
+                        log.warning(
+                            "Prefiltered path: no progress_callback bound; periodic saves may not trigger."
+                        )
+
+                    log.info(
+                        f"✅ Extracted: {product.get('title', 'N/A')} - £{product.get('price', 'N/A')}"
+                    )
                 else:
                     log.warning(f"⚠️ No data extracted from: {product_url}")
-                    
+
             except Exception as e:
                 log.error(f"❌ Error extracting product {i+1}: {e}")
                 continue
-        
-        log.info(f"🎯 FILTERED EXTRACTION COMPLETE: {len(products)} products extracted from {len(filtered_urls)} URLs")
+
+        log.info(
+            f"🎯 FILTERED EXTRACTION COMPLETE: {len(products)} products extracted from {len(filtered_urls)} URLs"
+        )
         return products
 
     async def _extract_product_data_from_soup(self, soup: BeautifulSoup, product_url: str) -> Dict:
         """Extract product data from BeautifulSoup object."""
         try:
-            title = self._extract_text_by_selector(soup, ["h1.page-title .base", "[data-ui-id='page-title-wrapper']"])
+            title = self._extract_text_by_selector(
+                soup, ["h1.page-title .base", "[data-ui-id='page-title-wrapper']"]
+            )
             price = await self.extract_price(soup, str(soup), product_url)
             ean = self._extract_text_by_selector(soup, [".value.attribute-code-product_barcode"])
-            sku = self._extract_text_by_selector(soup, [".value.attribute-code-sku", "[itemprop='sku']"])
-            availability = self._extract_text_by_selector(soup, [".stock.available", ".stock.unavailable"])
-            image_url = self._extract_image_by_selector(soup, ["img.product-image-photo", ".product-image img"])
-            
+            sku = self._extract_text_by_selector(
+                soup, [".value.attribute-code-sku", "[itemprop='sku']"]
+            )
+            availability = self._extract_text_by_selector(
+                soup, [".stock.available", ".stock.unavailable"]
+            )
+            image_url = self._extract_image_by_selector(
+                soup, ["img.product-image-photo", ".product-image img"]
+            )
+
             return {
-                'title': title,
-                'price': price,
-                'url': product_url,
-                'ean': ean,
-                'sku': sku,
-                'availability': availability,
-                'image_url': image_url,
-                'scraped_at': datetime.now().isoformat()
+                "title": title,
+                "price": price,
+                "url": product_url,
+                "ean": ean,
+                "sku": sku,
+                "availability": availability,
+                "image_url": image_url,
+                "scraped_at": datetime.now().isoformat(),
             }
         except Exception as e:
             log.error(f"Error extracting product data: {e}")
@@ -1096,7 +1352,7 @@ class ConfigurableSupplierScraper:
         Uses the current browser page managed by BrowserManager.
         """
         log.info(f"Setting page limiter for {url}")
-        
+
         try:
             # Get current page from BrowserManager
             if self.use_browser_manager:
@@ -1110,28 +1366,28 @@ class ConfigurableSupplierScraper:
             else:
                 log.warning("BrowserManager not available for page limiter setup")
                 return False
-            
+
             # Get page limiter configuration
             domain = urlparse(url).netloc
             selectors_config = self._get_selectors_for_domain(domain)
             page_limiter_config = selectors_config.get("page_limiter", {})
             limiter_selector = page_limiter_config.get("selector")
             limiter_value = page_limiter_config.get("value", "60")
-            
+
             if not limiter_selector:
                 log.info(f"No page limiter configuration found for {domain}")
                 return False
-            
+
             # Wait for and click the page limiter
-            await page.wait_for_selector(limiter_selector, state='visible', timeout=10000)
+            await page.wait_for_selector(limiter_selector, state="visible", timeout=10000)
             await page.click(limiter_selector, timeout=5000)
-            
+
             # Wait for page to reload with new limit
-            await page.wait_for_load_state('networkidle', timeout=10000)
-            
+            await page.wait_for_load_state("networkidle", timeout=10000)
+
             log.info(f"Successfully set page limiter to {limiter_value} for {url}")
             return True
-            
+
         except Exception as e:
             log.warning(f"Failed to set page limiter for {url}: {e}")
             return False
@@ -1145,7 +1401,7 @@ class ConfigurableSupplierScraper:
         all_product_urls = set()
         urls_per_page = []  # Track URLs found per page for pagination logging
         current_page = 1
-        
+
         while len(all_product_urls) < max_products:
             # Construct page URL
             if current_page == 1:
@@ -1153,51 +1409,53 @@ class ConfigurableSupplierScraper:
             else:
                 separator = "&" if "?" in url else "?"
                 page_url = f"{url}{separator}p={current_page}"
-            
+
             log.info(f"Processing page {current_page}: {page_url}")
-            
+
             # Fetch page content
             html_content = await self.get_page_content(page_url)
             if not html_content:
                 log.warning(f"Failed to fetch page {current_page}")
                 break
-            
+
             # Extract product elements from current page
             product_elements = self.extract_product_elements(html_content, page_url)
             if not product_elements:
                 log.info(f"No products found on page {current_page}, stopping pagination")
                 break
-            
+
             # Extract URLs from product elements
             base_url = f"{urlparse(page_url).scheme}://{urlparse(page_url).netloc}"
             page_urls = []
-            
+
             for element in product_elements:
                 element_html = str(element)
                 product_url = await self.extract_url(element, element_html, page_url, base_url)
                 if product_url and product_url not in all_product_urls:
                     all_product_urls.add(product_url)
                     page_urls.append(product_url)
-                    
+
                     if len(all_product_urls) >= max_products:
                         break
-            
+
             # Track URLs found on this page
             urls_per_page.append(len(page_urls))
             log.info(f"Found {len(page_urls)} new product URLs on page {current_page}")
-            
+
             # Stop if no new products found or max reached
             if not page_urls or len(all_product_urls) >= max_products:
                 break
-                
+
             current_page += 1
-            
+
             # Reasonable pagination limit to prevent infinite loops
             if current_page > 50:
                 log.warning("Reached pagination limit of 50 pages")
                 break
-        
-        log.info(f"Collected {len(all_product_urls)} total product URLs across {current_page} pages")
+
+        log.info(
+            f"Collected {len(all_product_urls)} total product URLs across {current_page} pages"
+        )
         # Expose details for external consumers (e.g., workflow manifest generation)
         self.last_collected_urls = list(all_product_urls)[:max_products]
         self.last_page_count = current_page
@@ -1215,37 +1473,42 @@ class ConfigurableSupplierScraper:
                 log.debug(f"Selector '{selector}' failed: {e}")
         return None
 
-    def _extract_price_by_selector(self, soup: BeautifulSoup, selectors: List[str]) -> Optional[float]:
+    def _extract_price_by_selector(
+        self, soup: BeautifulSoup, selectors: List[str]
+    ) -> Optional[float]:
         """Extract price using a list of CSS selectors."""
         for selector in selectors:
             try:
                 element = soup.select_one(selector)
                 if element:
                     # Try to get price from data attribute first
-                    price_value = element.get('content') or element.get('data-price-amount')
+                    price_value = element.get("content") or element.get("data-price-amount")
                     if price_value:
                         return float(price_value)
-                    
+
                     # Fall back to text content
                     text = element.get_text(strip=True)
                     if text:
                         # Extract number from text like "£12.99" or "12.99"
                         import re
-                        price_match = re.search(r'[\d,]+\.?\d*', text.replace(',', ''))
+
+                        price_match = re.search(r"[\d,]+\.?\d*", text.replace(",", ""))
                         if price_match:
                             return float(price_match.group())
             except Exception as e:
                 log.debug(f"Price selector '{selector}' failed: {e}")
         return None
 
-    def _extract_image_by_selector(self, soup: BeautifulSoup, selectors: List[str]) -> Optional[str]:
+    def _extract_image_by_selector(
+        self, soup: BeautifulSoup, selectors: List[str]
+    ) -> Optional[str]:
         """Extract image URL using a list of CSS selectors."""
         for selector in selectors:
             try:
                 element = soup.select_one(selector)
                 if element:
                     # Try different image URL attributes
-                    for attr in ['src', 'data-src', 'data-lazy']:
+                    for attr in ["src", "data-src", "data-lazy"]:
                         img_url = element.get(attr)
                         if img_url:
                             return img_url
@@ -1253,10 +1516,18 @@ class ConfigurableSupplierScraper:
                 log.debug(f"Image selector '{selector}' failed: {e}")
         return None
 
-    async def _retry_with_vision_selectors(self, element: BeautifulSoup, element_html: str, url: str, base_url: str, product_index: int, max_retries: int = 3) -> Optional[Dict[str, Any]]:
+    async def _retry_with_vision_selectors(
+        self,
+        element: BeautifulSoup,
+        element_html: str,
+        url: str,
+        base_url: str,
+        product_index: int,
+        max_retries: int = 3,
+    ) -> Optional[Dict[str, Any]]:
         """
         Retry product extraction with vision-based selector discovery if initial extraction fails.
-        
+
         Args:
             element: BeautifulSoup element for the product
             element_html: HTML content of the element
@@ -1264,118 +1535,140 @@ class ConfigurableSupplierScraper:
             base_url: Base URL for relative links
             product_index: Index of product being processed
             max_retries: Maximum retry attempts
-            
+
         Returns:
             Product dict if successful, None if all retries failed
         """
         try:
             domain = urlparse(url).netloc
-            log.info(f"Retrying product {product_index} extraction with vision selectors for {domain}")
-            
+            log.info(
+                f"Retrying product {product_index} extraction with vision selectors for {domain}"
+            )
+
             for retry in range(max_retries):
                 try:
                     log.info(f"Vision retry {retry + 1}/{max_retries} for product {product_index}")
-                    
+
                     # Try to navigate to the product page for better extraction
                     product_url = await self.extract_url(element, element_html, url, base_url)
-                    
+
                     if product_url and self.page:
                         log.info(f"Navigating to product page: {product_url}")
-                        await self.page.goto(product_url, wait_until='domcontentloaded')
-                        await self.page.wait_for_load_state('networkidle', timeout=5000)
-                        
+                        await self.page.goto(product_url, wait_until="domcontentloaded")
+                        await self.page.wait_for_load_state("networkidle", timeout=5000)
+
                         # Use vision discovery to find better selectors
                         from tools.vision_discovery_engine import VisionDiscoveryEngine
-                        
+
                         vision_engine = VisionDiscoveryEngine(self.page)
                         product_config = await vision_engine.discover_product_selectors()
-                        
-                        if product_config and product_config.get('success'):
+
+                        if product_config and product_config.get("success"):
                             log.info(f"Vision discovery successful for product {product_index}")
-                            
+
                             # Update selectors configuration
                             self._update_selectors_config(domain, product_config)
-                            
+
                             # Retry extraction with new selectors
                             page_content = await self.page.content()
-                            page_soup = BeautifulSoup(page_content, 'html.parser')
-                            
+                            page_soup = BeautifulSoup(page_content, "html.parser")
+
                             # Extract from the full page now
                             title = await self.extract_title(page_soup, page_content, product_url)
                             price = await self.extract_price(page_soup, page_content, product_url)
-                            image_url = await self.extract_image(page_soup, page_content, product_url, base_url)
-                            identifier = await self.extract_identifier(page_soup, page_content, product_url)
-                            
+                            image_url = await self.extract_image(
+                                page_soup, page_content, product_url, base_url
+                            )
+                            identifier = await self.extract_identifier(
+                                page_soup, page_content, product_url
+                            )
+
                             if title and price:
                                 product = {
-                                    'title': title,
-                                    'price': price,
-                                    'url': product_url,
-                                    'image_url': image_url,
-                                    'identifier': identifier,
-                                    'source_url': url,
-                                    'scraped_at': datetime.now().isoformat(),
-                                    'extraction_method': 'vision_retry'
+                                    "title": title,
+                                    "price": price,
+                                    "url": product_url,
+                                    "image_url": image_url,
+                                    "identifier": identifier,
+                                    "source_url": url,
+                                    "scraped_at": datetime.now().isoformat(),
+                                    "extraction_method": "vision_retry",
                                 }
-                                log.info(f"✅ Vision retry successful for product {product_index}: {title}")
+                                log.info(
+                                    f"✅ Vision retry successful for product {product_index}: {title}"
+                                )
                                 return product
                             else:
-                                log.warning(f"Vision retry {retry + 1} for product {product_index} still missing title or price")
+                                log.warning(
+                                    f"Vision retry {retry + 1} for product {product_index} still missing title or price"
+                                )
                     else:
-                        log.warning(f"No product URL or page available for vision retry {retry + 1}")
-                        
+                        log.warning(
+                            f"No product URL or page available for vision retry {retry + 1}"
+                        )
+
                 except Exception as e:
                     log.error(f"Vision retry {retry + 1} failed for product {product_index}: {e}")
-                    
+
                 # Small delay between retries
                 await asyncio.sleep(1)
-            
+
             log.warning(f"All vision retries failed for product {product_index}")
             return None
-            
+
         except Exception as e:
             log.error(f"Vision selector retry failed for product {product_index}: {e}")
             return None
-    
+
     def _update_selectors_config(self, domain: str, product_config: Dict[str, Any]) -> None:
         """Update the cached selectors configuration with vision-discovered selectors"""
         try:
             if domain not in self.loaded_selector_configs:
                 self.loaded_selector_configs[domain] = {}
-            
+
             # Merge vision-discovered selectors with existing config
-            if 'field_mappings' not in self.loaded_selector_configs[domain]:
-                self.loaded_selector_configs[domain]['field_mappings'] = {}
-            
-            field_mappings = self.loaded_selector_configs[domain]['field_mappings']
-            
+            if "field_mappings" not in self.loaded_selector_configs[domain]:
+                self.loaded_selector_configs[domain]["field_mappings"] = {}
+
+            field_mappings = self.loaded_selector_configs[domain]["field_mappings"]
+
             # Update with vision-discovered selectors
-            if product_config.get('title_selector'):
-                field_mappings['title'] = [product_config['title_selector']] + field_mappings.get('title', [])
-            
-            if product_config.get('price_selector'):
-                field_mappings['price'] = [product_config['price_selector']] + field_mappings.get('price', [])
-                
-            if product_config.get('url_selector'):
-                field_mappings['url'] = [product_config['url_selector']] + field_mappings.get('url', [])
-                
-            if product_config.get('image_selector'):
-                field_mappings['image'] = [product_config['image_selector']] + field_mappings.get('image', [])
-            
+            if product_config.get("title_selector"):
+                field_mappings["title"] = [product_config["title_selector"]] + field_mappings.get(
+                    "title", []
+                )
+
+            if product_config.get("price_selector"):
+                field_mappings["price"] = [product_config["price_selector"]] + field_mappings.get(
+                    "price", []
+                )
+
+            if product_config.get("url_selector"):
+                field_mappings["url"] = [product_config["url_selector"]] + field_mappings.get(
+                    "url", []
+                )
+
+            if product_config.get("image_selector"):
+                field_mappings["image"] = [product_config["image_selector"]] + field_mappings.get(
+                    "image", []
+                )
+
             # Save updated config to file
             try:
-                config_dir = os.path.join(os.path.dirname(__file__), '..', 'config', 'supplier_configs')
+                config_dir = os.path.join(
+                    os.path.dirname(__file__), "..", "config", "supplier_configs"
+                )
                 os.makedirs(config_dir, exist_ok=True)
-                
+
                 config_file = os.path.join(config_dir, f"{domain}.json")
-                with open(config_file, 'w') as f:
+                with open(config_file, "w") as f:
                     json.dump(self.loaded_selector_configs[domain], f, indent=2)
-                
+
                 log.info(f"Updated selectors configuration saved for {domain}")
-                
+
             except Exception as e:
                 log.warning(f"Failed to save updated selectors for {domain}: {e}")
-                
+
         except Exception as e:
             log.error(f"Failed to update selectors config for {domain}: {e}")
 
@@ -1394,99 +1687,130 @@ class ConfigurableSupplierScraper:
                 return self.loaded_selector_configs[domain]
 
             # PRIORITY 1: Check for generated supplier package
-            supplier_id = domain.replace('.', '-').replace('www-', '')
+            supplier_id = domain.replace(".", "-").replace("www-", "")
             base_dir = os.path.dirname(os.path.dirname(__file__))
-            supplier_ready_path = os.path.join(base_dir, "suppliers", supplier_id, ".supplier_ready")
-            supplier_config_path = os.path.join(base_dir, "suppliers", supplier_id, "config", "product_selectors.json")
-            
+            supplier_ready_path = os.path.join(
+                base_dir, "suppliers", supplier_id, ".supplier_ready"
+            )
+            supplier_config_path = os.path.join(
+                base_dir, "suppliers", supplier_id, "config", "product_selectors.json"
+            )
+
             if os.path.exists(supplier_ready_path) and os.path.exists(supplier_config_path):
                 try:
                     # Validate supplier package readiness
-                    with open(supplier_ready_path, 'r', encoding='utf-8') as f:
+                    with open(supplier_ready_path, "r", encoding="utf-8") as f:
                         ready_data = json.load(f)
-                    
+
                     validation_status = ready_data.get("validation_status", {})
                     if validation_status.get("products_validated", False):
                         # Load validated supplier package selectors
-                        with open(supplier_config_path, 'r', encoding='utf-8') as f:
+                        with open(supplier_config_path, "r", encoding="utf-8") as f:
                             supplier_selectors = json.load(f)
-                        
-                        log.info(f"✅ Loaded VALIDATED supplier package selectors for {domain} from {supplier_config_path}")
+
+                        log.info(
+                            f"✅ Loaded VALIDATED supplier package selectors for {domain} from {supplier_config_path}"
+                        )
                         self.loaded_selector_configs[domain] = supplier_selectors
                         return supplier_selectors
                     else:
-                        log.warning(f"⚠️ Supplier package for {domain} exists but not validated: {validation_status}")
+                        log.warning(
+                            f"⚠️ Supplier package for {domain} exists but not validated: {validation_status}"
+                        )
                 except Exception as e:
                     log.error(f"❌ Error loading supplier package for {domain}: {e}")
-            
+
             # PRIORITY 2: Fallback to config/supplier_configs/ (legacy)
-            config = load_supplier_selectors(domain) # Use the utility function
-            
+            config = load_supplier_selectors(domain)  # Use the utility function
+
             if config:
-                log.info(f"📁 Loaded selectors for domain {domain} from legacy config/supplier_configs/")
-                self.loaded_selector_configs[domain] = config # Cache it
+                log.info(
+                    f"📁 Loaded selectors for domain {domain} from legacy config/supplier_configs/"
+                )
+                self.loaded_selector_configs[domain] = config  # Cache it
                 # Store full configuration for navigation settings
                 self.supplier_config = config
                 return config
             else:
                 # PRIORITY 3: Direct filesystem fallback
-                clean_domain_fs = domain.replace('www.', '')
-                
+                clean_domain_fs = domain.replace("www.", "")
+
                 possible_paths = [
-                    os.path.join("config", "supplier_configs", f"{domain}.json"), 
+                    os.path.join("config", "supplier_configs", f"{domain}.json"),
                     os.path.join("config", "supplier_configs", f"{clean_domain_fs}.json"),
-                    os.path.join("..", "config", "supplier_configs", f"{domain}.json"),  
+                    os.path.join("..", "config", "supplier_configs", f"{domain}.json"),
                     os.path.join("..", "config", "supplier_configs", f"{clean_domain_fs}.json"),
-                    os.path.join(os.path.dirname(__file__), "..", "config", "supplier_configs", f"{domain}.json"),
-                    os.path.join(os.path.dirname(__file__), "..", "config", "supplier_configs", f"{clean_domain_fs}.json")
+                    os.path.join(
+                        os.path.dirname(__file__),
+                        "..",
+                        "config",
+                        "supplier_configs",
+                        f"{domain}.json",
+                    ),
+                    os.path.join(
+                        os.path.dirname(__file__),
+                        "..",
+                        "config",
+                        "supplier_configs",
+                        f"{clean_domain_fs}.json",
+                    ),
                 ]
-                
+
                 for config_path in possible_paths:
                     if os.path.exists(config_path):
-                        with open(config_path, 'r') as f:
+                        with open(config_path, "r") as f:
                             loaded_config = json.load(f)
-                            log.info(f"📂 Loaded selectors for domain {domain} via fallback path: {config_path}")
-                            self.loaded_selector_configs[domain] = loaded_config # Cache it
+                            log.info(
+                                f"📂 Loaded selectors for domain {domain} via fallback path: {config_path}"
+                            )
+                            self.loaded_selector_configs[domain] = loaded_config  # Cache it
                             # Store full configuration for navigation settings
                             self.supplier_config = loaded_config
                             return loaded_config
-            
-            log.warning(f"❌ No selector configuration found for domain {domain} in supplier packages or config files")
-            self.loaded_selector_configs[domain] = {} # Cache empty result to avoid re-attempts
+
+            log.warning(
+                f"❌ No selector configuration found for domain {domain} in supplier packages or config files"
+            )
+            self.loaded_selector_configs[domain] = {}  # Cache empty result to avoid re-attempts
             return {}
         except Exception as e:
             log.error(f"Error loading selectors for domain derived from {domain_or_url}: {e}")
             # Try to cache an empty dict for the original input to prevent repeated errors if domain extraction failed
-            if domain: # if domain was successfully extracted
-                 self.loaded_selector_configs[domain] = {}
+            if domain:  # if domain was successfully extracted
+                self.loaded_selector_configs[domain] = {}
             return {}
 
     def extract_product_elements(self, html_content: str, context_url: str) -> List[BeautifulSoup]:
         """Extract product elements from HTML using BeautifulSoup and site-specific selectors."""
         try:
-            soup = BeautifulSoup(html_content, 'html.parser')
+            soup = BeautifulSoup(html_content, "html.parser")
             selectors = self._get_selectors_for_domain(urlparse(context_url).netloc)
-            
+
             # Get product item selector from field_mappings
             product_item_selector = selectors.get("field_mappings", {}).get("product_item", [])
             if not product_item_selector:
                 return []
-                
+
             # Try each selector in the list
             for selector in product_item_selector:
                 elements = soup.select(selector)
                 if elements:
                     return elements
-                    
+
             return []
         except Exception as e:
             log.error(f"Error extracting product elements: {e}")
             return []
 
-    def _extract_with_selector(self, element_soup: BeautifulSoup, selector_configs: List[Union[str, Dict[str, Any]]], default_value: Optional[str] = None) -> Optional[str]:
+    def _extract_with_selector(
+        self,
+        element_soup: BeautifulSoup,
+        selector_configs: List[Union[str, Dict[str, Any]]],
+        default_value: Optional[str] = None,
+    ) -> Optional[str]:
         """
         Enhanced selector extraction with flexible configuration support.
-        
+
         Args:
             element_soup: BeautifulSoup element to search within
             selector_configs: List of selector configurations. Each can be:
@@ -1497,13 +1821,13 @@ class ConfigurableSupplierScraper:
                     - "processing_regex": Regex pattern to process value (optional)
                     - "regex_group": Regex group to return (optional, default 1)
             default_value: Value to return if no extraction succeeds
-            
+
         Returns:
             Extracted value or default_value if nothing found
         """
         if not isinstance(selector_configs, list):
             selector_configs = [selector_configs]
-        
+
         for config in selector_configs:
             try:
                 # Handle string selector (backward compatibility)
@@ -1513,32 +1837,32 @@ class ConfigurableSupplierScraper:
                         text_content = target.get_text(separator=" ", strip=True)
                         if text_content:
                             return text_content
-                            
+
                 # Handle dictionary configuration
                 elif isinstance(config, dict):
-                    selector = config.get('selector')
+                    selector = config.get("selector")
                     if not selector:
                         log.warning("Selector configuration missing 'selector' key")
                         continue
-                        
+
                     target = element_soup.select_one(selector)
                     if not target:
                         continue
-                        
+
                     # Extract based on attribute or text
-                    attribute = config.get('attribute')
+                    attribute = config.get("attribute")
                     if attribute:
                         value = target.get(attribute)
                     else:
                         value = target.get_text(separator=" ", strip=True)
-                        
+
                     if not value:
                         continue
-                        
+
                     # Apply regex processing if specified
-                    processing_regex = config.get('processing_regex')
+                    processing_regex = config.get("processing_regex")
                     if processing_regex:
-                        regex_group = config.get('regex_group', 1)
+                        regex_group = config.get("regex_group", 1)
                         match = re.search(processing_regex, str(value))
                         if match:
                             try:
@@ -1551,23 +1875,29 @@ class ConfigurableSupplierScraper:
                                 continue
                     else:
                         return str(value).strip()
-                        
+
             except Exception as e:
                 log.debug(f"Error with selector config '{config}': {e}")
                 continue
-                
+
         return default_value
 
-    async def _ai_extract_field_from_html_element(self, element_html: str, field_description: str, context_url: str) -> Optional[str]:
+    async def _ai_extract_field_from_html_element(
+        self, element_html: str, field_description: str, context_url: str
+    ) -> Optional[str]:
         """
         Call AI model to extract a specific field from a product HTML element.
         """
         if not self.ai_client:
-            log.warning(f"AI client not available. Cannot extract '{field_description}' from HTML element for {context_url}.")
+            log.warning(
+                f"AI client not available. Cannot extract '{field_description}' from HTML element for {context_url}."
+            )
             return None
 
         try:
-            max_html_len = 4000 # Reduced to be safer with token limits and typical product snippets
+            max_html_len = (
+                4000  # Reduced to be safer with token limits and typical product snippets
+            )
             truncated_html = element_html[:max_html_len]
             if len(element_html) > max_html_len:
                 truncated_html += "... [truncated]"
@@ -1583,28 +1913,37 @@ class ConfigurableSupplierScraper:
             api_params = {
                 "model": self.openai_model,
                 "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": 150
+                "max_tokens": 150,
             }
-            
+
             # Only add temperature for models that support it
             if "search-preview" not in self.openai_model.lower():
                 api_params["temperature"] = 0.0
-            
-            response = await asyncio.to_thread(
-                self.ai_client.chat.completions.create,
-                **api_params
-            )
+
+            response = await asyncio.to_thread(self.ai_client.chat.completions.create, **api_params)
             extracted_value = response.choices[0].message.content.strip()
 
-            if extracted_value.lower() in ["not found", "none", "n/a", "", "null", "not applicable"]:
+            if extracted_value.lower() in [
+                "not found",
+                "none",
+                "n/a",
+                "",
+                "null",
+                "not applicable",
+            ]:
                 log.info(f"AI indicated '{field_description}' not found in HTML for {context_url}.")
                 return None
 
-            log.info(f"AI extracted '{field_description}' for {context_url}: '{extracted_value[:60].replace(chr(10), ' ')}...'")
+            log.info(
+                f"AI extracted '{field_description}' for {context_url}: '{extracted_value[:60].replace(chr(10), ' ')}...'"
+            )
             return extracted_value
 
         except Exception as e:
-            log.error(f"AI HTML element extraction for '{field_description}' on {context_url} failed: {e}", exc_info=True)
+            log.error(
+                f"AI HTML element extraction for '{field_description}' on {context_url} failed: {e}",
+                exc_info=True,
+            )
             return None
 
     async def _ai_discover_selectors(self, html_content: str, context_url: str) -> Dict[str, Any]:
@@ -1669,33 +2008,30 @@ HTML CONTENT:
             api_params = {
                 "model": self.openai_model,
                 "messages": [{"role": "user", "content": prompt}],
-                "max_tokens": 800
+                "max_tokens": 800,
             }
-            
+
             # Only add temperature for models that support it
             if "search-preview" not in self.openai_model.lower():
                 api_params["temperature"] = 0.1
-            
-            response = await asyncio.to_thread(
-                self.ai_client.chat.completions.create,
-                **api_params
-            )
-            
+
+            response = await asyncio.to_thread(self.ai_client.chat.completions.create, **api_params)
+
             ai_response = response.choices[0].message.content.strip()
             log.info(f"AI selector discovery response for {context_url}: {ai_response[:200]}...")
-            
+
             # Try to parse JSON response (handle markdown code blocks)
             try:
                 import json
                 import re
-                
+
                 # Extract JSON from markdown code blocks if present
-                json_match = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', ai_response, re.DOTALL)
+                json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", ai_response, re.DOTALL)
                 if json_match:
                     json_content = json_match.group(1)
                 else:
                     json_content = ai_response
-                
+
                 selectors = json.loads(json_content)
                 log.info(f"Successfully discovered selectors for {context_url}: {selectors}")
                 return selectors
@@ -1708,13 +2044,15 @@ HTML CONTENT:
             log.error(f"AI selector discovery failed for {context_url}: {e}", exc_info=True)
             return {}
 
-    async def auto_configure_supplier(self, supplier_url: str, save_config: bool = True) -> Dict[str, Any]:
+    async def auto_configure_supplier(
+        self, supplier_url: str, save_config: bool = True
+    ) -> Dict[str, Any]:
         """
         Automatically configure a new supplier by discovering selectors with AI.
         """
         try:
             log.info(f"Auto-configuring supplier for {supplier_url}")
-            
+
             # Get homepage content
             html_content = await self.get_page_content(supplier_url)
             if not html_content:
@@ -1730,17 +2068,17 @@ HTML CONTENT:
             # Create configuration structure
             domain = get_domain_from_url(supplier_url)
             config = {
-                "supplier_id": domain.replace('.', '-'),
+                "supplier_id": domain.replace(".", "-"),
                 "supplier_name": domain.title(),
                 "base_url": supplier_url,
                 "field_mappings": discovered_selectors,
                 "pagination": {
                     "pattern": "?page={page_num}",
-                    "next_button_selector": ["a.next", ".pagination .next a", "a[rel='next']"]
+                    "next_button_selector": ["a.next", ".pagination .next a", "a[rel='next']"],
                 },
                 "auto_discovered": True,
                 "discovery_timestamp": datetime.now().isoformat(),
-                "success": True
+                "success": True,
             }
 
             # Save configuration if requested
@@ -1751,9 +2089,10 @@ HTML CONTENT:
                         from config.supplier_config_loader import save_supplier_selectors
                     except ImportError:
                         import sys
-                        sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'config'))
+
+                        sys.path.append(os.path.join(os.path.dirname(__file__), "..", "config"))
                         from supplier_config_loader import save_supplier_selectors
-                    
+
                     success = save_supplier_selectors(domain, config)
                     if success:
                         log.info(f"Saved auto-discovered configuration for {domain}")
@@ -1768,10 +2107,12 @@ HTML CONTENT:
             log.error(f"Auto-configuration failed for {supplier_url}: {e}", exc_info=True)
             return {}
 
-    def _prepare_selector_configs(self, raw_configs: List[Union[str, Dict[str, Any]]], default_attribute: Optional[str] = None) -> List[Union[str, Dict[str, Any]]]:
+    def _prepare_selector_configs(
+        self, raw_configs: List[Union[str, Dict[str, Any]]], default_attribute: Optional[str] = None
+    ) -> List[Union[str, Dict[str, Any]]]:
         """Helper to process raw selector configs, adding default attributes if needed."""
         processed_configs = []
-        if not isinstance(raw_configs, list): # Ensure it's a list
+        if not isinstance(raw_configs, list):  # Ensure it's a list
             raw_configs = [raw_configs]
 
         for config in raw_configs:
@@ -1779,7 +2120,7 @@ HTML CONTENT:
                 if default_attribute:
                     processed_configs.append({"selector": config, "attribute": default_attribute})
                 else:
-                    processed_configs.append(config) # Assumes text extraction
+                    processed_configs.append(config)  # Assumes text extraction
             elif isinstance(config, dict) and "selector" in config:
                 if default_attribute and "attribute" not in config:
                     processed_configs.append({**config, "attribute": default_attribute})
@@ -1788,29 +2129,32 @@ HTML CONTENT:
             # else: log an error or skip invalid config? For now, skip.
         return processed_configs
 
-
-    async def extract_title(self, element: BeautifulSoup, element_html: str, context_url: str) -> Optional[str]:
+    async def extract_title(
+        self, element: BeautifulSoup, element_html: str, context_url: str
+    ) -> Optional[str]:
         """Extract product title using configured selectors."""
         try:
             selectors = self._get_selectors_for_domain(urlparse(context_url).netloc)
             title_selectors = selectors.get("field_mappings", {}).get("title", [])
-            
+
             for selector in title_selectors:
                 title_element = element.select_one(selector)
                 if title_element and title_element.text.strip():
                     return title_element.text.strip()
-                    
+
             return None
         except Exception as e:
             log.error(f"Error extracting title: {e}")
             return None
 
-    async def extract_price(self, element: BeautifulSoup, element_html: str, context_url: str) -> Optional[float]:
+    async def extract_price(
+        self, element: BeautifulSoup, element_html: str, context_url: str
+    ) -> Optional[float]:
         """Extract product price using configured selectors."""
         try:
             selectors = self._get_selectors_for_domain(urlparse(context_url).netloc)
             price_selectors = selectors.get("field_mappings", {}).get("price", [])
-            
+
             for selector in price_selectors:
                 price_element = element.select_one(selector)
                 if price_element:
@@ -1823,16 +2167,18 @@ HTML CONTENT:
             log.error(f"Error extracting price: {e}")
             return None
 
-    async def extract_url(self, element: BeautifulSoup, element_html: str, context_url: str, base_url: str) -> Optional[str]:
+    async def extract_url(
+        self, element: BeautifulSoup, element_html: str, context_url: str, base_url: str
+    ) -> Optional[str]:
         """Extract product URL using configured selectors."""
         try:
             selectors = self._get_selectors_for_domain(urlparse(context_url).netloc)
             url_selectors = selectors.get("field_mappings", {}).get("url", [])
-            
+
             for selector in url_selectors:
                 url_element = element.select_one(selector)
                 if url_element:
-                    href = url_element.get('href')
+                    href = url_element.get("href")
                     if href:
                         return self._ensure_absolute_url(href, base_url)
             return None
@@ -1841,14 +2187,19 @@ HTML CONTENT:
             return None
 
     def _ensure_absolute_url(self, url: str, base_url: str) -> str:
-        if not url or not isinstance(url, str): return url
+        if not url or not isinstance(url, str):
+            return url
 
         url = url.strip()
-        if not url: return url
+        if not url:
+            return url
 
-        if url.startswith(('data:', 'javascript:', 'mailto:', 'tel:')): return url
-        if url.startswith('//'): return 'https:' + url # Protocol-relative
-        if url.startswith(('http://', 'https://')): return url # Already absolute
+        if url.startswith(("data:", "javascript:", "mailto:", "tel:")):
+            return url
+        if url.startswith("//"):
+            return "https:" + url  # Protocol-relative
+        if url.startswith(("http://", "https://")):
+            return url  # Already absolute
 
         try:
             parsed_base = urlparse(base_url)
@@ -1857,36 +2208,41 @@ HTML CONTENT:
             if not parsed_base.scheme:
                 # If base_url is like "domain.com/path", prepend https://
                 if not base_url.startswith("//") and "." in base_url.split("/")[0]:
-                     base_url_for_join = "https://" + base_url
+                    base_url_for_join = "https://" + base_url
                 # If base_url is like "//domain.com/path", prepend https:
                 elif base_url.startswith("//"):
-                     base_url_for_join = "https:" + base_url
+                    base_url_for_join = "https:" + base_url
                 # Else, it might be a local file path or malformed, urljoin might handle or fail
 
             return urljoin(base_url_for_join, url)
 
         except Exception as e:
-            log.warning(f"Error in urljoin for URL '{url}' with base '{base_url}': {e}. Falling back to basic join.")
+            log.warning(
+                f"Error in urljoin for URL '{url}' with base '{base_url}': {e}. Falling back to basic join."
+            )
             # Basic fallback if urljoin fails
-            if url.startswith('/'):
+            if url.startswith("/"):
                 try:
                     scheme, netloc, _, _, _, _ = urlparse(base_url)
                     if scheme and netloc:
                         return f"{scheme}://{netloc}{url}"
-                except: pass
-            return url # Return original url if all else fails
+                except:
+                    pass
+            return url  # Return original url if all else fails
 
-    async def extract_image(self, element: BeautifulSoup, element_html: str, context_url: str, base_url: str) -> Optional[str]:
+    async def extract_image(
+        self, element: BeautifulSoup, element_html: str, context_url: str, base_url: str
+    ) -> Optional[str]:
         """Extract product image using configured selectors."""
         try:
             selectors = self._get_selectors_for_domain(urlparse(context_url).netloc)
             image_selectors = selectors.get("field_mappings", {}).get("image", [])
-            
+
             for selector in image_selectors:
                 img_element = element.select_one(selector)
                 if img_element:
                     # Try common image attributes
-                    for attr in ['src', 'data-src', 'data-original']:
+                    for attr in ["src", "data-src", "data-original"]:
                         img_src = img_element.get(attr)
                         if img_src:
                             return self._ensure_absolute_url(img_src, base_url)
@@ -1895,46 +2251,84 @@ HTML CONTENT:
             log.error(f"Error extracting image: {e}")
             return None
 
-    async def extract_identifier(self, element_soup: BeautifulSoup, element_html: str, context_url: str) -> Optional[str]:
+    async def extract_identifier(
+        self, element_soup: BeautifulSoup, element_html: str, context_url: str
+    ) -> Optional[str]:
         config = self._get_selectors_for_domain(context_url)
 
-        if "clearance-king.co.uk" in context_url.lower(): # Specific handling for Clearance King
+        if "clearance-king.co.uk" in context_url.lower():  # Specific handling for Clearance King
             page_text_content = element_soup.get_text(" ", strip=True)
-            ck_barcode_match = re.search(r'Barcode\s*\*\*\s*(\d{8,14})\s*\*\*', page_text_content)
+            ck_barcode_match = re.search(r"Barcode\s*\*\*\s*(\d{8,14})\s*\*\*", page_text_content)
             if ck_barcode_match:
                 barcode_val = ck_barcode_match.group(1)
                 if len(barcode_val) in [8, 12, 13, 14]:
-                    log.info(f"Found Clearance King specific barcode pattern: '{barcode_val}' from {context_url}")
+                    log.info(
+                        f"Found Clearance King specific barcode pattern: '{barcode_val}' from {context_url}"
+                    )
                     return barcode_val
-            ck_text_match = re.search(r'(?:EAN|Barcode|UPC|GTIN)[\s:]*(\d{8,14})(?:\b|$)', page_text_content, re.IGNORECASE)
+            ck_text_match = re.search(
+                r"(?:EAN|Barcode|UPC|GTIN)[\s:]*(\d{8,14})(?:\b|$)",
+                page_text_content,
+                re.IGNORECASE,
+            )
             if ck_text_match:
                 barcode_val = ck_text_match.group(1)
                 if len(barcode_val) in [8, 12, 13, 14]:
-                    log.info(f"Found Clearance King text barcode: '{barcode_val}' from {context_url}")
+                    log.info(
+                        f"Found Clearance King text barcode: '{barcode_val}' from {context_url}"
+                    )
                     return barcode_val
 
         identifier_keys = [
-            "identifier_selectors_product_page", "ean_selector_product_page",
-            "barcode_selector_product_page", "upc_selector_product_page",
-            "gtin_selector_product_page", "sku_selector_product_page",
-            "mpn_selector_product_page", "product_code_selector_product_page"
+            "identifier_selectors_product_page",
+            "ean_selector_product_page",
+            "barcode_selector_product_page",
+            "upc_selector_product_page",
+            "gtin_selector_product_page",
+            "sku_selector_product_page",
+            "mpn_selector_product_page",
+            "product_code_selector_product_page",
         ]
         all_identifier_configs: List[Union[str, Dict[str, Any]]] = []
         for key in identifier_keys:
             configs = config.get(key, [])
-            if isinstance(configs, (str, dict)): configs = [configs] # Ensure list
+            if isinstance(configs, (str, dict)):
+                configs = [configs]  # Ensure list
             all_identifier_configs.extend(configs)
 
         # Add generic fallback selectors
         generic_selectors = [
-            "[itemprop='gtin13']", "[itemprop='gtin12']", "[itemprop='gtin8']", "[itemprop='gtin']",
-            "[itemprop='ean']", "[itemprop='upc']", "[itemprop='productID']", "[itemprop='sku']", "[itemprop='mpn']",
-            "dd.ean", "span.ean", ".product-ean", "div[class*='ean']",
-            "dd.upc", "span.upc", ".product-upc", "div[class*='upc']",
-            "dd.sku", "span.sku", ".product-sku", "div[class*='sku']",
-            "dd.mpn", "span.mpn", ".product-mpn", "div[class*='mpn']",
-            "div[class*='barcode']", "span[class*='barcode']",
-            {"selector": "dt:contains('EAN') + dd", "processing_regex": r"(\S+)"}, # Key-value pairs
+            "[itemprop='gtin13']",
+            "[itemprop='gtin12']",
+            "[itemprop='gtin8']",
+            "[itemprop='gtin']",
+            "[itemprop='ean']",
+            "[itemprop='upc']",
+            "[itemprop='productID']",
+            "[itemprop='sku']",
+            "[itemprop='mpn']",
+            "dd.ean",
+            "span.ean",
+            ".product-ean",
+            "div[class*='ean']",
+            "dd.upc",
+            "span.upc",
+            ".product-upc",
+            "div[class*='upc']",
+            "dd.sku",
+            "span.sku",
+            ".product-sku",
+            "div[class*='sku']",
+            "dd.mpn",
+            "span.mpn",
+            ".product-mpn",
+            "div[class*='mpn']",
+            "div[class*='barcode']",
+            "span[class*='barcode']",
+            {
+                "selector": "dt:contains('EAN') + dd",
+                "processing_regex": r"(\S+)",
+            },  # Key-value pairs
             {"selector": "dt:contains('UPC') + dd", "processing_regex": r"(\S+)"},
             {"selector": "dt:contains('SKU') + dd", "processing_regex": r"(\S+)"},
             {"selector": "dt:contains('MPN') + dd", "processing_regex": r"(\S+)"},
@@ -1942,68 +2336,127 @@ HTML CONTENT:
             {"selector": "dt:contains('Product Code') + dd", "processing_regex": r"(\S+)"},
         ]
         all_identifier_configs.extend(generic_selectors)
-        
+
         if all_identifier_configs:
             extracted_code_str = self._extract_with_selector(element_soup, all_identifier_configs)
             if extracted_code_str:
                 # Attempt to clean for numeric barcodes first
-                cleaned_numeric = re.sub(r'[^0-9]', '', extracted_code_str)
-                if cleaned_numeric and len(cleaned_numeric) in [8, 12, 13, 14]: # Standard EAN/UPC lengths
-                    log.info(f"Valid numeric identifier (EAN/UPC format) '{cleaned_numeric}' extracted using selectors from {context_url}.")
+                cleaned_numeric = re.sub(r"[^0-9]", "", extracted_code_str)
+                if cleaned_numeric and len(cleaned_numeric) in [
+                    8,
+                    12,
+                    13,
+                    14,
+                ]:  # Standard EAN/UPC lengths
+                    log.info(
+                        f"Valid numeric identifier (EAN/UPC format) '{cleaned_numeric}' extracted using selectors from {context_url}."
+                    )
                     return cleaned_numeric
 
                 # If not a standard numeric barcode, consider it as SKU/MPN/Product Code or other identifier
                 # Basic cleaning for alphanumeric codes: remove common prefixes/suffixes but preserve structure
-                cleaned_alphanumeric = re.sub(r'^(?:SKU|MPN|Code|ID|Item No\.?|Product Code|P/N|Part No\.?)[\s:]*', '', extracted_code_str, flags=re.IGNORECASE).strip()
-                
+                cleaned_alphanumeric = re.sub(
+                    r"^(?:SKU|MPN|Code|ID|Item No\.?|Product Code|P/N|Part No\.?)[\s:]*",
+                    "",
+                    extracted_code_str,
+                    flags=re.IGNORECASE,
+                ).strip()
+
                 # Avoid overly aggressive compaction for alphanumeric, allow some internal hyphens/spaces if meaningful
                 # Example: ABC-123 or XYZ 456 should be preserved if not clearly a barcode attempt
-                
+
                 # If it's purely numeric after this cleaning, but not a valid barcode length, it's likely an internal ID, not an EAN/UPC.
                 # We should be cautious about returning this if an EAN/UPC was expected.
                 # However, if the selector was for SKU/MPN, this might be valid.
                 # For now, if it becomes purely numeric and not barcode length, we won't treat it as a primary EAN for Amazon.
                 # It can still be stored as 'identifier' for the supplier product.
                 is_potentially_internal_numeric_id = False
-                temp_compacted_for_check = re.sub(r'[\s:-]+', '', cleaned_alphanumeric)
-                if temp_compacted_for_check.isdigit() and len(temp_compacted_for_check) not in [8, 12, 13, 14]:
+                temp_compacted_for_check = re.sub(r"[\s:-]+", "", cleaned_alphanumeric)
+                if temp_compacted_for_check.isdigit() and len(temp_compacted_for_check) not in [
+                    8,
+                    12,
+                    13,
+                    14,
+                ]:
                     is_potentially_internal_numeric_id = True
                     # log.debug(f"Identifier '{cleaned_alphanumeric}' from {context_url} is numeric but not standard EAN/UPC length.")
 
                 # Return if it seems like a valid alphanumeric SKU/MPN (not just a short, non-barcode number)
-                if cleaned_alphanumeric and 3 < len(cleaned_alphanumeric) < 50 and not is_potentially_internal_numeric_id:
-                    if len(cleaned_alphanumeric.split()) < 4 and cleaned_alphanumeric.lower() not in ['n/a', 'none', 'unknown', 'not available']:
-                        log.info(f"Potential alphanumeric identifier (SKU/MPN) '{cleaned_alphanumeric}' (from '{extracted_code_str}') extracted from {context_url}.")
+                if (
+                    cleaned_alphanumeric
+                    and 3 < len(cleaned_alphanumeric) < 50
+                    and not is_potentially_internal_numeric_id
+                ):
+                    if len(
+                        cleaned_alphanumeric.split()
+                    ) < 4 and cleaned_alphanumeric.lower() not in [
+                        "n/a",
+                        "none",
+                        "unknown",
+                        "not available",
+                    ]:
+                        log.info(
+                            f"Potential alphanumeric identifier (SKU/MPN) '{cleaned_alphanumeric}' (from '{extracted_code_str}') extracted from {context_url}."
+                        )
                         return cleaned_alphanumeric
                 elif cleaned_alphanumeric and is_potentially_internal_numeric_id:
                     # If it was an internal numeric ID, and that's what we got, return it. Passive workflow can decide if it tries it as EAN.
-                    log.info(f"Potential internal numeric ID '{cleaned_alphanumeric}' (from '{extracted_code_str}') extracted from {context_url}.")
+                    log.info(
+                        f"Potential internal numeric ID '{cleaned_alphanumeric}' (from '{extracted_code_str}') extracted from {context_url}."
+                    )
                     return cleaned_alphanumeric
                 # else: log.debug(f"Discarding '{cleaned_alphanumeric}' from '{extracted_code_str}' as it doesn't meet SKU/MPN criteria or is a non-barcode numeric string.")
-        
-        log.warning(f"Failed to extract EAN/Barcode/Identifier with selectors from {context_url}. Attempting AI fallback.")
+
+        log.warning(
+            f"Failed to extract EAN/Barcode/Identifier with selectors from {context_url}. Attempting AI fallback."
+        )
         ai_identifier_str = await self._ai_extract_field_from_html_element(
             element_html,
             "product's EAN (e.g., 13-digit), UPC (e.g., 12-digit), GTIN, SKU, MPN, or other primary Product Code. Provide only the identifier value.",
-            context_url
+            context_url,
         )
-        
-        if ai_identifier_str:
-            cleaned_ai_identifier = re.sub(r'^(?:SKU|MPN|Code|ID|Item No\.?|Product Code)[\s:]*', '', ai_identifier_str, flags=re.IGNORECASE).strip()
-            cleaned_ai_identifier_compact = re.sub(r'[\s:-]+', '', cleaned_ai_identifier)
 
-            if cleaned_ai_identifier_compact.isdigit() and len(cleaned_ai_identifier_compact) in [8, 12, 13, 14]:
-                log.info(f"AI extracted valid numeric identifier '{cleaned_ai_identifier_compact}' from {context_url}.")
+        if ai_identifier_str:
+            cleaned_ai_identifier = re.sub(
+                r"^(?:SKU|MPN|Code|ID|Item No\.?|Product Code)[\s:]*",
+                "",
+                ai_identifier_str,
+                flags=re.IGNORECASE,
+            ).strip()
+            cleaned_ai_identifier_compact = re.sub(r"[\s:-]+", "", cleaned_ai_identifier)
+
+            if cleaned_ai_identifier_compact.isdigit() and len(cleaned_ai_identifier_compact) in [
+                8,
+                12,
+                13,
+                14,
+            ]:
+                log.info(
+                    f"AI extracted valid numeric identifier '{cleaned_ai_identifier_compact}' from {context_url}."
+                )
                 return cleaned_ai_identifier_compact
-            elif 3 < len(cleaned_ai_identifier_compact) < 50 and cleaned_ai_identifier_compact.lower() not in ['n/a', 'none', 'unknown', 'not available']:
-                 log.info(f"AI extracted potential alphanumeric identifier '{cleaned_ai_identifier_compact}' (from '{ai_identifier_str}') from {context_url}.")
-                 return cleaned_ai_identifier_compact # Return the more readable version if it's alphanumeric
+            elif 3 < len(
+                cleaned_ai_identifier_compact
+            ) < 50 and cleaned_ai_identifier_compact.lower() not in [
+                "n/a",
+                "none",
+                "unknown",
+                "not available",
+            ]:
+                log.info(
+                    f"AI extracted potential alphanumeric identifier '{cleaned_ai_identifier_compact}' (from '{ai_identifier_str}') from {context_url}."
+                )
+                return cleaned_ai_identifier_compact  # Return the more readable version if it's alphanumeric
             else:
-                log.info(f"AI extraction for identifier from {context_url} ('{ai_identifier_str}') did not yield a usable or standard format code.")
-        
+                log.info(
+                    f"AI extraction for identifier from {context_url} ('{ai_identifier_str}') did not yield a usable or standard format code."
+                )
+
         return None
 
-    def get_next_page_url(self, current_url: str, current_page_soup: BeautifulSoup, current_page_num: int = 1) -> Optional[str]:
+    def get_next_page_url(
+        self, current_url: str, current_page_soup: BeautifulSoup, current_page_num: int = 1
+    ) -> Optional[str]:
         selectors_config = self._get_selectors_for_domain(current_url)
         pagination_config = selectors_config.get("pagination", {})
 
@@ -2011,32 +2464,44 @@ HTML CONTENT:
         next_button_config_raw = pagination_config.get("next_button_selector")
         if next_button_config_raw:
             next_button_configs = self._prepare_selector_configs(
-                next_button_config_raw if isinstance(next_button_config_raw, list) else [next_button_config_raw],
-                default_attribute="href"
+                next_button_config_raw
+                if isinstance(next_button_config_raw, list)
+                else [next_button_config_raw],
+                default_attribute="href",
             )
             next_url_path = self._extract_with_selector(current_page_soup, next_button_configs)
             if next_url_path:
                 abs_url = self._ensure_absolute_url(next_url_path, current_url)
-                if abs_url and abs_url != current_url and urlparse(abs_url).netloc == urlparse(current_url).netloc:
+                if (
+                    abs_url
+                    and abs_url != current_url
+                    and urlparse(abs_url).netloc == urlparse(current_url).netloc
+                ):
                     log.info(f"Found next page URL via specific config selector: {abs_url}")
                     return abs_url
 
         # Method 2: Pattern-based pagination from config
         pattern_str = pagination_config.get("pattern")
         if pattern_str and "{page_num}" in pattern_str:
-            next_page_url_from_pattern = self._apply_pagination_pattern(current_url, pattern_str, current_page_num + 1)
+            next_page_url_from_pattern = self._apply_pagination_pattern(
+                current_url, pattern_str, current_page_num + 1
+            )
             if next_page_url_from_pattern and next_page_url_from_pattern != current_url:
                 log.info(f"Found next page URL via pattern string: {next_page_url_from_pattern}")
                 return next_page_url_from_pattern
-        
+
         # Method 3: List of patterns from config
-        patterns_list = pagination_config.get("patterns", []) # Expects a list of pattern strings
+        patterns_list = pagination_config.get("patterns", [])  # Expects a list of pattern strings
         if isinstance(patterns_list, list):
             for pat_str in patterns_list:
                 if isinstance(pat_str, str) and "{page_num}" in pat_str:
-                    next_page_url_from_list = self._apply_pagination_pattern(current_url, pat_str, current_page_num + 1)
+                    next_page_url_from_list = self._apply_pagination_pattern(
+                        current_url, pat_str, current_page_num + 1
+                    )
                     if next_page_url_from_list and next_page_url_from_list != current_url:
-                        log.info(f"Found next page URL via patterns list item: {next_page_url_from_list}")
+                        log.info(
+                            f"Found next page URL via patterns list item: {next_page_url_from_list}"
+                        )
                         return next_page_url_from_list
 
         # Method 4: Common generic next button selectors
@@ -2047,14 +2512,23 @@ HTML CONTENT:
             {"selector": ".pagination .next a", "attribute": "href"},
             {"selector": "li.next a", "attribute": "href"},
             {"selector": ".pager .next a", "attribute": "href"},
-            {"selector": "a[aria-label*='Next']", "attribute": "href"}, # For accessibility-labeled links
+            {
+                "selector": "a[aria-label*='Next']",
+                "attribute": "href",
+            },  # For accessibility-labeled links
             {"selector": "a.page-link-next", "attribute": "href"},
-            {"selector": "link[rel='next']", "attribute": "href"} # Check <link> tags in <head>
+            {"selector": "link[rel='next']", "attribute": "href"},  # Check <link> tags in <head>
         ]
-        next_url_path_generic = self._extract_with_selector(current_page_soup, generic_next_button_selectors)
+        next_url_path_generic = self._extract_with_selector(
+            current_page_soup, generic_next_button_selectors
+        )
         if next_url_path_generic:
             abs_url = self._ensure_absolute_url(next_url_path_generic, current_url)
-            if abs_url and abs_url != current_url and urlparse(abs_url).netloc == urlparse(current_url).netloc:
+            if (
+                abs_url
+                and abs_url != current_url
+                and urlparse(abs_url).netloc == urlparse(current_url).netloc
+            ):
                 log.info(f"Found next page URL via generic selector: {abs_url}")
                 return abs_url
 
@@ -2064,64 +2538,97 @@ HTML CONTENT:
             log.info(f"Inferred next page URL: {inferred_next_page}")
             return inferred_next_page
 
-        log.info(f"Could not determine next page URL for {current_url} (current page: {current_page_num})")
+        log.info(
+            f"Could not determine next page URL for {current_url} (current page: {current_page_num})"
+        )
         return None
 
-    def _apply_pagination_pattern(self, current_url: str, pattern: str, next_page_num: int) -> Optional[str]:
+    def _apply_pagination_pattern(
+        self, current_url: str, pattern: str, next_page_num: int
+    ) -> Optional[str]:
         try:
-            if "{page_num}" not in pattern: return None
+            if "{page_num}" not in pattern:
+                return None
 
-            if pattern.startswith(("http://", "https://")): # Absolute URL pattern
+            if pattern.startswith(("http://", "https://")):  # Absolute URL pattern
                 return pattern.replace("{page_num}", str(next_page_num))
 
             parsed_current = urlparse(current_url)
-            
+
             # Query parameter pattern (e.g., "?page={page_num}" or "page={page_num}" or "&page={page_num}")
-            if pattern.startswith("?") or (pattern.count("=") == 1 and "{page_num}" in pattern.split("=")[1]) or pattern.startswith("&"):
-                param_name_val = pattern.lstrip("?&").split("=")[0] # e.g. "page" from "page={page_num}"
-                
+            if (
+                pattern.startswith("?")
+                or (pattern.count("=") == 1 and "{page_num}" in pattern.split("=")[1])
+                or pattern.startswith("&")
+            ):
+                param_name_val = pattern.lstrip("?&").split("=")[
+                    0
+                ]  # e.g. "page" from "page={page_num}"
+
                 query_dict = {}
                 if parsed_current.query:
                     for p_item in parsed_current.query.split("&"):
-                        if "=" in p_item: k,v = p_item.split("=",1); query_dict[k] = v
-                        elif p_item: query_dict[p_item] = "" # Handle params without values if any
+                        if "=" in p_item:
+                            k, v = p_item.split("=", 1)
+                            query_dict[k] = v
+                        elif p_item:
+                            query_dict[p_item] = ""  # Handle params without values if any
 
                 query_dict[param_name_val] = str(next_page_num)
-                new_query_string = "&".join(f"{k}={v}" for k,v in query_dict.items() if v is not None) # Filter out None values if any param was removed
+                new_query_string = "&".join(
+                    f"{k}={v}" for k, v in query_dict.items() if v is not None
+                )  # Filter out None values if any param was removed
                 return parsed_current._replace(query=new_query_string).geturl()
 
             # Path-based patterns
             # Using urljoin is generally safer for relative path manipulations
             base_for_join = current_url
             # If current_url looks like a file, and pattern is not absolute, join from parent dir
-            if not current_url.endswith('/') and '.' in parsed_current.path.split('/')[-1] and not pattern.startswith('/'):
-                 base_for_join = current_url.rsplit('/', 1)[0] + '/'
-            
+            if (
+                not current_url.endswith("/")
+                and "." in parsed_current.path.split("/")[-1]
+                and not pattern.startswith("/")
+            ):
+                base_for_join = current_url.rsplit("/", 1)[0] + "/"
+
             # If pattern is root-relative (starts with / but not //)
-            if pattern.startswith('/') and not pattern.startswith('//'):
-                 return f"{parsed_current.scheme}://{parsed_current.netloc}{pattern.replace('{page_num}', str(next_page_num))}"
+            if pattern.startswith("/") and not pattern.startswith("//"):
+                return f"{parsed_current.scheme}://{parsed_current.netloc}{pattern.replace('{page_num}', str(next_page_num))}"
 
             return urljoin(base_for_join, pattern.replace("{page_num}", str(next_page_num)))
 
         except Exception as e:
-            log.warning(f"Error applying pagination pattern '{pattern}' to '{current_url}': {e}", exc_info=True)
+            log.warning(
+                f"Error applying pagination pattern '{pattern}' to '{current_url}': {e}",
+                exc_info=True,
+            )
         return None
 
     def _infer_next_page_url(self, current_url: str, current_page_num: int) -> Optional[str]:
         parsed_url = urlparse(current_url)
-        path_segments = [seg for seg in parsed_url.path.split('/') if seg]
+        path_segments = [seg for seg in parsed_url.path.split("/") if seg]
         query_params = {}
         if parsed_url.query:
-            for item in parsed_url.query.split('&'):
-                if '=' in item: key,val = item.split('=',1); query_params[key] = val
+            for item in parsed_url.query.split("&"):
+                if "=" in item:
+                    key, val = item.split("=", 1)
+                    query_params[key] = val
 
         next_page_str = str(current_page_num + 1)
 
         # Check query parameters
         for key, val in query_params.items():
-            if val == str(current_page_num) and key.lower() in ["page", "p", "pg", "pagenum", "page_number", "startindex", "offset"]:
+            if val == str(current_page_num) and key.lower() in [
+                "page",
+                "p",
+                "pg",
+                "pagenum",
+                "page_number",
+                "startindex",
+                "offset",
+            ]:
                 query_params[key] = next_page_str
-                new_query = "&".join(f"{k}={v}" for k,v in query_params.items())
+                new_query = "&".join(f"{k}={v}" for k, v in query_params.items())
                 return parsed_url._replace(query=new_query).geturl()
 
         # Check path segments
@@ -2130,130 +2637,158 @@ HTML CONTENT:
                 new_segments = path_segments[:]
                 new_segments[i] = next_page_str
                 new_path = "/" + "/".join(new_segments)
-                if parsed_url.path.endswith('/'): new_path += '/'
+                if parsed_url.path.endswith("/"):
+                    new_path += "/"
                 return parsed_url._replace(path=new_path).geturl()
             # Try common prefixes like /page/2 or /p-2
             for prefix in ["page", "p", "pg"]:
-                if segment.lower().startswith(prefix) and segment.lower().replace(prefix, "").strip("-/") == str(current_page_num):
+                if segment.lower().startswith(prefix) and segment.lower().replace(prefix, "").strip(
+                    "-/"
+                ) == str(current_page_num):
                     new_segments = path_segments[:]
-                    new_segments[i] = prefix + next_page_str # Reconstruct with prefix
+                    new_segments[i] = prefix + next_page_str  # Reconstruct with prefix
                     new_path = "/" + "/".join(new_segments)
-                    if parsed_url.path.endswith('/'): new_path += '/'
+                    if parsed_url.path.endswith("/"):
+                        new_path += "/"
                     return parsed_url._replace(path=new_path).geturl()
-        
+
         # If current_page_num is 1, try appending common patterns
         if current_page_num == 1:
-            base_path = parsed_url.path.rstrip('/')
+            base_path = parsed_url.path.rstrip("/")
             common_appends = [
                 f"{base_path}/page/{next_page_str}",
                 f"{base_path}/p/{next_page_str}",
             ]
-            common_query_appends = [
-                f"page={next_page_str}",
-                f"p={next_page_str}"
-            ]
+            common_query_appends = [f"page={next_page_str}", f"p={next_page_str}"]
             for append_path_try in common_appends:
                 # Basic check: don't append if base_path already looks like a product detail page
-                if not any(kw in base_path.lower() for kw in ['.html', '.htm', 'product/', 'item/']):
+                if not any(
+                    kw in base_path.lower() for kw in [".html", ".htm", "product/", "item/"]
+                ):
                     new_url_try = parsed_url._replace(path=append_path_try, query="").geturl()
                     # Here, one might add a check if this URL is valid before returning
                     # For now, we assume it might be.
                     # return new_url_try # This can be too aggressive.
-            
+
             for query_append_try in common_query_appends:
-                new_query_str = f"{parsed_url.query}&{query_append_try}" if parsed_url.query else query_append_try
+                new_query_str = (
+                    f"{parsed_url.query}&{query_append_try}"
+                    if parsed_url.query
+                    else query_append_try
+                )
                 # return parsed_url._replace(query=new_query_str).geturl() # Also can be too aggressive.
 
         return None
 
     def _parse_price(self, price_text: str) -> Optional[float]:
-        if not price_text or not isinstance(price_text, str): return None
-        
+        if not price_text or not isinstance(price_text, str):
+            return None
+
         cleaned_text = price_text
         # Remove common prefixes/suffixes and currency symbols
-        prefixes = r'^(?:sale price|on sale|special|now only|price from|approx\.|our price|your price|was|rrp|msrp|ex\s*vat|inc\s*vat|total)[\s:CHF.-]*'
-        suffixes = r'[\s:CHF.-]*(?:only|each|per item|ex\s*vat|inc\s*vat|total)$'
-        currency_symbols = r'[£$€¥₹]|(?:GBP|USD|EUR|CAD|AUD|JPY|INR|SEK|PLN|CHF)\s*'
-        
-        cleaned_text = re.sub(prefixes, '', cleaned_text, flags=re.IGNORECASE).strip()
-        cleaned_text = re.sub(suffixes, '', cleaned_text, flags=re.IGNORECASE).strip()
-        cleaned_text = re.sub(currency_symbols, '', cleaned_text, flags=re.IGNORECASE).strip()
+        prefixes = r"^(?:sale price|on sale|special|now only|price from|approx\.|our price|your price|was|rrp|msrp|ex\s*vat|inc\s*vat|total)[\s:CHF.-]*"
+        suffixes = r"[\s:CHF.-]*(?:only|each|per item|ex\s*vat|inc\s*vat|total)$"
+        currency_symbols = r"[£$€¥₹]|(?:GBP|USD|EUR|CAD|AUD|JPY|INR|SEK|PLN|CHF)\s*"
+
+        cleaned_text = re.sub(prefixes, "", cleaned_text, flags=re.IGNORECASE).strip()
+        cleaned_text = re.sub(suffixes, "", cleaned_text, flags=re.IGNORECASE).strip()
+        cleaned_text = re.sub(currency_symbols, "", cleaned_text, flags=re.IGNORECASE).strip()
 
         # Regex to find numbers with optional decimal and thousands separators
         # Handles: 1,234.56 | 1.234,56 | 1234.56 | 1234,56 | 1 234.56 | 1 234,56 | 1'234.56
         # It will take the first valid-looking number sequence.
-        match = re.search(r'(\d{1,3}(?:[.,\s\']\d{3})*(?:[.,]\d{1,2})?|\d+(?:[.,]\d{1,2})?)', cleaned_text)
-        
+        match = re.search(
+            r"(\d{1,3}(?:[.,\s\']\d{3})*(?:[.,]\d{1,2})?|\d+(?:[.,]\d{1,2})?)", cleaned_text
+        )
+
         if match:
             price_str = match.group(1)
-            price_str = price_str.replace(' ', '').replace("'", "") # Remove spaces and apostrophes if used as thousand separators
-            
-            if ',' in price_str and '.' in price_str:
-                if price_str.rfind(',') > price_str.rfind('.'): # Comma is decimal: "1.234,56"
-                    price_str = price_str.replace('.', '').replace(',', '.')
-                else: # Dot is decimal: "1,234.56"
-                    price_str = price_str.replace(',', '')
-            elif ',' in price_str: # Only comma present
+            price_str = price_str.replace(" ", "").replace(
+                "'", ""
+            )  # Remove spaces and apostrophes if used as thousand separators
+
+            if "," in price_str and "." in price_str:
+                if price_str.rfind(",") > price_str.rfind("."):  # Comma is decimal: "1.234,56"
+                    price_str = price_str.replace(".", "").replace(",", ".")
+                else:  # Dot is decimal: "1,234.56"
+                    price_str = price_str.replace(",", "")
+            elif "," in price_str:  # Only comma present
                 # If last comma is followed by 1 or 2 digits, assume it's decimal (e.g., "1234,56")
                 # Otherwise, assume it's a thousands separator (e.g., "1,234")
-                if re.match(r'^\d+,\d{1,2}$', price_str.split()[-1]):
-                     price_str = price_str.replace(',', '.')
-                else: # Assume it's thousands separator
-                     price_str = price_str.replace(',', '')
-            
+                if re.match(r"^\d+,\d{1,2}$", price_str.split()[-1]):
+                    price_str = price_str.replace(",", ".")
+                else:  # Assume it's thousands separator
+                    price_str = price_str.replace(",", "")
+
             try:
                 price_float = float(price_str)
                 # Basic sanity check for price range (e.g., not excessively large or small)
-                if 0.001 < price_float < 5000000: # Adjusted upper limit
+                if 0.001 < price_float < 5000000:  # Adjusted upper limit
                     return round(price_float, 2)
                 else:
-                    log.debug(f"Parsed price {price_float} from '{price_text}' is out of typical range.")
+                    log.debug(
+                        f"Parsed price {price_float} from '{price_text}' is out of typical range."
+                    )
             except ValueError:
-                log.debug(f"ValueError converting final price string '{price_str}' to float from '{price_text}'.")
-        
+                log.debug(
+                    f"ValueError converting final price string '{price_str}' to float from '{price_text}'."
+                )
+
         log.warning(f"Could not parse valid price from: '{price_text}' (cleaned: '{cleaned_text}')")
         return None
 
     async def get_homepage_categories(self, base_url: str) -> List[str]:
         try:
             # Check if predefined categories are configured
-            if hasattr(self, 'supplier_config') and self.supplier_config:
-                nav_config = self.supplier_config.get('navigation_configuration', {})
-                if nav_config.get('use_predefined_categories') and nav_config.get('predefined_categories'):
+            if hasattr(self, "supplier_config") and self.supplier_config:
+                nav_config = self.supplier_config.get("navigation_configuration", {})
+                if nav_config.get("use_predefined_categories") and nav_config.get(
+                    "predefined_categories"
+                ):
                     log.info(f"Using predefined categories for {base_url}")
-                    predefined_categories = nav_config['predefined_categories']
-                    category_urls = [cat['url'] for cat in predefined_categories]
+                    predefined_categories = nav_config["predefined_categories"]
+                    category_urls = [cat["url"] for cat in predefined_categories]
                     log.info(f"Found {len(category_urls)} predefined category URLs:")
                     for i, cat in enumerate(predefined_categories):
                         log.info(f"  {i+1}. {cat['name']}: {cat['url']}")
                     return category_urls
-            
+
             log.info(f"Extracting homepage categories from {base_url}")
             html_content = await self.get_page_content(base_url)
-            if not html_content: return []
+            if not html_content:
+                return []
 
-            soup = BeautifulSoup(html_content, 'html.parser')
+            soup = BeautifulSoup(html_content, "html.parser")
             category_urls = set()
 
             # Comprehensive selectors for navigation elements
             # Prioritize the most effective selectors first
             nav_selectors = [
-                '.navigation ul li a',  # Primary navigation - most effective for clearance-king
-                '.navigation .level0 a',  # Magento-style navigation
-                '.nav-sections .level0 a',  # Alternative Magento navigation
-                'nav ul li a',  # Generic navigation
-                '.navigation a[href]', '.nav a[href]', '.menu a[href]',
-                '.main-menu a[href]', '.primary-menu a[href]', 'header a[href]',
-                '.header a[href]', '.category-menu a[href]', '.categories a[href]',
-                '#mainNav a[href]', '#main-navigation a[href]', 'ul.navbar-nav a[href]',
-                'div.sitemap a[href]', 'footer nav a[href]' # Include sitemap/footer links
+                ".navigation ul li a",  # Primary navigation - most effective for clearance-king
+                ".navigation .level0 a",  # Magento-style navigation
+                ".nav-sections .level0 a",  # Alternative Magento navigation
+                "nav ul li a",  # Generic navigation
+                ".navigation a[href]",
+                ".nav a[href]",
+                ".menu a[href]",
+                ".main-menu a[href]",
+                ".primary-menu a[href]",
+                "header a[href]",
+                ".header a[href]",
+                ".category-menu a[href]",
+                ".categories a[href]",
+                "#mainNav a[href]",
+                "#main-navigation a[href]",
+                "ul.navbar-nav a[href]",
+                "div.sitemap a[href]",
+                "footer nav a[href]",  # Include sitemap/footer links
             ]
 
             for selector in nav_selectors:
                 try:
                     links = soup.select(selector)
                     for link in links:
-                        href = link.get('href')
+                        href = link.get("href")
                         if href:
                             absolute_url = self._ensure_absolute_url(href, base_url)
                             if self._looks_like_category_url(absolute_url, base_url):
@@ -2262,69 +2797,194 @@ HTML CONTENT:
                     log.debug(f"Error with navigation selector '{selector}' on {base_url}: {e}")
 
             unique_urls = list(category_urls)
-            log.info(f"Found {len(unique_urls)} unique potential category URLs from homepage of {base_url}")
-            return unique_urls[:75] # Limit to a reasonable number, e.g., 75
+            log.info(
+                f"Found {len(unique_urls)} unique potential category URLs from homepage of {base_url}"
+            )
+            return unique_urls[:75]  # Limit to a reasonable number, e.g., 75
         except Exception as e:
             log.error(f"Error extracting homepage categories from {base_url}: {e}", exc_info=True)
             return []
 
     def _looks_like_category_url(self, url: str, base_url: str) -> bool:
-        if not url or not isinstance(url, str): return False
+        if not url or not isinstance(url, str):
+            return False
 
         url_lower = url.lower()
         parsed_url = urlparse(url)
         parsed_base_url = urlparse(base_url)
 
         # 1. Domain check
-        if parsed_url.netloc != parsed_base_url.netloc and not parsed_url.netloc.endswith('.' + parsed_base_url.netloc):
+        if parsed_url.netloc != parsed_base_url.netloc and not parsed_url.netloc.endswith(
+            "." + parsed_base_url.netloc
+        ):
             return False
 
         # 2. Exclude common file extensions and specific non-category paths
-        excluded_extensions = ['.jpg', '.jpeg', '.png', '.gif', '.pdf', '.zip', '.css', '.js', '.xml', '.txt', '.doc', '.docx', '.xls', '.xlsx', '.svg', '.webp', '.mp4', '.mov']
-        if any(url_lower.endswith(ext) for ext in excluded_extensions): return False
-
-        non_category_keywords = [
-            '/cart', '/basket', '/checkout', '/payment', '/account', '/login', '/register',
-            '/contact', '/about', '/help', '/support', '/faq', '/terms', '/privacy', '/policy',
-            '/search', '/wishlist', '/compare', '/blog', '/news', '/article', '/review',
-            'mailto:', 'tel:', 'javascript:', '#', 'add_to_cart', 'my_account',
-            'customer_service', 'track_order', 'order_status', 'returns_policy', 'shipping_info',
-            'sitemap', 'rss_feed', 'brand_list', 'all_brands', 'gift_card', 'voucher_codes',
-            'event=', 'attachment_id=', 'replytocom=', 'author/', 'tag/', 'feed/'
+        excluded_extensions = [
+            ".jpg",
+            ".jpeg",
+            ".png",
+            ".gif",
+            ".pdf",
+            ".zip",
+            ".css",
+            ".js",
+            ".xml",
+            ".txt",
+            ".doc",
+            ".docx",
+            ".xls",
+            ".xlsx",
+            ".svg",
+            ".webp",
+            ".mp4",
+            ".mov",
         ]
-        # Check full URL for non-category keywords
-        if any(keyword in url_lower for keyword in non_category_keywords): return False
-        # Avoid fragment-only URLs or URLs that are just the base_url again
-        if (parsed_url.path in ['', '/'] and not parsed_url.query and parsed_url.fragment) or url == base_url:
+        if any(url_lower.endswith(ext) for ext in excluded_extensions):
             return False
 
+        non_category_keywords = [
+            "/cart",
+            "/basket",
+            "/checkout",
+            "/payment",
+            "/account",
+            "/login",
+            "/register",
+            "/contact",
+            "/about",
+            "/help",
+            "/support",
+            "/faq",
+            "/terms",
+            "/privacy",
+            "/policy",
+            "/search",
+            "/wishlist",
+            "/compare",
+            "/blog",
+            "/news",
+            "/article",
+            "/review",
+            "mailto:",
+            "tel:",
+            "javascript:",
+            "#",
+            "add_to_cart",
+            "my_account",
+            "customer_service",
+            "track_order",
+            "order_status",
+            "returns_policy",
+            "shipping_info",
+            "sitemap",
+            "rss_feed",
+            "brand_list",
+            "all_brands",
+            "gift_card",
+            "voucher_codes",
+            "event=",
+            "attachment_id=",
+            "replytocom=",
+            "author/",
+            "tag/",
+            "feed/",
+        ]
+        # Check full URL for non-category keywords
+        if any(keyword in url_lower for keyword in non_category_keywords):
+            return False
+        # Avoid fragment-only URLs or URLs that are just the base_url again
+        if (
+            parsed_url.path in ["", "/"] and not parsed_url.query and parsed_url.fragment
+        ) or url == base_url:
+            return False
 
         # 3. Positive category indicators in path or query
         category_keywords = [
-            'category', 'categories', 'cat', 'collection', 'dept', 'department', 'section',
-            'products', 'items', 'group', 'range', 'shop', 'browse', 'listing', 'gallery',
-            'view', 'filter', 'sort', 'type', 'style', 'gender', 'sale', 'offers', 'deals',
-            'brand/', 'manufacturer/', 'c/', 'p/', 'pg/', 'page/', 'shopby', 'product-list', 'product_list',
+            "category",
+            "categories",
+            "cat",
+            "collection",
+            "dept",
+            "department",
+            "section",
+            "products",
+            "items",
+            "group",
+            "range",
+            "shop",
+            "browse",
+            "listing",
+            "gallery",
+            "view",
+            "filter",
+            "sort",
+            "type",
+            "style",
+            "gender",
+            "sale",
+            "offers",
+            "deals",
+            "brand/",
+            "manufacturer/",
+            "c/",
+            "p/",
+            "pg/",
+            "page/",
+            "shopby",
+            "product-list",
+            "product_list",
             # Add specific clearance-king category patterns
-            'clearance', 'pound', '50p', 'baby', 'kids', 'gifts', 'toys', 'health', 'beauty',
-            'household', 'pets', 'smoking', 'stationery', 'crafts', 'mailing', 'supplies',
-            'pallet', 'books', 'electrical', 'clothing', 'fashion', 'garden', 'outdoor'
+            "clearance",
+            "pound",
+            "50p",
+            "baby",
+            "kids",
+            "gifts",
+            "toys",
+            "health",
+            "beauty",
+            "household",
+            "pets",
+            "smoking",
+            "stationery",
+            "crafts",
+            "mailing",
+            "supplies",
+            "pallet",
+            "books",
+            "electrical",
+            "clothing",
+            "fashion",
+            "garden",
+            "outdoor",
         ]
-        path_and_query = (parsed_url.path + '?' + parsed_url.query).lower()
-        if any(keyword in path_and_query for keyword in category_keywords): return True
+        path_and_query = (parsed_url.path + "?" + parsed_url.query).lower()
+        if any(keyword in path_and_query for keyword in category_keywords):
+            return True
 
         # 4. Structural checks: Path depth, common patterns
-        path_segments = [seg for seg in parsed_url.path.split('/') if seg]
+        path_segments = [seg for seg in parsed_url.path.split("/") if seg]
         # Allow slightly deeper paths if they don't end in a file extension
         if 1 <= len(path_segments) <= 5:
             last_segment = path_segments[-1]
             # Avoid paths ending with numbers that look like product IDs if too long, unless it's a common page pattern
-            if not (last_segment.isdigit() and len(last_segment) > 6 and not any(p_ind in last_segment for p_ind in ["page","p"])):
-                if re.match(r'^[a-z0-9][a-z0-9\-_]*[a-z0-9]$', last_segment, re.IGNORECASE) and len(last_segment) > 1:
+            if not (
+                last_segment.isdigit()
+                and len(last_segment) > 6
+                and not any(p_ind in last_segment for p_ind in ["page", "p"])
+            ):
+                if (
+                    re.match(r"^[a-z0-9][a-z0-9\-_]*[a-z0-9]$", last_segment, re.IGNORECASE)
+                    and len(last_segment) > 1
+                ):
                     return True
-        
+
         # 5. Check for common pagination parameters
-        if parsed_url.query and any(page_param in parsed_url.query.lower() for page_param in ['page=', 'p=', 'pg=', 'startindex=', 'pagenumber=']):
+        if parsed_url.query and any(
+            page_param in parsed_url.query.lower()
+            for page_param in ["page=", "p=", "pg=", "startindex=", "pagenumber="]
+        ):
             return True
 
         return False
@@ -2335,36 +2995,48 @@ HTML CONTENT:
             domain = get_domain_from_url(base_url)
             if domain:
                 self._get_selectors_for_domain(domain)
-            
+
             category_urls = await self.get_homepage_categories(base_url)
             categories = []
             processed_urls = set()
 
             for url in category_urls:
-                if url in processed_urls: continue
+                if url in processed_urls:
+                    continue
                 processed_urls.add(url)
 
-                path = urlparse(url).path.strip('/')
-                name_parts = [part for part in path.split('/') if part and not part.isdigit()] # Exclude purely numeric parts
-                
-                name = ' '.join(name_parts[-2:]) if len(name_parts) >=2 else (name_parts[-1] if name_parts else 'Category')
-                name = name.replace('-', ' ').replace('_', ' ').title()
-                name = re.sub(r'\s+', ' ', name).strip() # Consolidate whitespace
+                path = urlparse(url).path.strip("/")
+                name_parts = [
+                    part for part in path.split("/") if part and not part.isdigit()
+                ]  # Exclude purely numeric parts
 
-                if not name or name.lower() == "category" or len(name) < 3: # Try to get a better name from link text
+                name = (
+                    " ".join(name_parts[-2:])
+                    if len(name_parts) >= 2
+                    else (name_parts[-1] if name_parts else "Category")
+                )
+                name = name.replace("-", " ").replace("_", " ").title()
+                name = re.sub(r"\s+", " ", name).strip()  # Consolidate whitespace
+
+                if (
+                    not name or name.lower() == "category" or len(name) < 3
+                ):  # Try to get a better name from link text
                     # This would require fetching the homepage again or passing soup, skipping for now
                     pass
-                if len(name) > 60: name = name[:57] + "..."
+                if len(name) > 60:
+                    name = name[:57] + "..."
 
                 categories.append({"name": name if name else "Unknown Category", "url": url})
-            
+
             log.info(f"Discovered {len(categories)} categories for {base_url}")
             return categories
         except Exception as e:
             log.error(f"Error discovering categories from {base_url}: {e}", exc_info=True)
             return []
 
-    async def discover_subpages(self, category_url: str, max_depth: int = 1, current_depth: int = 0) -> List[str]:
+    async def discover_subpages(
+        self, category_url: str, max_depth: int = 1, current_depth: int = 0
+    ) -> List[str]:
         """
         Discover subpages (subcategories or pagination) for a given category URL, with depth control.
         """
@@ -2376,37 +3048,53 @@ HTML CONTENT:
             log.info(f"Subpage discovery (depth {current_depth+1}) for: {category_url}")
             html_content = await self.get_page_content(category_url)
             if not html_content:
-                log.warning(f"Failed to fetch content for {category_url} at depth {current_depth+1}.")
+                log.warning(
+                    f"Failed to fetch content for {category_url} at depth {current_depth+1}."
+                )
                 return [category_url]
 
-            soup = BeautifulSoup(html_content, 'html.parser')
-            discovered_urls = {category_url} # Use set for uniqueness
+            soup = BeautifulSoup(html_content, "html.parser")
+            discovered_urls = {category_url}  # Use set for uniqueness
             base_domain = urlparse(category_url).netloc
 
             # Selectors for subcategories, pagination, and sometimes "view all" type links
             link_selectors = [
-                "nav[aria-label*='sub-categories'] a[href]", "ul.subcategory-list a[href]",
-                ".pagination a[href]", "ul.pager a[href]", "div.page-numbers a[href]",
-                "a[rel='next']", "a.next-page", "a.load-more", "a.view-all-products",
-                "aside nav a[href]", ".sidebar-menu a[href]", ".filter-options a[href]" # Broader sidebar/filter links
+                "nav[aria-label*='sub-categories'] a[href]",
+                "ul.subcategory-list a[href]",
+                ".pagination a[href]",
+                "ul.pager a[href]",
+                "div.page-numbers a[href]",
+                "a[rel='next']",
+                "a.next-page",
+                "a.load-more",
+                "a.view-all-products",
+                "aside nav a[href]",
+                ".sidebar-menu a[href]",
+                ".filter-options a[href]",  # Broader sidebar/filter links
             ]
 
             for selector in link_selectors:
                 try:
                     links = soup.select(selector)
                     for link in links:
-                        href = link.get('href')
+                        href = link.get("href")
                         if href:
                             absolute_url = self._ensure_absolute_url(href, category_url)
                             # Validate: same domain, looks like category/pagination, not an excluded type
-                            if urlparse(absolute_url).netloc == base_domain and \
-                               self._looks_like_category_url(absolute_url, category_url) and \
-                               absolute_url not in discovered_urls: # Avoid re-adding and re-processing
+                            if (
+                                urlparse(absolute_url).netloc == base_domain
+                                and self._looks_like_category_url(absolute_url, category_url)
+                                and absolute_url not in discovered_urls
+                            ):  # Avoid re-adding and re-processing
                                 discovered_urls.add(absolute_url)
-                                log.debug(f"Discovered potential subpage: {absolute_url} via '{selector}' from {category_url}")
+                                log.debug(
+                                    f"Discovered potential subpage: {absolute_url} via '{selector}' from {category_url}"
+                                )
                 except Exception as e:
-                    log.debug(f"Error with selector '{selector}' for subpage discovery on {category_url}: {e}")
-            
+                    log.debug(
+                        f"Error with selector '{selector}' for subpage discovery on {category_url}: {e}"
+                    )
+
             # Recursively discover for newly found, valid subcategory-like URLs
             # Pagination links are usually not recursed into unless they are also category links
             final_urls_list = list(discovered_urls)
@@ -2414,14 +3102,18 @@ HTML CONTENT:
             #     if new_url != category_url and self._looks_like_category_url(new_url, category_url) and not any(pg_kw in new_url for pg_kw in ["page=", "/page/", "?p="]): # Avoid recursing too deep on pagination
             #         final_urls_list.extend(await self.discover_subpages(new_url, max_depth, current_depth + 1))
 
-
-            unique_final_urls = sorted(list(set(final_urls_list))) # Ensure uniqueness and sort
-            log.info(f"Total unique subpages/pagination links found from {category_url} (depth {current_depth+1}): {len(unique_final_urls)}")
-            return unique_final_urls[:50] # Limit results per call
+            unique_final_urls = sorted(list(set(final_urls_list)))  # Ensure uniqueness and sort
+            log.info(
+                f"Total unique subpages/pagination links found from {category_url} (depth {current_depth+1}): {len(unique_final_urls)}"
+            )
+            return unique_final_urls[:50]  # Limit results per call
 
         except Exception as e:
-            log.error(f"Error discovering subpages for {category_url} at depth {current_depth+1}: {e}", exc_info=True)
-            return [category_url] # Return original if error
+            log.error(
+                f"Error discovering subpages for {category_url} at depth {current_depth+1}: {e}",
+                exc_info=True,
+            )
+            return [category_url]  # Return original if error
 
     async def validate_url_exists(self, url: str) -> bool:
         """
@@ -2465,7 +3157,7 @@ HTML CONTENT:
     async def _get_session(self) -> aiohttp.ClientSession:
         """Get or create aiohttp session for URL validation."""
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession(headers={'User-Agent': USER_AGENT})
+            self._session = aiohttp.ClientSession(headers={"User-Agent": USER_AGENT})
             log.debug("Created new aiohttp session.")
         return self._session
 
@@ -2480,16 +3172,18 @@ HTML CONTENT:
             except Exception as e:
                 log.warning(f"Error closing browser context: {e}")
             self.context = None
-            
+
         if self.browser:
             try:
                 await self.browser.close()
                 log.info("Playwright browser closed.")
-                log.debug("Browser isolation maintained: Dedicated instance for supplier scraping closed to ensure clean context and anti-bot detection separation from Amazon debug port 9222")
+                log.debug(
+                    "Browser isolation maintained: Dedicated instance for supplier scraping closed to ensure clean context and anti-bot detection separation from Amazon debug port 9222"
+                )
             except Exception as e:
                 log.warning(f"Error closing browser: {e}")
             self.browser = None
-            
+
         if self.playwright:
             try:
                 await self.playwright.stop()
@@ -2497,7 +3191,7 @@ HTML CONTENT:
             except Exception as e:
                 log.warning(f"Error stopping Playwright: {e}")
             self.playwright = None
-            
+
         # PHASE 1: Close aiohttp session
         if self._session and not self._session.closed:
             try:
@@ -2513,21 +3207,21 @@ HTML CONTENT:
 
     def extract_ean(self, product_page_soup, context_url: str = None):
         """Extract EAN from the product page using multiple methods including HTML pattern search."""
-        
+
         # FIRST: Try HTML pattern search for 8-14 digit codes (MOST RELIABLE)
         html_content = str(product_page_soup)
         ean_patterns = [
-            r'Product Barcode/ASIN/EAN:\s*([0-9]{8,14})',  # Poundwholesale specific pattern
-            r'barcode[^>]*[>:]?\s*([0-9]{8,14})',
-            r'ean[^>]*[>:]?\s*([0-9]{8,14})',
-            r'gtin[^>]*[>:]?\s*([0-9]{8,14})',
-            r'upc[^>]*[>:]?\s*([0-9]{8,14})',
+            r"Product Barcode/ASIN/EAN:\s*([0-9]{8,14})",  # Poundwholesale specific pattern
+            r"barcode[^>]*[>:]?\s*([0-9]{8,14})",
+            r"ean[^>]*[>:]?\s*([0-9]{8,14})",
+            r"gtin[^>]*[>:]?\s*([0-9]{8,14})",
+            r"upc[^>]*[>:]?\s*([0-9]{8,14})",
             r'"([0-9]{13})"',  # 13-digit codes in quotes
             r'"([0-9]{12})"',  # 12-digit codes in quotes
-            r'>([0-9]{13})<',  # 13-digit codes between tags
-            r'>([0-9]{12})<'   # 12-digit codes between tags
+            r">([0-9]{13})<",  # 13-digit codes between tags
+            r">([0-9]{12})<",  # 12-digit codes between tags
         ]
-        
+
         for pattern in ean_patterns:
             matches = re.finditer(pattern, html_content, re.IGNORECASE)
             for match in matches:
@@ -2535,33 +3229,33 @@ HTML CONTENT:
                 if len(code) >= 8 and code.isdigit():
                     log.info(f"🎯 EAN found via pattern search: {code}")
                     return code
-        
+
         # SECOND: Try CSS selectors
-        selectors = [] # Default to empty list
+        selectors = []  # Default to empty list
         if context_url:
-            domain = urlparse(context_url).netloc # Parse domain from product page URL
+            domain = urlparse(context_url).netloc  # Parse domain from product page URL
             selectors_config = self._get_selectors_for_domain(domain)
-            selectors = selectors_config.get('field_mappings', {}).get('ean', [])
-        
+            selectors = selectors_config.get("field_mappings", {}).get("ean", [])
+
         # Enhanced selectors for Poundwholesale specifically
-        if not selectors or 'poundwholesale' in (context_url or ''):
+        if not selectors or "poundwholesale" in (context_url or ""):
             selectors = [
                 # Meta tags (most reliable)
                 "meta[name='product:ean']",
-                "meta[property='product:ean']", 
+                "meta[property='product:ean']",
                 "meta[name='product:gtin']",
                 "meta[property='product:gtin']",
                 # Script and data attributes
                 "script[type='application/ld+json']",
                 "[data-barcode]",
-                "[data-ean]", 
+                "[data-ean]",
                 "[data-gtin]",
                 # Clearance King specific
                 "div.product-info-main div.ck-product-code-b-code span.ck-b-code-value b",
                 "div.product-info-main div.ck-product-code-b-code span.ck-b-code-value",
                 "table.additional-attributes-table td[data-th='EAN']",
                 "div.product.attribute.sku div.value[itemprop='sku']",
-                "div.product.attribute.gtin div.value[itemprop='gtin13']"
+                "div.product.attribute.gtin div.value[itemprop='gtin13']",
             ]
         for selector in selectors:
             if selector:  # Skip empty selectors
@@ -2572,12 +3266,12 @@ HTML CONTENT:
 
     def extract_barcode(self, product_page_soup, context_url: str = None):
         """Extract barcode from the product page using multiple selectors."""
-        selectors = [] # Default to empty list
+        selectors = []  # Default to empty list
         if context_url:
-            domain = urlparse(context_url).netloc # Parse domain from product page URL
+            domain = urlparse(context_url).netloc  # Parse domain from product page URL
             selectors_config = self._get_selectors_for_domain(domain)
-            selectors = selectors_config.get('field_mappings', {}).get('barcode', [])
-        
+            selectors = selectors_config.get("field_mappings", {}).get("barcode", [])
+
         # Fallback to generic selectors if no domain-specific ones are found or context_url is None
         if not selectors:
             selectors = [
@@ -2593,53 +3287,53 @@ HTML CONTENT:
 
     def extract_availability(self, product_page_soup, context_url: str = None):
         """Extract availability status from the product page using multiple selectors."""
-        selectors = [] # Default to empty list
+        selectors = []  # Default to empty list
         if context_url:
-            domain = urlparse(context_url).netloc # Parse domain from product page URL
+            domain = urlparse(context_url).netloc  # Parse domain from product page URL
             selectors_config = self._get_selectors_for_domain(domain)
-            selectors = selectors_config.get('field_mappings', {}).get('availability', [])
-        
+            selectors = selectors_config.get("field_mappings", {}).get("availability", [])
+
         # Fallback to generic selectors if no domain-specific ones are found or context_url is None
         if not selectors:
             selectors = [
                 "meta[property='product:availability']",
                 ".stock span",
                 ".availability",
-                ".product-availability"
+                ".product-availability",
             ]
-        
+
         for selector in selectors:
             if selector:  # Skip empty selectors
                 element = product_page_soup.select_one(selector)
                 if element:
                     # Check if it's a meta tag
                     if selector.startswith("meta"):
-                        return element.get('content', '').strip()
+                        return element.get("content", "").strip()
                     else:
                         return element.get_text(strip=True)
         return None
 
     def extract_out_of_stock_status(self, product_page_soup, context_url: str = None):
         """Extract out-of-stock status from the product page using multiple selectors."""
-        selectors = [] # Default to empty list
+        selectors = []  # Default to empty list
         if context_url:
-            domain = urlparse(context_url).netloc # Parse domain from product page URL
+            domain = urlparse(context_url).netloc  # Parse domain from product page URL
             selectors_config = self._get_selectors_for_domain(domain)
-            selectors = selectors_config.get('field_mappings', {}).get('out_of_stock', [])
-        
+            selectors = selectors_config.get("field_mappings", {}).get("out_of_stock", [])
+
         # Fallback to generic selectors if no domain-specific ones are found or context_url is None
         if not selectors:
             selectors = [
                 ".stock.unavailable",
                 ".out-of-stock",
                 "meta[property='product:availability'][content*='out of stock']",
-                "meta[property='product:availability'][content*='OutOfStock']"
+                "meta[property='product:availability'][content*='OutOfStock']",
             ]
-        
+
         for selector in selectors:
             if selector:  # Skip empty selectors
                 # Handle special selectors with attribute conditions
-                if '[content*=' in selector:
+                if "[content*=" in selector:
                     elements = product_page_soup.select(selector)
                     if elements:
                         return True
@@ -2647,60 +3341,73 @@ HTML CONTENT:
                     element = product_page_soup.select_one(selector)
                     if element:
                         return True
-        
+
         # Also check availability text for out-of-stock indicators
         availability = self.extract_availability(product_page_soup, context_url)
         if availability:
             availability_lower = availability.lower()
-            out_of_stock_indicators = ['out of stock', 'unavailable', 'sold out', 'outofstock']
+            out_of_stock_indicators = ["out of stock", "unavailable", "sold out", "outofstock"]
             for indicator in out_of_stock_indicators:
                 if indicator in availability_lower:
                     return True
-        
+
         return False
 
-    async def extract_availability_category(self, element: BeautifulSoup, element_html: str, context_url: str) -> Optional[str]:
+    async def extract_availability_category(
+        self, element: BeautifulSoup, element_html: str, context_url: str
+    ) -> Optional[str]:
         """Extract availability status from category page product element."""
         # Look for availability indicators within the product element
         availability_selectors = [
-            ".stock", ".availability", ".in-stock", ".out-of-stock",
-            "[data-availability]", ".product-availability"
+            ".stock",
+            ".availability",
+            ".in-stock",
+            ".out-of-stock",
+            "[data-availability]",
+            ".product-availability",
         ]
-        
+
         for selector in availability_selectors:
             availability_element = element.select_one(selector)
             if availability_element:
                 return availability_element.get_text(strip=True)
-        
+
         return None
 
-    async def extract_out_of_stock_category(self, element: BeautifulSoup, element_html: str, context_url: str) -> bool:
+    async def extract_out_of_stock_category(
+        self, element: BeautifulSoup, element_html: str, context_url: str
+    ) -> bool:
         """Extract out-of-stock status from category page product element."""
         # Look for out-of-stock indicators within the product element
         out_of_stock_selectors = [
-            ".out-of-stock", ".stock.unavailable", ".sold-out",
-            ".stock-alert", "[data-stock='out']"
+            ".out-of-stock",
+            ".stock.unavailable",
+            ".sold-out",
+            ".stock-alert",
+            "[data-stock='out']",
         ]
-        
+
         for selector in out_of_stock_selectors:
             if element.select_one(selector):
                 return True
-        
+
         # Check availability text
         availability = await self.extract_availability_category(element, element_html, context_url)
         if availability:
             availability_lower = availability.lower()
-            out_of_stock_indicators = ['out of stock', 'unavailable', 'sold out', 'outofstock']
+            out_of_stock_indicators = ["out of stock", "unavailable", "sold out", "outofstock"]
             for indicator in out_of_stock_indicators:
                 if indicator in availability_lower:
                     return True
-        
+
         return False
 
 
 async def test_new_suppliers(headless: bool = False, use_shared_chrome: bool = True):
     """Test AI selector discovery on new supplier websites."""
-    outputs_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "OUTPUTS", "supplier_data")
+    outputs_dir = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "OUTPUTS", "supplier_data"
+    )
     os.makedirs(outputs_dir, exist_ok=True)
 
     # Initialize AI client with environment key
@@ -2709,6 +3416,7 @@ async def test_new_suppliers(headless: bool = False, use_shared_chrome: bool = T
     if openai_api_key:
         try:
             from openai import OpenAI
+
             ai_client = OpenAI(api_key=openai_api_key)
             log.info("OpenAI client initialized for new supplier testing.")
         except Exception as e:
@@ -2719,124 +3427,145 @@ async def test_new_suppliers(headless: bool = False, use_shared_chrome: bool = T
         return
 
     scraper = ConfigurableSupplierScraper(
-        ai_client=ai_client, 
+        ai_client=ai_client,
         openai_model_name=os.getenv("OPENAI_MODEL_SUPPLIER", "gpt-4.1-mini-2025-04-14"),
         headless=headless,
-        use_shared_chrome=use_shared_chrome
+        use_shared_chrome=use_shared_chrome,
     )
-    
+
     # Test URLs
     test_suppliers = [
         {
             "url": "https://www.poundwholesale.co.uk/",
             "name": "Pound Wholesale",
-            "category_test_url": "https://www.poundwholesale.co.uk/"  # Use homepage (20 products available)
+            "category_test_url": "https://www.poundwholesale.co.uk/",  # Use homepage (20 products available)
         },
         {
             "url": "https://www.cutpricewholesaler.com/",
-            "name": "Cut Price Wholesaler", 
-            "category_test_url": "https://www.cutpricewholesaler.com/toys-games"  # Example category
-        }
+            "name": "Cut Price Wholesaler",
+            "category_test_url": "https://www.cutpricewholesaler.com/toys-games",  # Example category
+        },
     ]
 
     results = {}
-    
+
     for supplier in test_suppliers:
         log.info(f"\n{'='*80}")
         log.info(f"TESTING: {supplier['name']} - {supplier['url']}")
         log.info(f"{'='*80}")
-        
+
         try:
             # Step 1: Auto-discover selectors from homepage
             log.info(f"🔍 Auto-discovering selectors for {supplier['name']}...")
-            config = await scraper.auto_configure_supplier(supplier['url'], save_config=True)
-            
+            config = await scraper.auto_configure_supplier(supplier["url"], save_config=True)
+
             if not config:
                 log.error(f"❌ Failed to auto-configure {supplier['name']}")
-                results[supplier['name']] = {"status": "failed", "error": "auto-configuration failed"}
+                results[supplier["name"]] = {
+                    "status": "failed",
+                    "error": "auto-configuration failed",
+                }
                 continue
-                
+
             log.info(f"✅ Successfully discovered selectors for {supplier['name']}")
             log.info(f"📋 Config: {json.dumps(config['field_mappings'], indent=2)}")
-            
+
             # Step 2: Test selector discovery on a category page if available
-            if supplier.get('category_test_url'):
+            if supplier.get("category_test_url"):
                 log.info(f"🧪 Testing on category page: {supplier['category_test_url']}")
-                
-                html_content = await scraper.get_page_content(supplier['category_test_url'])
+
+                html_content = await scraper.get_page_content(supplier["category_test_url"])
                 if html_content:
-                    product_elements = scraper.extract_product_elements(html_content, supplier['category_test_url'])
+                    product_elements = scraper.extract_product_elements(
+                        html_content, supplier["category_test_url"]
+                    )
                     log.info(f"📦 Found {len(product_elements)} product elements on category page")
-                    
+
                     if product_elements:
                         # Test extraction on first few products
                         for i, element in enumerate(product_elements[:3]):
                             log.info(f"\n--- Testing Product {i+1} ---")
                             element_html = str(element)
-                            
-                            title = await scraper.extract_title(element, element_html, supplier['category_test_url'])
-                            price = await scraper.extract_price(element, element_html, supplier['category_test_url'])
-                            url = await scraper.extract_url(element, element_html, supplier['category_test_url'], supplier['url'])
-                            image = await scraper.extract_image(element, element_html, supplier['category_test_url'], supplier['url'])
-                            
+
+                            title = await scraper.extract_title(
+                                element, element_html, supplier["category_test_url"]
+                            )
+                            price = await scraper.extract_price(
+                                element, element_html, supplier["category_test_url"]
+                            )
+                            url = await scraper.extract_url(
+                                element,
+                                element_html,
+                                supplier["category_test_url"],
+                                supplier["url"],
+                            )
+                            image = await scraper.extract_image(
+                                element,
+                                element_html,
+                                supplier["category_test_url"],
+                                supplier["url"],
+                            )
+
                             log.info(f"  Title: {title}")
                             log.info(f"  Price: {price}")
                             log.info(f"  URL: {url}")
                             log.info(f"  Image: {image}")
-                            
+
                             if i == 0:  # Save detailed result for first product
-                                results[supplier['name']] = {
+                                results[supplier["name"]] = {
                                     "status": "success",
                                     "config": config,
                                     "test_extraction": {
                                         "title": title,
                                         "price": price,
                                         "url": url,
-                                        "image": image
-                                    }
+                                        "image": image,
+                                    },
                                 }
                     else:
-                        log.warning(f"⚠️ No product elements found on {supplier['category_test_url']}")
-                        results[supplier['name']] = {
+                        log.warning(
+                            f"⚠️ No product elements found on {supplier['category_test_url']}"
+                        )
+                        results[supplier["name"]] = {
                             "status": "partial_success",
                             "config": config,
-                            "warning": "no products found on category page"
+                            "warning": "no products found on category page",
                         }
             else:
-                results[supplier['name']] = {
-                    "status": "config_only",
-                    "config": config
-                }
-            
+                results[supplier["name"]] = {"status": "config_only", "config": config}
+
         except Exception as e:
             log.error(f"❌ Error testing {supplier['name']}: {e}", exc_info=True)
-            results[supplier['name']] = {"status": "error", "error": str(e)}
-        
+            results[supplier["name"]] = {"status": "error", "error": str(e)}
+
         # Brief pause between suppliers
         await asyncio.sleep(2)
-    
+
     # Save test results
     timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
     results_file = os.path.join(outputs_dir, f"new_suppliers_test_{timestamp_str}.json")
-    with open(results_file, 'w', encoding='utf-8') as f:
+    with open(results_file, "w", encoding="utf-8") as f:
         json.dump(results, f, indent=2, ensure_ascii=False)
-    
+
     log.info(f"\n📄 Test results saved to: {results_file}")
-    
+
     # Summary
     log.info(f"\n{'='*80}")
     log.info("SUMMARY:")
     for supplier_name, result in results.items():
-        status = result.get('status', 'unknown')
+        status = result.get("status", "unknown")
         log.info(f"  {supplier_name}: {status}")
     log.info(f"{'='*80}")
-    
+
     await scraper.close_session()
     return results
 
+
 async def test_scraper(headless: bool = False):
     """Test the scraper on a sample URL and save results to OUTPUTS directory."""
-    outputs_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "OUTPUTS", "supplier_data")
+    outputs_dir = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "OUTPUTS", "supplier_data"
+    )
     os.makedirs(outputs_dir, exist_ok=True)
 
     ai_client = None
@@ -2844,6 +3573,7 @@ async def test_scraper(headless: bool = False):
     if openai_api_key:
         try:
             from openai import OpenAI
+
             ai_client = OpenAI(api_key=openai_api_key)
             log.info("OpenAI client initialized for testing.")
         except Exception as e:
@@ -2853,7 +3583,7 @@ async def test_scraper(headless: bool = False):
 
     scraper = ConfigurableSupplierScraper(ai_client=ai_client, headless=headless)
     # Example test URL (replace with a more suitable one if needed)
-    test_url = "https://www.clearance-king.co.uk/pound-lines.html" # A category page
+    test_url = "https://www.clearance-king.co.uk/pound-lines.html"  # A category page
     base_url = "https://www.clearance-king.co.uk"
 
     # --- Test Category Discovery ---
@@ -2861,20 +3591,21 @@ async def test_scraper(headless: bool = False):
     categories = await scraper.discover_categories(base_url)
     if categories:
         log.info(f"Discovered {len(categories)} categories:")
-        for i, cat in enumerate(categories[:5]): # Log first 5
+        for i, cat in enumerate(categories[:5]):  # Log first 5
             log.info(f"  {i+1}. Name: {cat['name']}, URL: {cat['url']}")
         # --- Test Subpage Discovery for the first category ---
         if categories:
-            first_category_url = categories[0]['url']
+            first_category_url = categories[0]["url"]
             log.info(f"\n--- Testing Subpage Discovery for {first_category_url} (max_depth=1) ---")
             subpages = await scraper.discover_subpages(first_category_url, max_depth=1)
             if subpages:
-                log.info(f"Discovered {len(subpages)} subpages/pagination links for {first_category_url}:")
-                for i, sp_url in enumerate(subpages[:5]): # Log first 5
+                log.info(
+                    f"Discovered {len(subpages)} subpages/pagination links for {first_category_url}:"
+                )
+                for i, sp_url in enumerate(subpages[:5]):  # Log first 5
                     log.info(f"  {i+1}. {sp_url}")
     else:
         log.warning(f"No categories discovered from {base_url}")
-
 
     log.info(f"\n--- Testing Product Extraction from {test_url} ---")
     html = await scraper.get_page_content(test_url)
@@ -2885,14 +3616,14 @@ async def test_scraper(headless: bool = False):
 
         products_data = []
         if product_elements:
-            for i, p_soup in enumerate(product_elements[:3]): # Test first 3 products
+            for i, p_soup in enumerate(product_elements[:3]):  # Test first 3 products
                 p_html = str(p_soup)
                 log.info(f"\n--- Extracting data for Product {i+1} ---")
                 title = await scraper.extract_title(p_soup, p_html, test_url)
                 price = await scraper.extract_price(p_soup, p_html, test_url)
                 product_page_url = await scraper.extract_url(p_soup, p_html, test_url, base_url)
                 image = await scraper.extract_image(p_soup, p_html, test_url, base_url)
-                
+
                 # CRITICAL FIX: Extract EAN properly, leave blank if not found
                 ean = ""
                 sku = ""
@@ -2900,12 +3631,12 @@ async def test_scraper(headless: bool = False):
                     log.info(f"Fetching detail page for EAN: {product_page_url}")
                     detail_page_html = await scraper.get_page_content(product_page_url)
                     if detail_page_html:
-                        detail_soup = BeautifulSoup(detail_page_html, 'html.parser')
+                        detail_soup = BeautifulSoup(detail_page_html, "html.parser")
                         # Try EAN extraction first
                         extracted_ean = scraper.extract_ean(detail_soup, product_page_url)
                         if extracted_ean:
                             # Validate if it's actually an EAN (8-14 digits)
-                            cleaned_ean = re.sub(r'[^0-9]', '', extracted_ean)
+                            cleaned_ean = re.sub(r"[^0-9]", "", extracted_ean)
                             if cleaned_ean and len(cleaned_ean) in [8, 12, 13, 14]:
                                 ean = cleaned_ean
                                 log.info(f"✅ Valid EAN extracted: {ean}")
@@ -2914,9 +3645,11 @@ async def test_scraper(headless: bool = False):
                                 log.info(f"⚠️ SKU extracted (not EAN format): {sku}")
                         else:
                             # Try fallback identifier extraction
-                            identifier = await scraper.extract_identifier(detail_soup, str(detail_soup), product_page_url)
+                            identifier = await scraper.extract_identifier(
+                                detail_soup, str(detail_soup), product_page_url
+                            )
                             if identifier:
-                                cleaned_id = re.sub(r'[^0-9]', '', identifier)
+                                cleaned_id = re.sub(r"[^0-9]", "", identifier)
                                 if cleaned_id and len(cleaned_id) in [8, 12, 13, 14]:
                                     ean = cleaned_id
                                     log.info(f"✅ EAN from identifier: {ean}")
@@ -2924,38 +3657,52 @@ async def test_scraper(headless: bool = False):
                                     sku = identifier
                                     log.info(f"⚠️ SKU from identifier: {sku}")
                     else:
-                        log.warning(f"Failed to fetch detail page {product_page_url} for EAN extraction.")
-                
+                        log.warning(
+                            f"Failed to fetch detail page {product_page_url} for EAN extraction."
+                        )
+
                 product_data = {
-                    "id": i + 1, "title": title, "price": price, "url": product_page_url,
-                    "image": image, "ean": ean, "sku": sku, "out_of_stock_badge": "", 
-                    "source_url": test_url, "timestamp": datetime.now().isoformat()
+                    "id": i + 1,
+                    "title": title,
+                    "price": price,
+                    "url": product_page_url,
+                    "image": image,
+                    "ean": ean,
+                    "sku": sku,
+                    "out_of_stock_badge": "",
+                    "source_url": test_url,
+                    "timestamp": datetime.now().isoformat(),
                 }
                 products_data.append(product_data)
                 log.info(f"Product {i+1} Data: {json.dumps(product_data, indent=2)}")
-                if i < 2 : await asyncio.sleep(1) # Brief pause
+                if i < 2:
+                    await asyncio.sleep(1)  # Brief pause
 
             # Save to JSON
             timestamp_str = datetime.now().strftime("%Y%m%d_%H%M%S")
             output_file = os.path.join(outputs_dir, f"scraper_test_output_{timestamp_str}.json")
             output_content = {
-                "source_category_url": test_url, "extraction_time": datetime.now().isoformat(),
-                "total_products_processed": len(products_data), "products": products_data
+                "source_category_url": test_url,
+                "extraction_time": datetime.now().isoformat(),
+                "total_products_processed": len(products_data),
+                "products": products_data,
             }
-            with open(output_file, 'w', encoding='utf-8') as f:
+            with open(output_file, "w", encoding="utf-8") as f:
                 json.dump(output_content, f, indent=2, ensure_ascii=False)
             log.info(f"\nSaved {len(products_data)} products' data to: {output_file}")
 
             # Test pagination from the category page
             log.info(f"\n--- Testing Pagination from {test_url} ---")
-            category_page_soup = BeautifulSoup(html, 'html.parser')
+            category_page_soup = BeautifulSoup(html, "html.parser")
             next_page_url = scraper.get_next_page_url(test_url, category_page_soup, 1)
             log.info(f"Next page URL from {test_url}: {next_page_url}")
             if next_page_url:
                 next_page_html = await scraper.get_page_content(next_page_url)
                 if next_page_html:
-                    log.info(f"Successfully fetched next page ({next_page_url}) content ({len(next_page_html)} bytes)")
-                    next_page_soup = BeautifulSoup(next_page_html, 'html.parser')
+                    log.info(
+                        f"Successfully fetched next page ({next_page_url}) content ({len(next_page_html)} bytes)"
+                    )
+                    next_page_soup = BeautifulSoup(next_page_html, "html.parser")
                     next_next_page_url = scraper.get_next_page_url(next_page_url, next_page_soup, 2)
                     log.info(f"Next-next page URL from {next_page_url}: {next_next_page_url}")
 
@@ -2965,141 +3712,155 @@ async def test_scraper(headless: bool = False):
     await scraper.close_session()
     log.info("Scraper test finished.")
 
-async def run_validation_test(supplier_url: str, config_file: str, overrides: dict, headless: bool = False):
+
+async def run_validation_test(
+    supplier_url: str, config_file: str, overrides: dict, headless: bool = False
+):
     """Run validation test on specific supplier URL with overrides."""
-    print(f"="*80)
+    print(f"=" * 80)
     print(f"LIVE SELECTOR-EXTRACTION VALIDATION")
     print(f"Supplier URL: {supplier_url}")
     print(f"Config File: {config_file}")
     print(f"Overrides: {json.dumps(overrides, indent=2)}")
-    print(f"="*80)
-    
+    print(f"=" * 80)
+
     # Create outputs directory
-    outputs_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "OUTPUTS", "supplier_data")
+    outputs_dir = os.path.join(
+        os.path.dirname(os.path.dirname(__file__)), "OUTPUTS", "supplier_data"
+    )
     os.makedirs(outputs_dir, exist_ok=True)
-    
+
     # Initialize AI client
     ai_client = None
     openai_api_key = os.getenv("OPENAI_API_KEY_SUPPLIER") or os.getenv("OPENAI_API_KEY")
     if openai_api_key:
         try:
             from openai import OpenAI
+
             ai_client = OpenAI(api_key=openai_api_key)
             log.info("✅ OpenAI client initialized for validation testing.")
         except Exception as e:
             log.error(f"❌ Error initializing OpenAI client: {e}")
             return False
-    
+
     # Initialize scraper with headless setting
     scraper = ConfigurableSupplierScraper(
-        ai_client=ai_client, 
+        ai_client=ai_client,
         openai_model_name=os.getenv("OPENAI_MODEL_SUPPLIER", "gpt-4.1-mini-2025-04-14"),
-        headless=headless
+        headless=headless,
     )
-    
+
     try:
         # Apply clear_cache if requested
         if overrides.get("clear_cache", False):
             log.info("🗑️  Clearing cache as requested...")
-        
+
         # Test supplier configuration or auto-discovery
         domain = get_domain_from_url(supplier_url)
         log.info(f"🔍 Testing domain: {domain}")
-        
+
         # Try to auto-configure the supplier
         config_result = await scraper.auto_configure_supplier(supplier_url)
-        
+
         if config_result.get("success", False):
             log.info(f"✅ Auto-configuration successful for {domain}")
-            
+
             # Test product extraction with limits
             max_products = overrides.get("max_products", 40)
             max_categories = overrides.get("max_categories", 8)
-            
+
             log.info(f"📊 Testing with limits: {max_products} products, {max_categories} categories")
-            
+
             # Get category URLs or use base URL
             test_urls = [supplier_url]  # Start with base URL
-            
+
             products_extracted = 0
             categories_processed = 0
-            
+
             for test_url in test_urls:
                 if categories_processed >= max_categories:
                     break
-                    
+
                 log.info(f"\n🔍 Testing URL: {test_url}")
                 html = await scraper.get_page_content(test_url)
-                
+
                 if html:
-                    soup = BeautifulSoup(html, 'html.parser')
+                    soup = BeautifulSoup(html, "html.parser")
                     product_elements = scraper.extract_product_elements(html, test_url)
-                    
+
                     log.info(f"📦 Found {len(product_elements)} product elements")
-                    
+
                     # Extract data from products (limited by max_products)
                     for i, p_soup in enumerate(product_elements):
                         if products_extracted >= max_products:
                             break
-                            
+
                         p_html = str(p_soup)
                         log.info(f"\n--- Product {products_extracted + 1} ---")
-                        
+
                         title = await scraper.extract_title(p_soup, p_html, test_url)
                         price = await scraper.extract_price(p_soup, p_html, test_url)
-                        product_url = await scraper.extract_url(p_soup, p_html, test_url, supplier_url)
+                        product_url = await scraper.extract_url(
+                            p_soup, p_html, test_url, supplier_url
+                        )
                         image = await scraper.extract_image(p_soup, p_html, test_url, supplier_url)
-                        
+
                         # Try to extract price from detail page (for sites requiring login)
                         detail_price = None
                         ean = None
                         if product_url:
                             detail_html = await scraper.get_page_content(product_url)
                             if detail_html:
-                                detail_soup = BeautifulSoup(detail_html, 'html.parser')
-                                
+                                detail_soup = BeautifulSoup(detail_html, "html.parser")
+
                                 # Extract price from meta tags
-                                price_meta = detail_soup.select_one('meta[property="product:price:amount"]')
-                                if price_meta and price_meta.get('content'):
+                                price_meta = detail_soup.select_one(
+                                    'meta[property="product:price:amount"]'
+                                )
+                                if price_meta and price_meta.get("content"):
                                     try:
-                                        detail_price = float(price_meta.get('content'))
+                                        detail_price = float(price_meta.get("content"))
                                         log.info(f"  💰 Meta Price Found: £{detail_price}")
                                     except:
                                         pass
-                                
+
                                 # Check for login required message
-                                login_btn = detail_soup.select_one('a.btn.customer-login-link.login-btn')
+                                login_btn = detail_soup.select_one(
+                                    "a.btn.customer-login-link.login-btn"
+                                )
                                 if login_btn:
-                                    log.info(f"  🔒 Login Required: {login_btn.get_text(strip=True)}")
-                                
+                                    log.info(
+                                        f"  🔒 Login Required: {login_btn.get_text(strip=True)}"
+                                    )
+
                                 # Extract EAN using enhanced method
                                 ean = scraper.extract_ean(detail_soup, product_url)
-                        
+
                         # Use detail page price if found, otherwise listing price
                         final_price = detail_price if detail_price is not None else price
-                        
+
                         log.info(f"  Title: {title}")
                         log.info(f"  Price: {final_price}")
                         log.info(f"  URL: {product_url}")
                         log.info(f"  EAN: {ean or 'Not found'}")
-                        
+
                         products_extracted += 1
-                        
+
                         if i < min(3, len(product_elements) - 1):
                             await asyncio.sleep(0.5)  # Brief pause
-                
+
                 categories_processed += 1
-            
+
             log.info(f"\n✅ VALIDATION COMPLETE")
             log.info(f"   Products extracted: {products_extracted}")
             log.info(f"   Categories processed: {categories_processed}")
-            
+
             return True
-            
+
         else:
             log.error(f"❌ Auto-configuration failed for {domain}")
             return False
-            
+
     except Exception as e:
         log.error(f"❌ Validation test failed: {e}")
         return False
@@ -3110,32 +3871,42 @@ async def run_validation_test(supplier_url: str, config_file: str, overrides: di
 if __name__ == "__main__":
     import sys
     import argparse
-    
+
     # Set up argument parser
-    parser = argparse.ArgumentParser(description='ConfigurableSupplierScraper Validation Tool')
-    parser.add_argument('--url', type=str, help='Supplier URL to test')
-    parser.add_argument('--config', type=str, help='Config file path')
-    parser.add_argument('--override', type=str, help='JSON string with override parameters')
-    parser.add_argument('--new-suppliers', action='store_true', help='Test new supplier websites')
-    parser.add_argument('--headless', action='store_true', default=False, 
-                       help='Run browser in headless mode (default: False for debugging)')
-    parser.add_argument('--use-shared-chrome', action='store_true', default=True,
-                       help='Connect to shared Chrome instance on port 9222 (default: True)')
-    
+    parser = argparse.ArgumentParser(description="ConfigurableSupplierScraper Validation Tool")
+    parser.add_argument("--url", type=str, help="Supplier URL to test")
+    parser.add_argument("--config", type=str, help="Config file path")
+    parser.add_argument("--override", type=str, help="JSON string with override parameters")
+    parser.add_argument("--new-suppliers", action="store_true", help="Test new supplier websites")
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        default=False,
+        help="Run browser in headless mode (default: False for debugging)",
+    )
+    parser.add_argument(
+        "--use-shared-chrome",
+        action="store_true",
+        default=True,
+        help="Connect to shared Chrome instance on port 9222 (default: True)",
+    )
+
     args = parser.parse_args()
-    
-    print("="*80)
+
+    print("=" * 80)
     print("ConfigurableSupplierScraper Test Run")
-    print("="*80)
-    
+    print("=" * 80)
+
     # Check for validation mode (--url, --config, --override)
     if args.url and args.config and args.override:
         try:
             overrides = json.loads(args.override)
             print(f"🚀 Running validation test mode... (headless: {args.headless})")
-            
+
             # Pass headless parameter to validation test
-            success = asyncio.run(run_validation_test(args.url, args.config, overrides, args.headless))
+            success = asyncio.run(
+                run_validation_test(args.url, args.config, overrides, args.headless)
+            )
             if success:
                 print("✅ Validation test completed successfully")
             else:
@@ -3146,12 +3917,18 @@ if __name__ == "__main__":
             sys.exit(1)
     # Check for new suppliers mode
     elif args.new_suppliers:
-        print(f"Testing new supplier websites with AI selector discovery... (headless: {args.headless}, shared-chrome: {args.use_shared_chrome})")
-        asyncio.run(test_new_suppliers(headless=args.headless, use_shared_chrome=args.use_shared_chrome))
+        print(
+            f"Testing new supplier websites with AI selector discovery... (headless: {args.headless}, shared-chrome: {args.use_shared_chrome})"
+        )
+        asyncio.run(
+            test_new_suppliers(headless=args.headless, use_shared_chrome=args.use_shared_chrome)
+        )
     else:
         print(f"Running standard test on Clearance King... (headless: {args.headless})")
         print("Usage examples:")
-        print("  --new-suppliers                    # Test Pound Wholesale and Cut Price Wholesaler")
+        print(
+            "  --new-suppliers                    # Test Pound Wholesale and Cut Price Wholesaler"
+        )
         print("  --url <URL> --config <CONFIG> --override <JSON>  # Validation mode")
         print("  --headless                         # Run in headless mode")
         asyncio.run(test_scraper(headless=args.headless))

--- a/tools/passive_extraction_workflow_latest.py
+++ b/tools/passive_extraction_workflow_latest.py
@@ -2099,7 +2099,7 @@ class PassiveExtractionWorkflow:
             # --- CUSTOM CATEGORY LOGIC ---
             if self.workflow_config.get("use_predefined_categories"):
                 self.log.info("CUSTOM MODE: Using predefined category list.")
-                category_urls_to_scrape = await self._get_predefined_categories(self.supplier_name)
+                category_urls_to_scrape = self._get_predefined_categories(self.supplier_name)
                 if not category_urls_to_scrape:
                     self.log.error(
                         "CUSTOM MODE FAILED: No URLs found in predefined list. Aborting."
@@ -3591,7 +3591,7 @@ class PassiveExtractionWorkflow:
             "ai_decision_history": [],  # New field for AI decisions
         }
 
-    async def _get_predefined_categories(self, supplier_name: str) -> list:
+    def _get_predefined_categories(self, supplier_name: str) -> list:
         """Load predefined category URLs from a custom JSON file."""
         log.info(f"Attempting to load predefined categories for {supplier_name}")
         try:

--- a/tools/passive_extraction_workflow_latest.py
+++ b/tools/passive_extraction_workflow_latest.py
@@ -55,6 +55,7 @@ The system's architecture is now properly decoupled. The `PassiveExtractionWorkf
 """
 
 import os, logging
+
 if not os.getenv("OPENAI_API_KEY"):
     logging.warning("OPENAI_API_KEY not set – AI features disabled")
 
@@ -73,28 +74,33 @@ import time
 import xml.etree.ElementTree as ET
 import requests
 from urllib.parse import urlparse, parse_qs, urljoin, parse_qsl, urlencode, urlunparse
-import difflib # Added for enhanced title similarity
+import difflib  # Added for enhanced title similarity
 import shutil
 from abc import ABC, abstractmethod
 
 # Import Windows Save Guardian for atomic persistence
 import sys
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from utils.windows_save_guardian import WindowsSaveGuardian
 from dataclasses import dataclass, field
-from pathlib import Path # ADDED IMPORT
+from pathlib import Path  # ADDED IMPORT
 import aiohttp  # Added for async HTTP requests
 
 # 🚨 SENTINEL MONITORING: Import sentinel monitoring system
 from utils.sentinel_monitor import get_sentinel_monitor, SentinelMonitor
+
 # 🚨 SENTINEL MONITORING: Import sentinel monitoring system
 from utils.sentinel_monitor import get_sentinel_monitor, SentinelMonitor
+
 # Load environment variables
 from dotenv import load_dotenv
+
 load_dotenv()
 
 # Assuming OpenAI client; ensure it's installed: pip install openai
 from openai import OpenAI
+
 # For enhanced HTML parsing
 from bs4 import BeautifulSoup
 
@@ -102,61 +108,82 @@ from bs4 import BeautifulSoup
 # FIXED: Change relative imports to absolute imports when running as standalone script
 import sys
 import os
+
 # Add both tools directory and parent directory to Python path
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
 # 🚀 HASH OPTIMIZATION: Import hash lookup optimizer for O(1) performance
-sys.path.append(os.path.join(current_dir, '..', 'utils'))
+sys.path.append(os.path.join(current_dir, "..", "utils"))
 from hash_lookup_optimizer import HashLookupOptimizer, LegacyPerformanceComparator
 from url_filter import filter_urls
+
 parent_dir = os.path.dirname(current_dir)
 sys.path.append(current_dir)
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-from amazon_playwright_extractor import AmazonExtractor # Base class for FixedAmazonExtractor
+from amazon_playwright_extractor import AmazonExtractor  # Base class for FixedAmazonExtractor
+
 # MODIFIED: Use ConfigurableSupplierScraper
 from configurable_supplier_scraper import ConfigurableSupplierScraper
+
 # Zero-token triage module available but not activated by default
 # from zero_token_triage_module import perform_zero_token_triage
 # Import FBA Calculator for accurate fee calculations
 from FBA_Financial_calculator import run_calculations, financials as calc_financials
 from cache_manager import CacheManager
+
 # Removed LinkingMapWriter - using internal linking map methods
 # Import enhanced state manager
 # The utils directory is at the parent level (project root), not in tools/
 try:
     import sys
     import os
+
     parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     sys.path.insert(0, parent_dir)
     from utils.fixed_enhanced_state_manager import FixedEnhancedStateManager as EnhancedStateManager
     from tools.category_completion_tracker import get_completion_metrics
 except ImportError:
     from fixed_enhanced_state_manager import FixedEnhancedStateManager as EnhancedStateManager
+
     try:
         from category_completion_tracker import get_completion_metrics
     except ImportError:
+
         def get_completion_metrics(base_path=None):
             """Fallback if category tracker not available - load from config"""
             try:
                 # 🚨 FIX 1: Load actual category count from config instead of returning 0
                 from config.system_config_loader import SystemConfigLoader
+
                 config_loader = SystemConfigLoader()
                 config_data = config_loader.load_config()
-                supplier_config = config_data.get("supplier_configs", {}).get("poundwholesale.co.uk", {})
+                supplier_config = config_data.get("supplier_configs", {}).get(
+                    "poundwholesale.co.uk", {}
+                )
                 category_urls = supplier_config.get("category_urls", [])
                 return {
-                    "total_categories": len(category_urls), 
-                    "category_completion_status": {}, 
-                    "last_analyze_url": None
+                    "total_categories": len(category_urls),
+                    "category_completion_status": {},
+                    "last_analyze_url": None,
                 }
             except Exception as e:
                 # Ultimate fallback - but log the issue
                 print(f"⚠️ WARNING: Cannot load category count from config: {e}")
-                return {"total_categories": 0, "category_completion_status": {}, "last_analyze_url": None}
+                return {
+                    "total_categories": 0,
+                    "category_completion_status": {},
+                    "last_analyze_url": None,
+                }
 
-from playwright.async_api import async_playwright, Browser, Page, TimeoutError as PlaywrightTimeoutError
+
+from playwright.async_api import (
+    async_playwright,
+    Browser,
+    Page,
+    TimeoutError as PlaywrightTimeoutError,
+)
 from utils.browser_manager import BrowserManager
 from utils.path_manager import path_manager, get_linking_map_path
 from config.system_config_loader import SystemConfigLoader
@@ -164,153 +191,422 @@ from config.system_config_loader import SystemConfigLoader
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[
         logging.StreamHandler(),
-        logging.FileHandler(f"fba_extraction_{datetime.now().strftime('%Y%m%d')}.log")
-    ]
+        logging.FileHandler(f"fba_extraction_{datetime.now().strftime('%Y%m%d')}.log"),
+    ],
 )
 log = logging.getLogger(__name__)
 
 # ──────────────────────── ①  Enhanced FBA Priority Patterns (Research-Based) ──────────────────────
 FBA_FRIENDLY_PATTERNS = {
-    "home_kitchen":      ["home","kitchen","dining","storage","decor","organization","household"],     # Priority #1
-    "pet_supplies":      ["pet","dog","cat","animal","bird","aquarium","fish"],                  # Priority #2
-    "beauty_care":       ["beauty","personal","skincare","grooming","cosmetic","health"],            # Priority #3
-    "sports_outdoor":    ["sport","fitness","camping","outdoor","exercise","yoga","garden"],     # Priority #4
-    "office_stationery": ["office","stationery","desk","paper","business","school"],           # Priority #5
-    "diy_tools":         ["diy","tool","hardware","hand-tool","craft","workshop","repair"],           # Priority #6
-    "baby_nursery":      ["baby","infant","nursery","toddler","child-safe","kids"],               # Priority #7
-    "toys_games":        ["toy","game","puzzle","educational","learning","play"],              # Priority #8
-    "automotive":        ["car","auto","vehicle","motorcycle","bike","cycling"],                # Priority #9
-    "kids_books":        ["kids book","children book","coloring book","sticker book","activity book","playbook","educational book","picture book","story book"],  # Priority #10
-    "clearance_value":   ["pound","poundline","50p","under","clearance","sale","discount","bargain","cheap","value","deal"],  # Priority #11 (Medium-Low)
-    "crafts_hobbies":    ["craft","hobby","sewing","knitting","art","creative","scrapbook","drawing"],  # Priority #12 (Lower)
-    "seasonal_items":    ["christmas","halloween","easter","valentine","seasonal","holiday","party"],  # Priority #13 (Lower)
-    "miscellaneous":     ["misc","other","general","various","assorted","mixed"]                # Priority #14 (Lower)
+    "home_kitchen": [
+        "home",
+        "kitchen",
+        "dining",
+        "storage",
+        "decor",
+        "organization",
+        "household",
+    ],  # Priority #1
+    "pet_supplies": ["pet", "dog", "cat", "animal", "bird", "aquarium", "fish"],  # Priority #2
+    "beauty_care": [
+        "beauty",
+        "personal",
+        "skincare",
+        "grooming",
+        "cosmetic",
+        "health",
+    ],  # Priority #3
+    "sports_outdoor": [
+        "sport",
+        "fitness",
+        "camping",
+        "outdoor",
+        "exercise",
+        "yoga",
+        "garden",
+    ],  # Priority #4
+    "office_stationery": [
+        "office",
+        "stationery",
+        "desk",
+        "paper",
+        "business",
+        "school",
+    ],  # Priority #5
+    "diy_tools": [
+        "diy",
+        "tool",
+        "hardware",
+        "hand-tool",
+        "craft",
+        "workshop",
+        "repair",
+    ],  # Priority #6
+    "baby_nursery": ["baby", "infant", "nursery", "toddler", "child-safe", "kids"],  # Priority #7
+    "toys_games": ["toy", "game", "puzzle", "educational", "learning", "play"],  # Priority #8
+    "automotive": ["car", "auto", "vehicle", "motorcycle", "bike", "cycling"],  # Priority #9
+    "kids_books": [
+        "kids book",
+        "children book",
+        "coloring book",
+        "sticker book",
+        "activity book",
+        "playbook",
+        "educational book",
+        "picture book",
+        "story book",
+    ],  # Priority #10
+    "clearance_value": [
+        "pound",
+        "poundline",
+        "50p",
+        "under",
+        "clearance",
+        "sale",
+        "discount",
+        "bargain",
+        "cheap",
+        "value",
+        "deal",
+    ],  # Priority #11 (Medium-Low)
+    "crafts_hobbies": [
+        "craft",
+        "hobby",
+        "sewing",
+        "knitting",
+        "art",
+        "creative",
+        "scrapbook",
+        "drawing",
+    ],  # Priority #12 (Lower)
+    "seasonal_items": [
+        "christmas",
+        "halloween",
+        "easter",
+        "valentine",
+        "seasonal",
+        "holiday",
+        "party",
+    ],  # Priority #13 (Lower)
+    "miscellaneous": [
+        "misc",
+        "other",
+        "general",
+        "various",
+        "assorted",
+        "mixed",
+    ],  # Priority #14 (Lower)
 }
 FBA_AVOID_PATTERNS = {
-    "dangerous_goods": ["battery","power","lithium","flammable","hazmat","explosive"],           # CRITICAL AVOID
-    "electronics":     ["electronic","tech","computer","phone","gadget","digital","tv"],     # HIGH AVOID
-    "clothing":        ["clothing","fashion","apparel","shoe","sock","wear","dress"],             # HIGH AVOID
-    "medical":         ["medical","pharma","medicine","healthcare","therapeutic","prescription"],          # HIGH AVOID
-    "food":            ["food","beverage","grocery","snack","drink","edible","alcohol"],               # HIGH AVOID
-    "large_bulky":     ["appliance","sofa","mattress","wardrobe","furniture","heavy"],          # MEDIUM AVOID
-    "high_value":      ["jewelry","jewellery","watch","precious","gold","diamond","expensive"],      # MEDIUM AVOID
-    "adult_books":     ["novel","fiction","romance","thriller","biography","autobiography","textbook","academic book","adult book","paperback novel"]  # AVOID adult reading books
+    "dangerous_goods": [
+        "battery",
+        "power",
+        "lithium",
+        "flammable",
+        "hazmat",
+        "explosive",
+    ],  # CRITICAL AVOID
+    "electronics": [
+        "electronic",
+        "tech",
+        "computer",
+        "phone",
+        "gadget",
+        "digital",
+        "tv",
+    ],  # HIGH AVOID
+    "clothing": ["clothing", "fashion", "apparel", "shoe", "sock", "wear", "dress"],  # HIGH AVOID
+    "medical": [
+        "medical",
+        "pharma",
+        "medicine",
+        "healthcare",
+        "therapeutic",
+        "prescription",
+    ],  # HIGH AVOID
+    "food": ["food", "beverage", "grocery", "snack", "drink", "edible", "alcohol"],  # HIGH AVOID
+    "large_bulky": [
+        "appliance",
+        "sofa",
+        "mattress",
+        "wardrobe",
+        "furniture",
+        "heavy",
+    ],  # MEDIUM AVOID
+    "high_value": [
+        "jewelry",
+        "jewellery",
+        "watch",
+        "precious",
+        "gold",
+        "diamond",
+        "expensive",
+    ],  # MEDIUM AVOID
+    "adult_books": [
+        "novel",
+        "fiction",
+        "romance",
+        "thriller",
+        "biography",
+        "autobiography",
+        "textbook",
+        "academic book",
+        "adult book",
+        "paperback novel",
+    ],  # AVOID adult reading books
 }
 
 # Third category for when FBA friendly categories are exhausted
 FBA_NEUTRAL_PATTERNS = {
-    "collectibles":    ["collectible","vintage","antique","memorabilia"],
-    "media_dvd_cd":    ["dvd","cd","music","movie","film","media"]  # Removed general "book" from here since it's now classified above
+    "collectibles": ["collectible", "vintage", "antique", "memorabilia"],
+    "media_dvd_cd": [
+        "dvd",
+        "cd",
+        "music",
+        "movie",
+        "film",
+        "media",
+    ],  # Removed general "book" from here since it's now classified above
 }
+
 
 # ──────────────────────── BACKUP UTILITY FUNCTIONS ──────────────────────
 def create_backup_with_experiment_number(file_path: str, experiment_number: int) -> str:
     """Create backup with .bakN suffix for experiment tracking"""
     if not os.path.exists(file_path):
         return None
-    
+
     backup_path = f"{file_path}.bak{experiment_number}"
     shutil.copy2(file_path, backup_path)
     return backup_path
+
 
 # DISABLED: backup_experiment_files and callers per P0 requirements
 # def backup_experiment_files(experiment_number: int, output_root: str = "OUTPUTS") -> Dict[str, str]:
 #     """Backup all files that need .bakN suffix (EXCEPT Amazon cache)"""
 #     backup_results = {}
-#     
+#
 #     # System config
 #     config_path = "config/system_config.json"
 #     if os.path.exists(config_path):
 #         backup_results["system_config"] = create_backup_with_experiment_number(config_path, experiment_number)
-#     
+#
 #     # Processing state
 #     state_path = os.path.join(output_root, "CACHE/processing_states/poundwholesale_co_uk_processing_state.json")
 #     if os.path.exists(state_path):
 #         backup_results["processing_state"] = create_backup_with_experiment_number(state_path, experiment_number)
-#     
+#
 #     # Linking map
 #     linking_path = os.path.join(output_root, "FBA_ANALYSIS/linking_maps/poundwholesale.co.uk/linking_map.json")
 #     if os.path.exists(linking_path):
 #         backup_results["linking_map"] = create_backup_with_experiment_number(linking_path, experiment_number)
-#     
+#
 #     # Supplier product cache
 #     supplier_cache_path = os.path.join(output_root, "cached_products/poundwholesale-co-uk_products_cache.json")
 #     if os.path.exists(supplier_cache_path):
 #         backup_results["supplier_cache"] = create_backup_with_experiment_number(supplier_cache_path, experiment_number)
-#     
+#
 #     return backup_results
 
 # ──────────────────────── ②  Add OpenAI client initialization (after imports) ────────────
 
 # Battery filtering patterns - products containing these will be excluded
 BATTERY_KEYWORDS = [
-    "battery", "batteries", "lithium", "alkaline", "rechargeable", 
-    "power cell", "coin cell", "button cell", "watch battery", 
-    "hearing aid battery", "cordless phone battery", "9v battery",
-    "aa battery", "aaa battery", "c battery", "d battery",
-    "cr2032", "cr2025", "cr2016", "cr1220", "cr1632", "cr2354",
-    "lr44", "lr41", "lr20", "lr14", "lr6", "lr03",
-    "ag13", "ag10", "ag4", "ag3", "ag1", "sr626", "sr621",
-    "18650", "26650", "14500", "16340", "10440",
-    "4lr44", "23a", "27a", "n battery", "aaaa battery"
+    "battery",
+    "batteries",
+    "lithium",
+    "alkaline",
+    "rechargeable",
+    "power cell",
+    "coin cell",
+    "button cell",
+    "watch battery",
+    "hearing aid battery",
+    "cordless phone battery",
+    "9v battery",
+    "aa battery",
+    "aaa battery",
+    "c battery",
+    "d battery",
+    "cr2032",
+    "cr2025",
+    "cr2016",
+    "cr1220",
+    "cr1632",
+    "cr2354",
+    "lr44",
+    "lr41",
+    "lr20",
+    "lr14",
+    "lr6",
+    "lr03",
+    "ag13",
+    "ag10",
+    "ag4",
+    "ag3",
+    "ag1",
+    "sr626",
+    "sr621",
+    "18650",
+    "26650",
+    "14500",
+    "16340",
+    "10440",
+    "4lr44",
+    "23a",
+    "27a",
+    "n battery",
+    "aaaa battery",
 ]
 
 BATTERY_BRAND_CONTEXT = [
-    "duracell", "energizer", "panasonic", "rayovac", "eveready",
-    "maxell", "renata", "vinnic", "gp", "varta", "sony",
-    "toshiba", "philips", "uniross", "extrastar", "infapower",
-    "eunicell", "jcb battery", "tesco battery"
+    "duracell",
+    "energizer",
+    "panasonic",
+    "rayovac",
+    "eveready",
+    "maxell",
+    "renata",
+    "vinnic",
+    "gp",
+    "varta",
+    "sony",
+    "toshiba",
+    "philips",
+    "uniross",
+    "extrastar",
+    "infapower",
+    "eunicell",
+    "jcb battery",
+    "tesco battery",
 ]
 
 # Non-FBA friendly product filtering patterns - products containing these will be excluded
 NON_FBA_FRIENDLY_KEYWORDS = [
     # Smoking/Drug-related products
-    "smoking pipe", "glass pipe", "water pipe", "tobacco pipe", "hookah", "shisha",
-    "bong", "vaporizer", "vape", "e-cigarette", "cigarette", "cigar", "rolling paper",
-    "grinder", "herb grinder", "smoking accessories", "pipe cleaner", "pipe screen",
-    
+    "smoking pipe",
+    "glass pipe",
+    "water pipe",
+    "tobacco pipe",
+    "hookah",
+    "shisha",
+    "bong",
+    "vaporizer",
+    "vape",
+    "e-cigarette",
+    "cigarette",
+    "cigar",
+    "rolling paper",
+    "grinder",
+    "herb grinder",
+    "smoking accessories",
+    "pipe cleaner",
+    "pipe screen",
     # Weapons and dangerous items
-    "knife", "blade", "sword", "dagger", "machete", "tactical", "self defense",
-    "pepper spray", "stun gun", "taser", "brass knuckles", "nunchucks",
-    
+    "knife",
+    "blade",
+    "sword",
+    "dagger",
+    "machete",
+    "tactical",
+    "self defense",
+    "pepper spray",
+    "stun gun",
+    "taser",
+    "brass knuckles",
+    "nunchucks",
     # Adult/inappropriate content
-    "adult toy", "sex toy", "erotic", "pornographic", "xxx", "adult entertainment",
-    
+    "adult toy",
+    "sex toy",
+    "erotic",
+    "pornographic",
+    "xxx",
+    "adult entertainment",
     # Hazardous materials
-    "flammable", "explosive", "toxic", "corrosive", "radioactive", "biohazard",
-    "chemical", "pesticide", "insecticide", "poison", "acid",
-    
+    "flammable",
+    "explosive",
+    "toxic",
+    "corrosive",
+    "radioactive",
+    "biohazard",
+    "chemical",
+    "pesticide",
+    "insecticide",
+    "poison",
+    "acid",
     # Restricted electronics
-    "laser pointer", "high power laser", "jamming device", "signal jammer",
-    "surveillance", "spy camera", "hidden camera", "wiretap",
-    
+    "laser pointer",
+    "high power laser",
+    "jamming device",
+    "signal jammer",
+    "surveillance",
+    "spy camera",
+    "hidden camera",
+    "wiretap",
     # Medical devices (restricted)
-    "prescription", "medical device", "surgical", "diagnostic", "therapeutic device",
-    "hearing aid", "pacemaker", "insulin pump", "blood glucose",
-    
+    "prescription",
+    "medical device",
+    "surgical",
+    "diagnostic",
+    "therapeutic device",
+    "hearing aid",
+    "pacemaker",
+    "insulin pump",
+    "blood glucose",
     # Counterfeit indicators
-    "replica", "fake", "knockoff", "copy", "imitation", "unauthorized",
-    
+    "replica",
+    "fake",
+    "knockoff",
+    "copy",
+    "imitation",
+    "unauthorized",
     # Alcohol and controlled substances
-    "alcohol", "wine", "beer", "spirits", "liquor", "alcoholic",
-    
+    "alcohol",
+    "wine",
+    "beer",
+    "spirits",
+    "liquor",
+    "alcoholic",
     # Live animals and perishables
-    "live animal", "pet", "fish", "bird", "reptile", "fresh food", "perishable"
+    "live animal",
+    "pet",
+    "fish",
+    "bird",
+    "reptile",
+    "fresh food",
+    "perishable",
 ]
 
 NON_FBA_FRIENDLY_BRAND_CONTEXT = [
     # Smoking brands
-    "zippo", "clipper", "bic lighter", "dunhill", "peterson pipe", "savinelli",
-    "chacom", "stanwell", "missouri meerschaum", "raw papers", "zig zag",
-    
+    "zippo",
+    "clipper",
+    "bic lighter",
+    "dunhill",
+    "peterson pipe",
+    "savinelli",
+    "chacom",
+    "stanwell",
+    "missouri meerschaum",
+    "raw papers",
+    "zig zag",
     # Weapon brands
-    "gerber", "benchmade", "spyderco", "cold steel", "ka-bar", "smith wesson",
-    
+    "gerber",
+    "benchmade",
+    "spyderco",
+    "cold steel",
+    "ka-bar",
+    "smith wesson",
     # Vaping brands
-    "juul", "pax", "volcano", "storz bickel", "davinci", "arizer"
+    "juul",
+    "pax",
+    "volcano",
+    "storz bickel",
+    "davinci",
+    "arizer",
 ]
 
 # Price criteria for supplier products
@@ -319,7 +615,7 @@ MAX_PRICE = float(os.getenv("MAX_PRICE", "20.0"))
 
 # Profitability and Amazon listing criteria
 MIN_ROI_PERCENT = float(os.getenv("MIN_ROI_PERCENT", "35.0"))
-MIN_PROFIT_PER_UNIT = float(os.getenv("MIN_PROFIT_PER_UNIT", "3.0")) # Added explicit min profit
+MIN_PROFIT_PER_UNIT = float(os.getenv("MIN_PROFIT_PER_UNIT", "3.0"))  # Added explicit min profit
 MIN_RATING = float(os.getenv("MIN_RATING", "4.0"))
 MIN_REVIEWS = int(os.getenv("MIN_REVIEWS", "50"))
 MAX_SALES_RANK = int(os.getenv("MAX_SALES_RANK", "150000"))
@@ -339,17 +635,23 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUTPUT_DIR = os.getenv("OUTPUT_DIR", os.path.join(BASE_DIR, "OUTPUTS", "FBA_ANALYSIS"))
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
+
 # Load cache directories from config/system_config.json
 def _load_cache_directories():
     try:
-        config_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "config", "system_config.json")
-        with open(config_path, 'r', encoding='utf-8') as f:
+        config_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "config",
+            "system_config.json",
+        )
+        with open(config_path, "r", encoding="utf-8") as f:
             config = json.load(f)
         cache_dirs = config.get("cache", {}).get("directories", {})
         return cache_dirs
     except Exception as e:
         logging.warning(f"Failed to load cache directories from config: {e}")
         return {}
+
 
 cache_directories = _load_cache_directories()
 
@@ -367,27 +669,33 @@ os.makedirs(SUPPLIER_CACHE_DIR, exist_ok=True)
 os.makedirs(AMAZON_CACHE_DIR, exist_ok=True)
 os.makedirs(AI_CATEGORY_CACHE_DIR, exist_ok=True)
 
+
 # Load OpenAI configuration from system config
 def _load_openai_config():
     """Load OpenAI configuration from system_config.json"""
     try:
-        config_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "config", "system_config.json")
-        with open(config_path, 'r', encoding='utf-8') as f:
+        config_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "config",
+            "system_config.json",
+        )
+        with open(config_path, "r", encoding="utf-8") as f:
             config = json.load(f)
-        
+
         openai_config = config.get("integrations", {}).get("openai", {})
         return {
             "api_key": openai_config.get("api_key", ""),
             "model": openai_config.get("model", "gpt-4o-mini"),
-            "enabled": openai_config.get("enabled", False)
+            "enabled": openai_config.get("enabled", False),
         }
     except Exception as e:
         log.warning(f"Failed to load OpenAI config from system_config.json: {e}")
         return {
             "api_key": os.getenv("OPENAI_API_KEY", ""),
             "model": os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
-            "enabled": True
+            "enabled": True,
         }
+
 
 # Load OpenAI configuration
 _openai_config = _load_openai_config()
@@ -406,11 +714,13 @@ if not OPENAI_API_KEY:
 # Battery product detection constants
 BATTERY_KEYWORDS = ("battery", "batteries", "cell", "cr20", "lr41", "lithium", "alkaline")
 
+
 def is_battery_title(title: str) -> bool:
     """Check if a product title indicates it's a battery product."""
     if not title:
         return False
     return any(k in title.lower() for k in BATTERY_KEYWORDS)
+
 
 class FixedAmazonExtractor(AmazonExtractor):
     """
@@ -423,7 +733,7 @@ class FixedAmazonExtractor(AmazonExtractor):
         super().__init__(chrome_debug_port, ai_client)
         # self.ai_client is already set by parent constructor if ai_client is passed.
 
-    async def connect(self) -> Browser: # type: ignore
+    async def connect(self) -> Browser:  # type: ignore
         """
         Connect to browser using the centralized BrowserManager singleton.
         All browser operations now go through the shared BrowserManager instance.
@@ -432,103 +742,111 @@ class FixedAmazonExtractor(AmazonExtractor):
         try:
             # Use the browser manager singleton for centralized browser management
             browser_manager = BrowserManager.get_instance()
-            
+
             # Ensure browser manager is properly launched
-            if not hasattr(browser_manager, 'browser') or not browser_manager.browser:
+            if not hasattr(browser_manager, "browser") or not browser_manager.browser:
                 await browser_manager.launch_browser(cdp_port=self.chrome_debug_port)
-            
+
             # Get the shared browser instance
             self.browser = browser_manager.browser
             log.info("✅ FixedAmazonExtractor connected via BrowserManager singleton")
-            
+
             return self.browser
         except Exception as e:
             log.error(f"❌ FixedAmazonExtractor failed to connect via BrowserManager: {e}")
-            log.error("Ensure Chrome is running with --remote-debugging-port=9222 and BrowserManager is properly initialized")
+            log.error(
+                "Ensure Chrome is running with --remote-debugging-port=9222 and BrowserManager is properly initialized"
+            )
             raise
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
 
-    async def search_by_title_using_search_bar(self, title: str, page: Optional[Page] = None) -> Dict[str, Any]:
+    async def search_by_title_using_search_bar(
+        self, title: str, page: Optional[Page] = None
+    ) -> Dict[str, Any]:
         """Search Amazon by title using search bar interaction (not URL building)"""
         if not self.browser or not self.browser.is_connected():
             await self.connect()
 
         log.info(f"Searching Amazon by title using search bar: '{title}'")
-        
+
         # Get page from parameter or use BrowserManager
         if page is None:
             from utils.browser_manager import get_page_for_url
+
             log.info("No page provided to search_by_title, getting one from BrowserManager.")
             page = await get_page_for_url("https://www.amazon.co.uk", reuse_existing=True)
-        
+
         try:
             # Navigate to Amazon UK and search by typing title into search bar
             log.info(f"Navigating to Amazon UK to search for title: {title}")
             await page.goto("https://www.amazon.co.uk", timeout=60000)
-            
+
             # Type title into search box and press Enter
             await page.fill("input#twotabsearchtextbox", title, timeout=5000)
             await page.press("input#twotabsearchtextbox", "Enter")
-            
+
             # Wait for search results
             await page.wait_for_selector("div.s-search-results", timeout=15000)
-            
+
             # Parse search results - extract first few results with improved element selection
             potential_asins_info = []
-            
+
             # Try multiple selectors for search result elements
             search_result_elements = []
             search_selectors = [
                 "div.s-search-results > div[data-asin]",
                 "div[data-component-type='s-search-result']",
                 "div[data-asin]:not([data-asin=''])",
-                "[cel_widget_id*='MAIN-SEARCH_RESULTS'] div[data-asin]"
+                "[cel_widget_id*='MAIN-SEARCH_RESULTS'] div[data-asin]",
             ]
-            
+
             for selector in search_selectors:
                 try:
                     elements = await page.query_selector_all(selector)
                     if elements:
                         search_result_elements = elements
-                        log.info(f"Title search found {len(elements)} elements using selector: {selector}")
+                        log.info(
+                            f"Title search found {len(elements)} elements using selector: {selector}"
+                        )
                         break
                 except Exception as e:
                     log.debug(f"Title search selector '{selector}' failed: {e}")
                     continue
-            
+
             for element in search_result_elements[:10]:  # More results for title search
                 asin = await element.get_attribute("data-asin")
                 # FIX: Remove overly restrictive 10-character requirement for ASIN validation
                 # ASINs can be valid with fewer than 10 characters
-                if asin and len(asin) >= 8 and len(asin) <= 12:  # More reasonable range for ASIN validation
+                if (
+                    asin and len(asin) >= 8 and len(asin) <= 12
+                ):  # More reasonable range for ASIN validation
                     # Use improved title extraction
                     result_title = await self._extract_title_from_element(element, asin)
-                    
-                    potential_asins_info.append({
-                        "asin": asin,
-                        "title": result_title
-                    })
-            
+
+                    potential_asins_info.append({"asin": asin, "title": result_title})
+
             # Create search_results_data in expected format
             if potential_asins_info:
                 search_results_data = {
                     "results": potential_asins_info,
-                    "search_method": "title_search_bar_interaction"
+                    "search_method": "title_search_bar_interaction",
                 }
                 log.info(f"Title search found {len(potential_asins_info)} results for '{title}'")
             else:
                 search_results_data = {"error": f"No valid ASINs found for title '{title}'"}
                 log.warning(f"No valid ASINs found for title '{title}'")
-                
+
         except Exception as search_error:
             log.error(f"Error during title search for '{title}': {search_error}")
-            search_results_data = {"error": f"Search error for title '{title}': {str(search_error)}"}
-            
+            search_results_data = {
+                "error": f"Search error for title '{title}': {str(search_error)}"
+            }
+
         return search_results_data
 
     async def _extract_title_from_element(self, element, asin: str) -> str:
@@ -551,21 +869,23 @@ class FixedAmazonExtractor(AmazonExtractor):
             "a.a-link-normal > span.a-text-normal",
             "a span[aria-label]",
             "a[href*='/dp/'] span",
-            ".a-link-normal span"
+            ".a-link-normal span",
         ]
-        
+
         for selector in title_selectors:
             try:
                 title_element = await element.query_selector(selector)
                 if title_element:
                     title_text = await title_element.inner_text()
                     if title_text and title_text.strip() and title_text.strip() != "":
-                        log.debug(f"ASIN {asin} title extracted using selector '{selector}': {title_text.strip()[:50]}...")
+                        log.debug(
+                            f"ASIN {asin} title extracted using selector '{selector}': {title_text.strip()[:50]}..."
+                        )
                         return title_text.strip()
             except Exception as e:
                 log.debug(f"Selector '{selector}' failed for ASIN {asin}: {e}")
                 continue
-        
+
         # Fallback level 1: Try any element with "title" in class or data attributes
         try:
             title_containing_selectors = [
@@ -573,34 +893,40 @@ class FixedAmazonExtractor(AmazonExtractor):
                 "[data-cy*='title']",
                 "[data-a-target*='title']",
                 ".a-size-base-plus",
-                ".a-size-medium"
+                ".a-size-medium",
             ]
-            
+
             for fallback_selector in title_containing_selectors:
                 fallback_element = await element.query_selector(fallback_selector)
                 if fallback_element:
                     fallback_text = await fallback_element.inner_text()
                     if fallback_text and fallback_text.strip():
-                        log.debug(f"ASIN {asin} title extracted using fallback selector '{fallback_selector}': {fallback_text.strip()[:50]}...")
+                        log.debug(
+                            f"ASIN {asin} title extracted using fallback selector '{fallback_selector}': {fallback_text.strip()[:50]}..."
+                        )
                         return fallback_text.strip()
         except Exception as e:
             log.debug(f"Fallback title extraction with selectors failed for ASIN {asin}: {e}")
-        
+
         # Fallback level 2: Try to get any text content from h2 or other common title containers
         try:
             fallback_element = await element.query_selector("h2, .a-text-normal, .a-link-normal")
             if fallback_element:
                 fallback_text = await fallback_element.inner_text()
                 if fallback_text and fallback_text.strip():
-                    log.debug(f"ASIN {asin} title extracted using last-resort fallback: {fallback_text.strip()[:50]}...")
+                    log.debug(
+                        f"ASIN {asin} title extracted using last-resort fallback: {fallback_text.strip()[:50]}..."
+                    )
                     return fallback_text.strip()
         except Exception as e:
             log.debug(f"Last-resort fallback title extraction failed for ASIN {asin}: {e}")
-        
+
         log.warning(f"Could not extract title for ASIN {asin} using any selector")
         return "Unknown Title"
 
-    async def search_by_ean_and_extract_data(self, ean: str, supplier_product_title: str, page: Optional[Page] = None) -> Dict[str, Any]:
+    async def search_by_ean_and_extract_data(
+        self, ean: str, supplier_product_title: str, page: Optional[Page] = None
+    ) -> Dict[str, Any]:
         """
         Search Amazon by EAN and extract data for the best match.
         Uses AI for disambiguation if multiple results are found.
@@ -609,35 +935,38 @@ class FixedAmazonExtractor(AmazonExtractor):
         if not self.browser or not self.browser.is_connected():
             await self.connect()
 
-        log.info(f"Searching Amazon by EAN: {ean} for supplier product: '{supplier_product_title}' (FixedAmazonExtractor)")
-        
+        log.info(
+            f"Searching Amazon by EAN: {ean} for supplier product: '{supplier_product_title}' (FixedAmazonExtractor)"
+        )
+
         # Get page from parameter or use BrowserManager
         if page is None:
             from utils.browser_manager import get_page_for_url
+
             log.info("No page provided to search_by_ean, getting one from BrowserManager.")
             page = await get_page_for_url("https://www.amazon.co.uk", reuse_existing=True)
-        
+
         try:
             # Navigate to Amazon UK and search by typing EAN into search bar
             log.info(f"Navigating to Amazon UK to search for EAN: {ean}")
-            
+
             await page.goto("https://www.amazon.co.uk", timeout=60000)
-            
+
             # Type EAN into search box and press Enter
             await page.fill("input#twotabsearchtextbox", ean, timeout=5000)
             await page.press("input#twotabsearchtextbox", "Enter")
-            
+
             # Wait for search results with enhanced multiple selector approach - REQUIREMENT 1
             log.info(f"Waiting for search results page to load for EAN {ean}...")
             search_result_containers_found = False
             container_selectors = [
-                "div.s-search-results", 
-                "div[data-component-type='s-search-results']", 
+                "div.s-search-results",
+                "div[data-component-type='s-search-results']",
                 "[data-cy='search-result-list]",
                 "div.s-result-list",
-                "div.s-main-slot"
+                "div.s-main-slot",
             ]
-            
+
             # Wait for any of the container selectors with a longer timeout
             for container_selector in container_selectors:
                 try:
@@ -646,37 +975,43 @@ class FixedAmazonExtractor(AmazonExtractor):
                     search_result_containers_found = True
                     break
                 except Exception as container_error:
-                    log.debug(f"Container selector '{container_selector}' not found: {container_error}")
-            
+                    log.debug(
+                        f"Container selector '{container_selector}' not found: {container_error}"
+                    )
+
             if not search_result_containers_found:
                 # Check for a direct product page (Amazon sometimes redirects to product page for exact EAN match)
                 try:
                     direct_product_selectors = ["div#dp-container", "div#ppd", "div#centerCol"]
                     for direct_selector in direct_product_selectors:
                         if await page.query_selector(direct_selector):
-                            log.info(f"EAN search redirected to a direct product page (selector: {direct_selector})")
+                            log.info(
+                                f"EAN search redirected to a direct product page (selector: {direct_selector})"
+                            )
                             # Extract ASIN from URL
                             current_url = page.url
                             asin_match = re.search(r"/dp/([A-Z0-9]{10})", current_url)
                             if asin_match:
                                 direct_asin = asin_match.group(1)
-                                log.info(f"Found direct product match for EAN {ean}: ASIN {direct_asin}")
+                                log.info(
+                                    f"Found direct product match for EAN {ean}: ASIN {direct_asin}"
+                                )
                                 # Return the data directly
                                 return await super().extract_data(direct_asin)
                             break
                 except Exception as direct_page_error:
                     log.debug(f"Error checking for direct product page: {direct_page_error}")
-                
+
                 log.warning(f"No search results containers found for EAN {ean}")
                 return {"error": f"No search results found for EAN {ean}"}
-            
+
             # Add a brief stabilization wait to ensure all elements are loaded
             await asyncio.sleep(2)
-                        
-            # REQUIREMENT 2: Search Result Element (Tile) Selection with improved selectors 
+
+            # REQUIREMENT 2: Search Result Element (Tile) Selection with improved selectors
             organic_results = []
             search_result_elements = []
-            
+
             # Enhanced list of selectors for finding individual product tiles
             search_selectors = [
                 # Try to exclude obvious ad containers at the selection stage
@@ -686,53 +1021,66 @@ class FixedAmazonExtractor(AmazonExtractor):
                 "div.s-search-results > div[data-asin]",
                 "div[data-cel-widget*='search_result_'][data-asin]:not([data-asin=''])",
                 "[cel_widget_id*='MAIN-SEARCH_RESULTS'] div[data-asin]",
-                "div[data-uuid][data-asin]:not([data-asin=''])"
+                "div[data-uuid][data-asin]:not([data-asin=''])",
             ]
-            
+
             for selector in search_selectors:
                 try:
                     elements = await page.query_selector_all(selector)
                     if elements and len(elements) > 0:
                         search_result_elements = elements
-                        log.info(f"Found {len(elements)} search result elements using selector: {selector}")
+                        log.info(
+                            f"Found {len(elements)} search result elements using selector: {selector}"
+                        )
                         break
                 except Exception as e:
                     log.debug(f"Search selector '{selector}' failed: {e}")
                     continue
-            
+
             if not search_result_elements:
                 log.warning(f"No search result elements found for EAN {ean}")
                 return {"error": "no_elements_found"}
             else:
-                log.info(f"Processing {len(search_result_elements)} search result elements for EAN {ean}")
-                
+                log.info(
+                    f"Processing {len(search_result_elements)} search result elements for EAN {ean}"
+                )
+
                 # Look at more elements (up to 15) to find organic results
                 for i, element in enumerate(search_result_elements[:15]):
                     asin = await element.get_attribute("data-asin")
                     # FIX: Remove overly restrictive 10-character requirement for ASIN validation
                     # ASINs can be valid with fewer than 10 characters
-                    if not asin or len(asin) < 8 or len(asin) > 12:  # More reasonable range for ASIN validation
+                    if (
+                        not asin or len(asin) < 8 or len(asin) > 12
+                    ):  # More reasonable range for ASIN validation
                         log.debug(f"Element {i+1}: Invalid or missing ASIN: {asin}")
                         continue
-                        
+
                     log.debug(f"Processing element {i+1}: ASIN {asin}")
-                    
+
                     # --- REQUIREMENT 4: Enhanced sponsored detection logic (Iteration 3) ---
                     is_sponsored = False
                     sponsor_detection_reason = ""
-                    
+
                     # Add debug logging for first few elements
                     if i < 3:
                         try:
-                            element_html_debug = await element.evaluate("element => element.outerHTML")
-                            log.debug(f"ASIN {asin} HTML structure sample: {element_html_debug[:600]}...")
+                            element_html_debug = await element.evaluate(
+                                "element => element.outerHTML"
+                            )
+                            log.debug(
+                                f"ASIN {asin} HTML structure sample: {element_html_debug[:600]}..."
+                            )
                         except Exception as html_error:
                             log.debug(f"Could not get HTML for element debug: {html_error}")
-                    
+
                     # Check 1: Explicit "Sponsored" text directly visible within the element
                     try:
-                        sponsored_badge_locator = element.locator("span:visible", has_text=re.compile(r"^\\s*Sponsored\\s*$", re.IGNORECASE))
-                        if await sponsored_badge_locator.count() > 0: 
+                        sponsored_badge_locator = element.locator(
+                            "span:visible",
+                            has_text=re.compile(r"^\\s*Sponsored\\s*$", re.IGNORECASE),
+                        )
+                        if await sponsored_badge_locator.count() > 0:
                             is_sponsored = True
                             sponsor_detection_reason = "visible 'Sponsored' text badge"
                     except Exception as e_badge:
@@ -741,40 +1089,49 @@ class FixedAmazonExtractor(AmazonExtractor):
                     # Check 2: Aria-label on the element or a significant child
                     if not is_sponsored:
                         try:
-                            if await element.locator('[aria-label="Sponsored"]:visible').count() > 0:
+                            if (
+                                await element.locator('[aria-label="Sponsored"]:visible').count()
+                                > 0
+                            ):
                                 is_sponsored = True
                                 sponsor_detection_reason = "aria-label='Sponsored'"
                         except Exception as e_aria:
                             log.debug(f"Error checking aria-label for ASIN {asin}: {e_aria}")
-                    
+
                     # Check 3: Data attributes on the element itself (tile)
                     if not is_sponsored:
                         try:
-                            is_sponsored = await element.evaluate("""el => {
+                            is_sponsored = await element.evaluate(
+                                """el => {
                                 if (el.getAttribute('data-component-type') === 'sp-sponsored-result') return true;
                                 if (el.getAttribute('data-ad-marker') === 'true') return true;
                                 if (el.querySelector('[data-component-type="sp-sponsored-result"]')) return true;
                                 if (el.querySelector('[data-cel-widget*="advertising"]')) return true;
                                 if (el.querySelector('[data-ad-id]')) return true;
                                 return false;
-                            }""")
+                            }"""
+                            )
                             if is_sponsored:
-                                sponsor_detection_reason = "data attributes indicating sponsored content"
+                                sponsor_detection_reason = (
+                                    "data attributes indicating sponsored content"
+                                )
                         except Exception as e_data_attr:
-                            log.debug(f"Error checking data-attributes for ASIN {asin}: {e_data_attr}")
+                            log.debug(
+                                f"Error checking data-attributes for ASIN {asin}: {e_data_attr}"
+                            )
 
                     # Check 4: Presence of known ad-specific classes on the main element (tile)
                     if not is_sponsored:
                         try:
                             element_classes = await element.get_attribute("class") or ""
                             known_ad_classes = [
-                                "AdHolder", 
-                                "s-widget-sponsored-product", 
+                                "AdHolder",
+                                "s-widget-sponsored-product",
                                 "sponsored-results-padding",
                                 "s-result-item-sponsored-popup",
                                 "puis-sponsored-container-component",
-                                "ad-feedback"
-                            ] 
+                                "ad-feedback",
+                            ]
                             for ad_class in known_ad_classes:
                                 if ad_class in element_classes:
                                     is_sponsored = True
@@ -786,31 +1143,36 @@ class FixedAmazonExtractor(AmazonExtractor):
                     # Check 5: Text content contains typical ad indicators
                     if not is_sponsored:
                         try:
-                            ad_indicators_locator = element.locator("text=/sponsored|advertisement|ad for/i")
+                            ad_indicators_locator = element.locator(
+                                "text=/sponsored|advertisement|ad for/i"
+                            )
                             if await ad_indicators_locator.count() > 0:
                                 is_sponsored = True
                                 sponsor_detection_reason = "text containing ad indicators"
                         except Exception as e_text:
-                            log.debug(f"Error checking text for ad indicators for ASIN {asin}: {e_text}")
+                            log.debug(
+                                f"Error checking text for ad indicators for ASIN {asin}: {e_text}"
+                            )
 
                     if is_sponsored:
-                        log.info(f"Skipping sponsored result: ASIN {asin} (detected by {sponsor_detection_reason})")
+                        log.info(
+                            f"Skipping sponsored result: ASIN {asin} (detected by {sponsor_detection_reason})"
+                        )
                         continue
-                    
+
                     # Process organic result with improved title extraction from helper method
                     title = await self._extract_title_from_element(element, asin)
-                    
-                    organic_results.append({
-                        "asin": asin,
-                        "title": title
-                    })
+
+                    organic_results.append({"asin": asin, "title": title})
                     log.info(f"Found organic result: ASIN {asin} - {title[:60]}...")
-                    
+
                     # Break after finding a reasonable number of organic results to improve performance
                     if len(organic_results) >= 5:
-                        log.info(f"Found {len(organic_results)} organic results, stopping search to improve performance.")
+                        log.info(
+                            f"Found {len(organic_results)} organic results, stopping search to improve performance."
+                        )
                         break
-            
+
                 # Check if we have any organic results
                 if not organic_results:
                     log.warning(f"EAN {ean} returned no organic results - skipping")
@@ -820,34 +1182,54 @@ class FixedAmazonExtractor(AmazonExtractor):
                     # When EAN search returns results, use the first organic result (highest relevance)
                     if len(organic_results) == 1:
                         chosen_result = organic_results[0]
-                        log.info(f"Single organic result found for EAN {ean}: ASIN {chosen_result['asin']}")
+                        log.info(
+                            f"Single organic result found for EAN {ean}: ASIN {chosen_result['asin']}"
+                        )
                     else:
                         # Multiple EAN search results - use first organic result (most relevant by Amazon's ranking)
                         chosen_result = organic_results[0]
-                        log.info(f"Multiple organic results ({len(organic_results)}) found for EAN {ean}. Using first organic result (most relevant): ASIN {chosen_result['asin']}")
-                        log.info(f"FIXED: No title scoring on EAN search results - using Amazon's search relevance ranking")
-                    
+                        log.info(
+                            f"Multiple organic results ({len(organic_results)}) found for EAN {ean}. Using first organic result (most relevant): ASIN {chosen_result['asin']}"
+                        )
+                        log.info(
+                            f"FIXED: No title scoring on EAN search results - using Amazon's search relevance ranking"
+                        )
+
                     search_results_data = {
                         "results": [chosen_result],  # Single chosen result
-                        "search_method": "ean_search_bar_with_verification"
+                        "search_method": "ean_search_bar_with_verification",
                     }
                     log.info(f"EAN search selected ASIN {chosen_result['asin']} for {ean}")
-                
+
         except Exception as search_error:
             log.error(f"Error during EAN search for {ean}: {search_error}")
             search_results_data = {"error": f"Search error for EAN {ean}: {str(search_error)}"}
 
         if "error" in search_results_data or not search_results_data.get("results"):
-            log.warning(f"No Amazon results or error for EAN '{ean}'. Details: {search_results_data.get('error', 'No results list')}")
+            log.warning(
+                f"No Amazon results or error for EAN '{ean}'. Details: {search_results_data.get('error', 'No results list')}"
+            )
             # FIX 1: EAN search → title match fallback
-            log.info(f"Falling back to title search for supplier product: '{supplier_product_title}'")
-            title_search_results = await self.search_by_title_using_search_bar(supplier_product_title, page=page)
-            if title_search_results and "error" not in title_search_results and title_search_results.get("results"):
-                log.info(f"Title search successful for '{supplier_product_title}' after EAN '{ean}' failed")
+            log.info(
+                f"Falling back to title search for supplier product: '{supplier_product_title}'"
+            )
+            title_search_results = await self.search_by_title_using_search_bar(
+                supplier_product_title, page=page
+            )
+            if (
+                title_search_results
+                and "error" not in title_search_results
+                and title_search_results.get("results")
+            ):
+                log.info(
+                    f"Title search successful for '{supplier_product_title}' after EAN '{ean}' failed"
+                )
                 # FIXED: Extract complete data for title search result instead of returning search result only
                 fallback_asin = title_search_results["results"][0].get("asin")
                 if fallback_asin:
-                    log.info(f"Extracting complete data for fallback ASIN {fallback_asin} from title search")
+                    log.info(
+                        f"Extracting complete data for fallback ASIN {fallback_asin} from title search"
+                    )
                     product_data = await super().extract_data(fallback_asin)
                     if product_data and "error" not in product_data:
                         # Set search method for linking map
@@ -856,7 +1238,9 @@ class FixedAmazonExtractor(AmazonExtractor):
                 else:
                     return {"error": f"No ASIN found in title search result for EAN {ean}"}
             else:
-                log.warning(f"Both EAN '{ean}' and title '{supplier_product_title}' searches failed")
+                log.warning(
+                    f"Both EAN '{ean}' and title '{supplier_product_title}' searches failed"
+                )
                 return {"error": f"No results for EAN {ean} or title search"}
 
         potential_asins_info = search_results_data["results"]
@@ -869,8 +1253,12 @@ class FixedAmazonExtractor(AmazonExtractor):
             # FIX 1: EAN search → stop title scoring when search initiated by EAN
             # Trust Amazon's search relevance ranking for EAN searches
             chosen_asin_data = potential_asins_info[0]
-            log.info(f"Multiple ASINs ({len(potential_asins_info)}) found for EAN {ean}. Using Amazon's first result: ASIN {chosen_asin_data.get('asin')}")
-            log.info(f"FIXED: No title scoring on EAN search results - using Amazon's search relevance ranking")
+            log.info(
+                f"Multiple ASINs ({len(potential_asins_info)}) found for EAN {ean}. Using Amazon's first result: ASIN {chosen_asin_data.get('asin')}"
+            )
+            log.info(
+                f"FIXED: No title scoring on EAN search results - using Amazon's search relevance ranking"
+            )
 
             # EAN search complete - skip AI disambiguation to trust Amazon's ranking
             # AI disambiguation removed to prevent title scoring on EAN results
@@ -880,44 +1268,59 @@ class FixedAmazonExtractor(AmazonExtractor):
                     f"The EAN '{ean}' (from supplier product '{supplier_product_title}') "
                     f"returned multiple products on Amazon. Which of the following Amazon products is the most likely match to the supplier product title?\n"
                 )
-                for i, item in enumerate(potential_asins_info[:3]): # Limit to top 3 for AI prompt
+                for i, item in enumerate(potential_asins_info[:3]):  # Limit to top 3 for AI prompt
                     prompt += f"{i+1}. ASIN: {item.get('asin')}, Title: {item.get('title')}\n"
                 prompt += "Respond with the ASIN of the best match, or 'NONE' if no good match."
-                
+
                 try:
                     # Ensure ai_client is not None before calling create
                     if self.ai_client:
                         chat_completion = await asyncio.to_thread(
-                            self.ai_client.chat.completions.create, # type: ignore
+                            self.ai_client.chat.completions.create,  # type: ignore
                             messages=[{"role": "user", "content": prompt}],
                             model=OPENAI_MODEL_NAME,
                         )
-                        ai_response = chat_completion.choices[0].message.content.strip() # type: ignore
+                        ai_response = chat_completion.choices[0].message.content.strip()  # type: ignore
                         log.info(f"AI response for EAN {ean} disambiguation: {ai_response}")
-                        
+
                         # Find the item that matches the AI's chosen ASIN
-                        matched_item_by_ai = next((item for item in potential_asins_info if item.get('asin') == ai_response), None)
+                        matched_item_by_ai = next(
+                            (
+                                item
+                                for item in potential_asins_info
+                                if item.get("asin") == ai_response
+                            ),
+                            None,
+                        )
                         if matched_item_by_ai:
                             chosen_asin_data = matched_item_by_ai
-                            log.info(f"AI selected ASIN {chosen_asin_data.get('asin')} for EAN {ean}.")
+                            log.info(
+                                f"AI selected ASIN {chosen_asin_data.get('asin')} for EAN {ean}."
+                            )
                         elif ai_response != "NONE":
-                             log.warning(f"AI suggested ASIN {ai_response} not in search results. Using first result.")
-                        else: # AI responded "NONE"
-                            log.warning(f"AI could not confidently match EAN {ean}. Using first result.")
+                            log.warning(
+                                f"AI suggested ASIN {ai_response} not in search results. Using first result."
+                            )
+                        else:  # AI responded "NONE"
+                            log.warning(
+                                f"AI could not confidently match EAN {ean}. Using first result."
+                            )
                     else:
-                        log.warning("AI client not available for EAN disambiguation. Using first result.")
+                        log.warning(
+                            "AI client not available for EAN disambiguation. Using first result."
+                        )
                 except Exception as ai_err:
                     log.error(f"AI disambiguation failed for EAN {ean}: {ai_err}")
-        
+
         if not chosen_asin_data or not chosen_asin_data.get("asin"):
             log.warning(f"No suitable ASIN found for EAN {ean} after search and disambiguation.")
             return {"error": f"No suitable ASIN for EAN {ean}"}
 
         chosen_asin = chosen_asin_data.get("asin")
         log.info(f"Proceeding with ASIN: {chosen_asin} for EAN: {ean}")
-        
+
         # Extract detailed data for the chosen ASIN using the base class method
-        product_data = await super().extract_data(chosen_asin) # type: ignore
+        product_data = await super().extract_data(chosen_asin)  # type: ignore
 
         # 🚨 CRITICAL FIX: Explicitly record that this was an EAN search
         if "error" not in product_data:
@@ -929,10 +1332,11 @@ class FixedAmazonExtractor(AmazonExtractor):
         # The base AmazonExtractor's extract_data method should now attempt to get 'ean_on_page'.
         # No need for redundant EAN extraction here if the base class handles it.
         if "error" not in product_data and product_data.get("title"):
-            log.info(f"Successfully extracted data for ASIN {chosen_asin} (EAN on page: {product_data.get('ean_on_page', 'N/A')})")
+            log.info(
+                f"Successfully extracted data for ASIN {chosen_asin} (EAN on page: {product_data.get('ean_on_page', 'N/A')})"
+            )
 
         return product_data
-
 
     async def extract_data(self, asin: str) -> Dict[str, Any]:
         """
@@ -944,15 +1348,15 @@ class FixedAmazonExtractor(AmazonExtractor):
         # The FixedAmazonExtractor's role is more about specialized search (like by EAN)
         # and ensuring the correct browser context is used.
         if not self.browser or not self.browser.is_connected():
-            await self.connect() # Ensure connection
+            await self.connect()  # Ensure connection
 
         # Call the parent's extract_data method
-        result = await super().extract_data(asin) # type: ignore
+        result = await super().extract_data(asin)  # type: ignore
 
         # The base class's extract_data should now be responsible for finding 'ean_on_page'.
         # Any additional EAN logic specific to FixedAmazonExtractor could go here if needed,
         # but it's better if the base class is comprehensive.
-        
+
         # The stabilization wait is also part of the base class's extract_data
         # log.info(f"Waiting {EXTENSION_DATA_WAIT}s for extensions to stabilize (FixedAmazonExtractor.extract_data)...")
         # await asyncio.sleep(EXTENSION_DATA_WAIT) # This is in the base class
@@ -960,35 +1364,40 @@ class FixedAmazonExtractor(AmazonExtractor):
 
 
 class PassiveExtractionWorkflow:
-    def __init__(self, config_loader: SystemConfigLoader, workflow_config: dict, browser_manager: BrowserManager):
+    def __init__(
+        self,
+        config_loader: SystemConfigLoader,
+        workflow_config: dict,
+        browser_manager: BrowserManager,
+    ):
         self.config_loader = config_loader
         self.workflow_config = workflow_config
         self.browser_manager = browser_manager
         self.log = logging.getLogger(self.__class__.__name__)
-        
+
         # 🚨 IMPORT HYGIENE: Log module path to confirm correct workflow is running
         self.log.info(f"MODULE PATH: {__file__}")
-        
+
         # Core components initialized here
-        self.supplier_name = self.workflow_config.get('supplier_name')
+        self.supplier_name = self.workflow_config.get("supplier_name")
         self.full_config = self.config_loader.get_full_config()
         self.system_config = self.full_config.get("system", {})
-        
+
         # Check for test mode environment variables for audit testing
-        self.test_mode = os.getenv('FBA_TEST_MODE', 'false').lower() == 'true'
-        self.test_limit = int(os.getenv('FBA_TEST_LIMIT', '0'))
-        self.audit_mode = os.getenv('FBA_AUDIT_MODE', 'false').lower() == 'true'
-        
+        self.test_mode = os.getenv("FBA_TEST_MODE", "false").lower() == "true"
+        self.test_limit = int(os.getenv("FBA_TEST_LIMIT", "0"))
+        self.audit_mode = os.getenv("FBA_AUDIT_MODE", "false").lower() == "true"
+
         if self.test_mode:
             self.log.info(f"TEST MODE: Processing limit set to {self.test_limit} products")
         if self.audit_mode:
             self.log.info(f"AUDIT MODE: Enhanced logging and validation enabled")
-        
+
         # Initialize paths using centralized path management
         self.output_dir = self._initialize_output_directory()
-        self.supplier_cache_dir = str(path_manager.get_output_path('cached_products'))
-        self.amazon_cache_dir = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache'))
-        
+        self.supplier_cache_dir = str(path_manager.get_output_path("cached_products"))
+        self.amazon_cache_dir = str(path_manager.get_output_path("FBA_ANALYSIS", "amazon_cache"))
+
         # 🚨 CRITICAL FIX: Enhanced directory creation with error handling
         try:
             self.log.info(f"🔍 DEBUG: output_dir = '{self.output_dir}'")
@@ -1003,35 +1412,38 @@ class PassiveExtractionWorkflow:
             self.log.error(f"🚨 Supplier cache dir: {self.supplier_cache_dir}")
             raise
         self.state_manager = EnhancedStateManager(self.supplier_name)
-        
+
         # 🚨 FIX 3: Initialize state manager with accurate totals BEFORE startup analysis
         try:
             # Get total cache and category counts for proper initialization
             cache_file, cache_count = self._find_actual_supplier_cache_file(self.supplier_name)
-            
+
             # Load categories from config to get accurate total
             from config.system_config_loader import SystemConfigLoader
+
             config_loader = SystemConfigLoader()
             config_data = config_loader.load_config()
             supplier_config = config_data.get("supplier_configs", {}).get(self.supplier_name, {})
             category_urls = supplier_config.get("category_urls", [])
-            
+
             # Update runtime settings with accurate counts
-            if hasattr(self.state_manager, 'state_data'):
-                runtime_settings = self.state_manager.state_data.setdefault('runtime_settings', {})
-                runtime_settings['supplier_cache_count'] = cache_count
-                runtime_settings['total_categories'] = len(category_urls)
-                runtime_settings['max_products_to_process'] = cache_count  # Set reasonable default
-                
+            if hasattr(self.state_manager, "state_data"):
+                runtime_settings = self.state_manager.state_data.setdefault("runtime_settings", {})
+                runtime_settings["supplier_cache_count"] = cache_count
+                runtime_settings["total_categories"] = len(category_urls)
+                runtime_settings["max_products_to_process"] = cache_count  # Set reasonable default
+
                 # Also update main state fields for consistency
-                self.state_manager.state_data['total_products'] = cache_count
-                
-                self.log.info(f"✅ State manager initialized with accurate totals: {cache_count} products, {len(category_urls)} categories")
+                self.state_manager.state_data["total_products"] = cache_count
+
+                self.log.info(
+                    f"✅ State manager initialized with accurate totals: {cache_count} products, {len(category_urls)} categories"
+                )
         except Exception as e:
             self.log.warning(f"⚠️ Could not initialize state manager with totals: {e}")
-        
+
         # 🚨 SURGICAL FIX: Perform startup analysis to detect reverse gap scenario
-        if hasattr(self.state_manager, 'perform_startup_analysis'):
+        if hasattr(self.state_manager, "perform_startup_analysis"):
             try:
                 self.state_manager.perform_startup_analysis()
                 self.log.info("✅ Startup analysis performed - gap processing detection initialized")
@@ -1039,91 +1451,101 @@ class PassiveExtractionWorkflow:
                 self.log.warning(f"⚠️ Startup analysis failed: {e}")
         else:
             # Fallback: manually update gap processing status
-            if hasattr(self.state_manager, 'state_data'):
-                gap_data = self.state_manager.state_data.setdefault('gap_processing', {})
-                gap_data['startup_analysis_completed'] = True
+            if hasattr(self.state_manager, "state_data"):
+                gap_data = self.state_manager.state_data.setdefault("gap_processing", {})
+                gap_data["startup_analysis_completed"] = True
                 # Check linking map vs cache to set reverse gap detection
-                linking_map_count = self.state_manager.state_data.get('runtime_settings', {}).get('linking_map_count', 0)
-                supplier_cache_count = self.state_manager.state_data.get('runtime_settings', {}).get('supplier_cache_count', 0)
+                linking_map_count = self.state_manager.state_data.get("runtime_settings", {}).get(
+                    "linking_map_count", 0
+                )
+                supplier_cache_count = self.state_manager.state_data.get(
+                    "runtime_settings", {}
+                ).get("supplier_cache_count", 0)
                 if linking_map_count > supplier_cache_count:
-                    gap_data['reverse_gap_detected'] = True
-                    gap_data['phase'] = 'reverse_gap_fresh_categories'
-                    self.log.info(f"🔄 REVERSE GAP DETECTED: Linking map ({linking_map_count}) > Cache ({supplier_cache_count})")
-        
+                    gap_data["reverse_gap_detected"] = True
+                    gap_data["phase"] = "reverse_gap_fresh_categories"
+                    self.log.info(
+                        f"🔄 REVERSE GAP DETECTED: Linking map ({linking_map_count}) > Cache ({supplier_cache_count})"
+                    )
+
         # 🔧 CRITICAL FIX: Validate category count consistency across all sources
-        if hasattr(self.state_manager, 'validate_category_count_consistency'):
+        if hasattr(self.state_manager, "validate_category_count_consistency"):
             try:
                 validation_result = self.state_manager.validate_category_count_consistency()
-                if not validation_result.get('is_consistent', False):
-                    self.log.warning(f"⚠️ Category count discrepancies found and corrected: {validation_result.get('corrected_values', [])}")
-                    if validation_result.get('auto_corrected', False):
+                if not validation_result.get("is_consistent", False):
+                    self.log.warning(
+                        f"⚠️ Category count discrepancies found and corrected: {validation_result.get('corrected_values', [])}"
+                    )
+                    if validation_result.get("auto_corrected", False):
                         self.log.info("✅ Category count consistency restored automatically")
                 else:
-                    self.log.info(f"✅ Category count validation passed: {validation_result.get('authoritative_count', 0)} categories")
+                    self.log.info(
+                        f"✅ Category count validation passed: {validation_result.get('authoritative_count', 0)} categories"
+                    )
             except Exception as e:
                 self.log.error(f"❌ Category count validation failed: {e}")
-        
+
         # Pass the single browser_manager instance to the tools
         self.amazon_extractor = self._initialize_amazon_extractor()
         self.supplier_scraper = self._initialize_supplier_scraper()
-        
+
         self.extractor = self.amazon_extractor
-        
+
         self.web_scraper = self.supplier_scraper
-        
+
         # Initialize linking map as an array of detailed objects (matching archived format)
         self.linking_map = []
         self.log.debug(f"🔍 DEBUG: linking_map initialized as type: {type(self.linking_map)}")
-        
+
         # 🚀 HASH OPTIMIZATION: Initialize O(1) hash lookup system for 3,650x performance improvement
         self.hash_optimizer = HashLookupOptimizer(logger=self.log)
         self.performance_comparator = LegacyPerformanceComparator(logger=self.log)
         self.log.info("🚀 Hash-based lookup optimization system initialized")
-        
+
         # 🚨 SENTINEL MONITORING: Initialize proactive monitoring system
         self.sentinel_monitor = get_sentinel_monitor(self.supplier_name)
         self.log.info("🚨 SENTINEL MONITORING: Proactive monitoring system initialized")
-        
+
         # 🛡️ WINDOWS SAVE GUARDIAN: Initialize atomic persistence system
         self.save_guardian = WindowsSaveGuardian()
         self.log.info("🛡️ WINDOWS SAVE GUARDIAN: Atomic persistence system initialized")
-        
+
         # self.performance_tracker = PerformanceTracker()  # Removed - not defined
 
         # Workflow state attributes
         self.consecutive_amazon_price_misses = 0
         self.products_for_fba_analysis = []
         self.last_processed_index = 0
-        
+
         # 🔧 AUTHENTICATION FALLBACK TRACKING
         self.products_without_price_count = 0
         self.products_processed_since_auth = 0
         self.last_authentication_time = None
         self.auth_fallback_config = {
             "price_missing_threshold": 3,  # Trigger after 3 products without price
-            "products_per_auth": 100,      # Re-auth every 100 products
-            "hours_per_auth": 2            # Re-auth every 2 hours
+            "products_per_auth": 100,  # Re-auth every 100 products
+            "hours_per_auth": 2,  # Re-auth every 2 hours
         }
-        
+
         self.results_summary = {
             "total_supplier_products": 0,
             "profitable_products": 0,
             "products_analyzed_ean": 0,
             "products_analyzed_title": 0,
-            "errors": 0
+            "errors": 0,
         }
 
         self.log.info(f"✅ Output directory set to: {self.output_dir}")
-        
+
         self._validate_initialization()
 
     def _add_linking_map_entry_optimized(self, entry: Dict[str, Any]) -> None:
         """
         Add entry to linking map with hash index optimization.
-        
+
         🚀 HASH OPTIMIZATION: This method adds entries to both the linking_map list
         and the hash indexes for O(1) lookups, providing 3,650x performance improvement.
-        
+
         Args:
             entry: Linking map entry to add
         """
@@ -1140,26 +1562,28 @@ class PassiveExtractionWorkflow:
             self.log.debug(
                 f"🔄 HASH OPTIMIZATION: Duplicate entry updated - EAN: {entry.get('supplier_ean', 'N/A')}, URL: {entry.get('supplier_url', 'N/A')}"
             )
-        
+
         # Update performance metrics
         stats = self.hash_optimizer.get_index_stats()
-        if stats['total_lookups'] > 0 and stats['total_lookups'] % 100 == 0:
-            self.log.info(f"🚀 HASH PERFORMANCE: {stats['total_lookups']} lookups, {stats['cache_hit_rate']:.1f}% hit rate, {stats['performance_improvement']:.1f}x improvement")
+        if stats["total_lookups"] > 0 and stats["total_lookups"] % 100 == 0:
+            self.log.info(
+                f"🚀 HASH PERFORMANCE: {stats['total_lookups']} lookups, {stats['cache_hit_rate']:.1f}% hit rate, {stats['performance_improvement']:.1f}x improvement"
+            )
 
     def log_hash_optimization_summary(self) -> None:
         """
         🚀 HASH OPTIMIZATION: Log comprehensive performance summary with timing metrics.
-        
+
         This method provides detailed performance analysis showing the massive improvement
         from O(n) linear searches to O(1) hash lookups.
         """
         try:
             stats = self.hash_optimizer.get_index_stats()
-            
+
             self.log.info("=" * 80)
             self.log.info("🚀 HASH LOOKUP OPTIMIZATION PERFORMANCE SUMMARY")
             self.log.info("=" * 80)
-            
+
             # Index Statistics
             self.log.info(f"📊 INDEX STATISTICS:")
             self.log.info(f"   🔍 EAN Index Entries: {stats['ean_entries']:,}")
@@ -1167,54 +1591,66 @@ class PassiveExtractionWorkflow:
             self.log.info(f"   📦 ASIN Index Entries: {stats['asin_entries']:,}")
             self.log.info(f"   ✅ Index Valid: {stats['index_valid']}")
             self.log.info(f"   🔧 Index Builds: {stats['index_builds']}")
-            
+
             # Performance Metrics
             self.log.info(f"🚀 PERFORMANCE METRICS:")
             self.log.info(f"   ⚡ Total Lookups: {stats['total_lookups']:,}")
             self.log.info(f"   🚀 Hash Lookups: {stats['hash_lookups']:,}")
             self.log.info(f"   🐌 Linear Lookups: {stats['linear_lookups']:,}")
             self.log.info(f"   🎯 Cache Hit Rate: {stats['cache_hit_rate']:.1f}%")
-            
+
             # Timing Analysis
-            if stats['hash_lookups'] > 0:
+            if stats["hash_lookups"] > 0:
                 self.log.info(f"⏱️ TIMING ANALYSIS:")
-                self.log.info(f"   ⚡ Avg Hash Lookup Time: {stats['avg_hash_lookup_time_ms']:.3f}ms")
-                if stats['linear_lookups'] > 0:
-                    self.log.info(f"   🐌 Avg Linear Lookup Time: {stats['avg_linear_lookup_time_ms']:.3f}ms")
-                    self.log.info(f"   🚀 Performance Improvement: {stats['performance_improvement']:.1f}x FASTER")
-                
+                self.log.info(
+                    f"   ⚡ Avg Hash Lookup Time: {stats['avg_hash_lookup_time_ms']:.3f}ms"
+                )
+                if stats["linear_lookups"] > 0:
+                    self.log.info(
+                        f"   🐌 Avg Linear Lookup Time: {stats['avg_linear_lookup_time_ms']:.3f}ms"
+                    )
+                    self.log.info(
+                        f"   🚀 Performance Improvement: {stats['performance_improvement']:.1f}x FASTER"
+                    )
+
                 # Calculate theoretical savings
                 linking_map_size = len(self.linking_map)
-                theoretical_linear_time = linking_map_size * stats['avg_hash_lookup_time_ms'] / 1000
-                actual_hash_time = stats['hash_lookup_time']
+                theoretical_linear_time = linking_map_size * stats["avg_hash_lookup_time_ms"] / 1000
+                actual_hash_time = stats["hash_lookup_time"]
                 time_saved = theoretical_linear_time - actual_hash_time
-                
+
                 self.log.info(f"💰 EFFICIENCY GAINS:")
                 self.log.info(f"   🔍 Linking Map Size: {linking_map_size:,} entries")
                 self.log.info(f"   ⏱️ Time Saved: {time_saved:.3f} seconds")
-                self.log.info(f"   🚀 Expected Performance: {linking_map_size}x improvement over linear search")
-            
+                self.log.info(
+                    f"   🚀 Expected Performance: {linking_map_size}x improvement over linear search"
+                )
+
             # Memory Usage
             linking_map_memory = len(self.linking_map) * 1024  # Rough estimate
-            index_memory = (stats['ean_entries'] + stats['url_entries'] + stats['asin_entries']) * 512  # Rough estimate
-            
+            index_memory = (
+                stats["ean_entries"] + stats["url_entries"] + stats["asin_entries"]
+            ) * 512  # Rough estimate
+
             self.log.info(f"🧠 MEMORY ANALYSIS:")
             self.log.info(f"   📋 Linking Map Memory: ~{linking_map_memory/1024:.1f}KB")
             self.log.info(f"   🔍 Hash Index Memory: ~{index_memory/1024:.1f}KB")
-            self.log.info(f"   📊 Memory Overhead: {(index_memory/max(1, linking_map_memory))*100:.1f}%")
-            
+            self.log.info(
+                f"   📊 Memory Overhead: {(index_memory/max(1, linking_map_memory))*100:.1f}%"
+            )
+
             self.log.info("=" * 80)
-            
+
         except Exception as e:
             self.log.error(f"❌ Error generating hash optimization summary: {e}")
 
     def benchmark_hash_performance(self, sample_size: int = 100) -> Dict[str, Any]:
         """
         🚀 HASH OPTIMIZATION: Benchmark hash lookup performance against linear search.
-        
+
         Args:
             sample_size: Number of test lookups to perform
-            
+
         Returns:
             Dictionary with benchmark results
         """
@@ -1222,31 +1658,43 @@ class PassiveExtractionWorkflow:
             if not self.linking_map or len(self.linking_map) < 10:
                 self.log.warning("⚠️ Insufficient linking map data for benchmarking")
                 return {}
-            
+
             # Extract test data
-            test_eans = [entry.get('supplier_ean') for entry in self.linking_map[:sample_size] if entry.get('supplier_ean')]
-            test_urls = [entry.get('supplier_url') for entry in self.linking_map[:sample_size] if entry.get('supplier_url')]
-            
+            test_eans = [
+                entry.get("supplier_ean")
+                for entry in self.linking_map[:sample_size]
+                if entry.get("supplier_ean")
+            ]
+            test_urls = [
+                entry.get("supplier_url")
+                for entry in self.linking_map[:sample_size]
+                if entry.get("supplier_url")
+            ]
+
             if not test_eans and not test_urls:
                 self.log.warning("⚠️ No valid test data found for benchmarking")
                 return {}
-            
+
             # Run benchmark
             results = self.performance_comparator.benchmark_performance(
                 linking_map=self.linking_map,
-                test_eans=test_eans[:min(50, len(test_eans))],
-                test_urls=test_urls[:min(50, len(test_urls))],
-                hash_optimizer=self.hash_optimizer
+                test_eans=test_eans[: min(50, len(test_eans))],
+                test_urls=test_urls[: min(50, len(test_urls))],
+                hash_optimizer=self.hash_optimizer,
             )
-            
+
             self.log.info("🧪 HASH OPTIMIZATION BENCHMARK COMPLETED:")
             self.log.info(f"   🚀 Hash Lookup Average: {results.get('avg_hash_time_ms', 0):.3f}ms")
-            self.log.info(f"   🐌 Linear Lookup Average: {results.get('avg_linear_time_ms', 0):.3f}ms")
-            self.log.info(f"   ⚡ Performance Improvement: {results.get('performance_improvement', 0):.1f}x faster")
+            self.log.info(
+                f"   🐌 Linear Lookup Average: {results.get('avg_linear_time_ms', 0):.3f}ms"
+            )
+            self.log.info(
+                f"   ⚡ Performance Improvement: {results.get('performance_improvement', 0):.1f}x faster"
+            )
             self.log.info(f"   ✅ Match Consistency: {results.get('match_consistency', False)}")
-            
+
             return results
-            
+
         except Exception as e:
             self.log.error(f"❌ Error running hash optimization benchmark: {e}")
             return {}
@@ -1259,10 +1707,9 @@ class PassiveExtractionWorkflow:
 
     def _initialize_amazon_extractor(self):
         """Initializes the Amazon extractor with the shared browser manager."""
-        chrome_debug_port = self.system_config.get('chrome_debug_port', 9222)
+        chrome_debug_port = self.system_config.get("chrome_debug_port", 9222)
         return FixedAmazonExtractor(
-            chrome_debug_port=chrome_debug_port,
-            ai_client=None  # AI features disabled
+            chrome_debug_port=chrome_debug_port, ai_client=None  # AI features disabled
         )
 
     def _initialize_supplier_scraper(self):
@@ -1272,68 +1719,74 @@ class PassiveExtractionWorkflow:
             headless=False,  # Keep browser visible for debugging
             use_shared_chrome=True,  # Use existing Chrome instance
             auth_callback=None,  # No authentication callback needed
-            browser_manager=self.browser_manager
+            browser_manager=self.browser_manager,
         )
 
     def _get_product_identifier(self, product_url: str) -> str:
         """
         Get a readable identifier for a product from URL for debugging
-        
+
         Args:
             product_url: Product URL or product dict
-            
+
         Returns:
             Short identifier for logging
         """
         if isinstance(product_url, dict):
             # If it's a product dict, try to get title or URL
-            title = product_url.get('title', '')
+            title = product_url.get("title", "")
             if title and len(title) > 3:
                 return title[:30] + ("..." if len(title) > 30 else "")
-            url = product_url.get('url', '')
+            url = product_url.get("url", "")
             if url:
-                return url.split('/')[-1][:20]
+                return url.split("/")[-1][:20]
             return "Unknown Product"
         elif isinstance(product_url, str):
             # If it's a URL string, extract the last part
-            return product_url.split('/')[-1][:20] if product_url else "Unknown URL"
+            return product_url.split("/")[-1][:20] if product_url else "Unknown URL"
         else:
             return str(product_url)[:20]
 
     def _validate_initialization(self):
         """Validates that all critical attributes are properly initialized."""
         required_attributes = {
-            'results_summary': dict,
-            'extractor': object,
-            'amazon_extractor': object,
-            'supplier_scraper': object,
-            'system_config': dict,
-            'output_dir': str,
-            'supplier_cache_dir': str,
-            'state_manager': object
+            "results_summary": dict,
+            "extractor": object,
+            "amazon_extractor": object,
+            "supplier_scraper": object,
+            "system_config": dict,
+            "output_dir": str,
+            "supplier_cache_dir": str,
+            "state_manager": object,
         }
-        
+
         for attr_name, expected_type in required_attributes.items():
             if not hasattr(self, attr_name):
-                raise AttributeError(f"Critical attribute '{attr_name}' not initialized in PassiveExtractionWorkflow")
-            
+                raise AttributeError(
+                    f"Critical attribute '{attr_name}' not initialized in PassiveExtractionWorkflow"
+                )
+
             attr_value = getattr(self, attr_name)
             if attr_value is None:
-                raise AttributeError(f"Critical attribute '{attr_name}' is None in PassiveExtractionWorkflow")
-            
+                raise AttributeError(
+                    f"Critical attribute '{attr_name}' is None in PassiveExtractionWorkflow"
+                )
+
             if not isinstance(attr_value, expected_type):
-                raise AttributeError(f"Critical attribute '{attr_name}' has wrong type. Expected {expected_type}, got {type(attr_value)}")
-        
+                raise AttributeError(
+                    f"Critical attribute '{attr_name}' has wrong type. Expected {expected_type}, got {type(attr_value)}"
+                )
+
         self.log.info("✅ Initialization validation passed - all critical attributes verified")
-    
+
     def _get_authoritative_category_count(self, category_urls_to_scrape: List[str] = None) -> int:
         """
         Get authoritative category count from configuration as the single source of truth.
         This replaces hardcoded fallbacks with dynamic configuration loading.
-        
+
         Args:
             category_urls_to_scrape: Optional list of category URLs for fallback counting
-            
+
         Returns:
             int: Authoritative category count from configuration
         """
@@ -1341,93 +1794,78 @@ class PassiveExtractionWorkflow:
             # Primary source: Direct configuration file loading
             from pathlib import Path
             import json
+
             config_path = Path(__file__).parent.parent / "config" / "poundwholesale_categories.json"
             if config_path.exists():
-                with open(config_path, 'r', encoding='utf-8') as f:
+                with open(config_path, "r", encoding="utf-8") as f:
                     config_data = json.load(f)
                 total_categories = len(config_data.get("category_urls", []))
-                self.log.info(f"📊 AUTHORITATIVE COUNT: {total_categories} categories from config file")
+                self.log.info(
+                    f"📊 AUTHORITATIVE COUNT: {total_categories} categories from config file"
+                )
                 return total_categories
-                
+
         except Exception as e:
             self.log.warning(f"Failed to load categories from config file: {e}")
-            
+
         try:
             # Secondary source: SystemConfigLoader
             from config.system_config_loader import SystemConfigLoader
+
             config_loader = SystemConfigLoader()
             config_data = config_loader.load_config()
             supplier_config = config_data.get("supplier_configs", {}).get(self.supplier_name, {})
             category_urls_from_config = supplier_config.get("category_urls", [])
             if category_urls_from_config:
                 total_categories = len(category_urls_from_config)
-                self.log.info(f"📊 AUTHORITATIVE COUNT: {total_categories} categories from SystemConfigLoader")
+                self.log.info(
+                    f"📊 AUTHORITATIVE COUNT: {total_categories} categories from SystemConfigLoader"
+                )
                 return total_categories
-                
+
         except Exception as e:
             self.log.warning(f"Failed to load categories from SystemConfigLoader: {e}")
-            
+
         # Tertiary source: Runtime category URLs parameter
-        if category_urls_to_scrape and hasattr(self, 'category_urls_to_scrape'):
+        if category_urls_to_scrape and hasattr(self, "category_urls_to_scrape"):
             total_categories = len(self.category_urls_to_scrape)
-            self.log.info(f"📊 AUTHORITATIVE COUNT: {total_categories} categories from category_urls_to_scrape attribute")
+            self.log.info(
+                f"📊 AUTHORITATIVE COUNT: {total_categories} categories from category_urls_to_scrape attribute"
+            )
             return total_categories
         elif category_urls_to_scrape:
             total_categories = len(category_urls_to_scrape)
             self.log.info(f"📊 AUTHORITATIVE COUNT: {total_categories} categories from parameter")
             return total_categories
-            
+
         # Final fallback: File-grounded calculation from state manager
-        if hasattr(self, 'state_manager') and self.state_manager:
+        if hasattr(self, "state_manager") and self.state_manager:
             try:
                 file_grounded = self.state_manager._calculate_file_grounded_totals()
                 total_categories = file_grounded.get("total_categories", 0)
                 if total_categories > 0:
-                    self.log.info(f"📊 AUTHORITATIVE COUNT: {total_categories} categories from state manager file-grounded calculation")
+                    self.log.info(
+                        f"📊 AUTHORITATIVE COUNT: {total_categories} categories from state manager file-grounded calculation"
+                    )
                     return total_categories
             except Exception as e:
                 self.log.warning(f"Failed to get categories from state manager: {e}")
-        
+
         # Ultimate fallback - log warning but don't use hardcoded value
-        self.log.error("❌ CRITICAL: Could not determine authoritative category count from any source")
+        self.log.error(
+            "❌ CRITICAL: Could not determine authoritative category count from any source"
+        )
         self.log.error("This indicates a configuration or system error that needs investigation")
         return 0  # Return 0 instead of hardcoded fallback to make the issue visible
 
     # Authoritative, frozen total categories (precedence: runtime_settings → system_progression → computed list → fallback 1)
     def _authoritative_total_categories(self) -> int:
-        if hasattr(self, "_frozen_total_categories"):
-            try:
-                return int(self._frozen_total_categories)
-            except Exception:
-                pass
-        rs = {}
-        sp = {}
+        """Return authoritative category count from predefined list."""
         try:
-            rs = self.state_manager.state_data.get("runtime_settings", {})
-            sp = self.state_manager.state_data.get("system_progression", {})
+            categories = self._get_predefined_categories(self.supplier_name) or []
         except Exception:
-            rs, sp = {}, {}
-        frozen = (rs.get("total_categories") if isinstance(rs, dict) else None) or (
-            sp.get("total_categories") if isinstance(sp, dict) else None
-        )
-        if frozen:
-            try:
-                self._frozen_total_categories = int(frozen)
-                return self._frozen_total_categories
-            except Exception:
-                pass
-        try:
-            cats = self._get_predefined_categories(self.supplier_name) or []
-            self._frozen_total_categories = len(cats)
-        except Exception:
-            self._frozen_total_categories = 1
-        if isinstance(rs, dict):
-            rs["total_categories"] = int(self._frozen_total_categories)
-            try:
-                self.state_manager.save_state(preserve_interruption_state=True)
-            except Exception:
-                pass
-        return int(self._frozen_total_categories)
+            categories = []
+        return len(categories)
 
     async def run(self):
         """Main execution loop for the workflow."""
@@ -1436,29 +1874,47 @@ class PassiveExtractionWorkflow:
         self.log.info(f"--- Starting Passive Extraction Workflow for: {self.supplier_name} ---")
         self.log.info(f"Session ID: {session_id}")
 
+        # Freeze total categories and config hash before any resume logic
+        category_urls = self._get_predefined_categories(self.supplier_name) or []
+        frozen_total = len(category_urls)
+        config_hash = self.state_manager.compute_supplier_config_hash(category_urls)
+        rs = self.state_manager.state_data.setdefault("runtime_settings", {})
+        rs["total_categories"] = frozen_total
+        rs["supplier_config_hash"] = config_hash
+        sp = self.state_manager.state_data.setdefault("system_progression", {})
+        sp["total_categories"] = frozen_total
+        self.state_manager.save(note="denominator-freeze")
+        self.log.info(f"🔒 FROZEN TOTAL CATEGORIES set to {frozen_total} (hash {config_hash[:8]})")
+
+        cat_idx, prod_idx = self.state_manager.get_resumption_ptr()
+        self.log.info(f"▶ RESUME PTR: cat={cat_idx} prod={prod_idx}")
+
         # FIXED: Load configuration values directly from system_config (no hardcoded fallbacks)
         # This ensures all toggle experiments work correctly
-        
+
         # So we don't need to access ["system"] again - it's already the system section
         max_products_to_process = self.system_config.get("max_products", 10)
         max_products_per_category = self.system_config.get("max_products_per_category", 5)
         max_analyzed_products = self.system_config.get("max_analyzed_products", 5)
         max_products_per_cycle = self.system_config.get("max_products_per_cycle", 5)
         supplier_extraction_batch_size = self.system_config.get("supplier_extraction_batch_size", 3)
-        
+
         # Get the full config for accessing root level values
         full_config = self.config_loader._config
         max_categories_per_request = full_config.get("max_categories_per_request", 5)
-        
+
         self.max_price = full_config.get("processing_limits", {}).get("max_price_gbp", 20.0)
-        
+
         # Apply batch synchronization if enabled
         batch_sync_config = full_config.get("batch_synchronization", {})
         if batch_sync_config.get("enabled", False):
-            max_products_per_cycle, supplier_extraction_batch_size = self._apply_batch_synchronization(
+            (
+                max_products_per_cycle,
+                supplier_extraction_batch_size,
+            ) = self._apply_batch_synchronization(
                 max_products_per_cycle, supplier_extraction_batch_size, batch_sync_config
             )
-        
+
         self.log.info(f"📊 CONFIGURATION VALUES:")
         self.log.info(f"   max_products_to_process: {max_products_to_process}")
         self.log.info(f"   max_products_per_category: {max_products_per_category}")
@@ -1470,12 +1926,12 @@ class PassiveExtractionWorkflow:
         # Load state and linking map
         self.state_manager.load_state()
         # Run validation with off-by-one clamping before computing resume/slicing
-        if hasattr(self.state_manager, 'validate_loaded_state'):
+        if hasattr(self.state_manager, "validate_loaded_state"):
             try:
                 self.state_manager.validate_loaded_state()
             except Exception:
                 pass
-        elif hasattr(self.state_manager, 'validate_and_repair_state'):
+        elif hasattr(self.state_manager, "validate_and_repair_state"):
             try:
                 self.state_manager.validate_and_repair_state()
             except Exception:
@@ -1484,20 +1940,26 @@ class PassiveExtractionWorkflow:
         try:
             frozen_total = self._authoritative_total_categories()
             self.state_manager.update_progression_unified(
-                current_phase="supplier",
-                total_categories=frozen_total
+                current_phase="supplier", total_categories=frozen_total
             )
             self.log.info(f"🔒 FROZEN TOTAL CATEGORIES set to {frozen_total} (authoritative)")
             # Drift check between legacy and unified views
-            legacy_total = self.state_manager.state_data.get("supplier_extraction_progress", {}).get("total_categories")
-            system_total = self.state_manager.state_data.get("system_progression", {}).get("total_categories")
+            legacy_total = self.state_manager.state_data.get(
+                "supplier_extraction_progress", {}
+            ).get("total_categories")
+            system_total = self.state_manager.state_data.get("system_progression", {}).get(
+                "total_categories"
+            )
             if legacy_total is not None and legacy_total != system_total:
-                self.log.warning(f"LEGACY VIEW DRIFT: legacy_total={legacy_total} vs system_total={system_total} — using system only.")
+                self.log.warning(
+                    f"LEGACY VIEW DRIFT: legacy_total={legacy_total} vs system_total={system_total} — using system only."
+                )
         except Exception as e:
             self.log.warning(f"⚠️ Could not set frozen total categories at startup: {e}")
 
-        self.last_processed_index = self.state_manager.get_resumption_index()
-        self.consecutive_amazon_price_misses = self.state_manager.state_data.get('consecutive_amazon_price_misses', 0)
+        self.consecutive_amazon_price_misses = self.state_manager.state_data.get(
+            "consecutive_amazon_price_misses", 0
+        )
         self.log.info(f"📋 Loaded existing processing state for {self.supplier_name}")
         # Resume banner with frozen denominator
         try:
@@ -1513,80 +1975,94 @@ class PassiveExtractionWorkflow:
         # 🚨 REMOVED: Hard reset logic removed per user request - was causing incorrect cache validation
         # System will now always attempt to resume from processing state without validation conflicts
         self.log.info("✅ Processing state loaded - system will resume from last position")
-        
+
         # Load the linking map for the current supplier
         self.linking_map = self._load_linking_map(self.supplier_name)
-        self.log.debug(f"🔍 DEBUG: linking_map loaded as type: {type(self.linking_map)}, length: {len(self.linking_map)}")
-        
+        self.log.debug(
+            f"🔍 DEBUG: linking_map loaded as type: {type(self.linking_map)}, length: {len(self.linking_map)}"
+        )
+
         # 🚨 CRITICAL: Two-Phase Detection Logic - Find actual supplier cache file
-        supplier_cache_file, supplier_cache_count = self._find_actual_supplier_cache_file(self.supplier_name)
+        supplier_cache_file, supplier_cache_count = self._find_actual_supplier_cache_file(
+            self.supplier_name
+        )
         supplier_cache_exists = bool(supplier_cache_file)
-        
+
         # 🚨 FIX 2: Store total cache count for proper state updates
         self.total_cache_count = supplier_cache_count
-        
+
         linking_map_count = len(self.linking_map) if self.linking_map else 0
-        
+
         # 🚨 SENTINEL MONITORING: Check for session vs global totals divergence
         self.sentinel_monitor.check_totals_divergence(
-            linking_map_count, supplier_cache_count, 'supplier_cache_vs_linking_map'
+            linking_map_count, supplier_cache_count, "supplier_cache_vs_linking_map"
         )
-        
+
         # Phase detection logic - FIXED to handle reverse gap scenario correctly
         if supplier_cache_count == 0:
             current_phase = "SUPPLIER_EXTRACTION"
             self.log.info(f"🔍 PHASE DETECTION: SUPPLIER_EXTRACTION (no supplier cache found)")
         elif linking_map_count == 0:
             current_phase = "AMAZON_ANALYSIS"
-            self.log.info(f"🔍 PHASE DETECTION: AMAZON_ANALYSIS (supplier cache: {supplier_cache_count} products, no linking map)")
+            self.log.info(
+                f"🔍 PHASE DETECTION: AMAZON_ANALYSIS (supplier cache: {supplier_cache_count} products, no linking map)"
+            )
         elif linking_map_count > supplier_cache_count:
             # REVERSE GAP: More linking map entries than cache entries
             current_phase = "FRESH_CATEGORIES"
-            self.log.info(f"🔍 PHASE DETECTION: FRESH_CATEGORIES (reverse gap - linking map: {linking_map_count} > cache: {supplier_cache_count})")
-            self.log.info("✅ System will start with first URL in config and skip already processed products")
+            self.log.info(
+                f"🔍 PHASE DETECTION: FRESH_CATEGORIES (reverse gap - linking map: {linking_map_count} > cache: {supplier_cache_count})"
+            )
+            self.log.info(
+                "✅ System will start with first URL in config and skip already processed products"
+            )
         elif linking_map_count < supplier_cache_count:
             # NORMAL GAP: More cache entries than linking map entries
             current_phase = "GAP_PROCESSING"
             gap_size = supplier_cache_count - linking_map_count
-            self.log.info(f"🔍 PHASE DETECTION: GAP_PROCESSING (normal gap - cache: {supplier_cache_count} > linking map: {linking_map_count})")
+            self.log.info(
+                f"🔍 PHASE DETECTION: GAP_PROCESSING (normal gap - cache: {supplier_cache_count} > linking map: {linking_map_count})"
+            )
             self.log.info(f"📊 GAP SIZE: {gap_size} products need Amazon analysis first")
         else:
             current_phase = "COMPLETED"
-            self.log.info(f"🔍 PHASE DETECTION: COMPLETED (supplier: {supplier_cache_count}, linking map: {linking_map_count})")
-        
+            self.log.info(
+                f"🔍 PHASE DETECTION: COMPLETED (supplier: {supplier_cache_count}, linking map: {linking_map_count})"
+            )
+
         self.current_phase = current_phase
-        
+
         config_hash = str(hash(str(self.system_config)))
         runtime_settings = {
             "max_products_to_process": max_products_to_process,
             "max_products_per_category": max_products_per_category,
             "current_phase": current_phase,
             "supplier_cache_count": supplier_cache_count,
-            "linking_map_count": linking_map_count
+            "linking_map_count": linking_map_count,
         }
         # 🚨 SURGICAL WORKFLOW FIX: STATE CONTRADICTION GUARDRAIL (ENHANCED)
         # Fixed to read from correct state tracking system and add comprehensive debug logging
         current_state = self.state_manager.state_data
         is_fresh_start_flag = current_state.get("is_fresh_start", True)
         successful_products = current_state.get("successful_products", 0)
-        
+
         # Check BOTH tracking systems for evidence of work (dual tracking fix)
         system_progression = current_state.get("system_progression", {})
         supplier_extraction = current_state.get("supplier_extraction_progress", {})
-        
+
         # System progression tracking
         system_category = system_progression.get("current_category_index")
-        
+
         # Supplier extraction tracking (more reliable for detecting actual work)
         supplier_category = supplier_extraction.get("current_category_index", 0)
         completed_categories = supplier_extraction.get("categories_completed", [])
-        
+
         # Enhanced evidence detection using both tracking systems
         has_evidence_of_work = (
-            successful_products > 0 or
-            (system_category is not None and system_category > 0) or
-            supplier_category > 0 or
-            len(completed_categories) > 0
+            successful_products > 0
+            or (system_category is not None and system_category > 0)
+            or supplier_category > 0
+            or len(completed_categories) > 0
         )
 
         # Debug logging to show actual state values being read
@@ -1595,12 +2071,18 @@ class PassiveExtractionWorkflow:
         self.log.info(f"   successful_products: {successful_products}")
         self.log.info(f"   system_progression.current_category_index: {system_category}")
         self.log.info(f"   supplier_extraction.current_category_index: {supplier_category}")
-        self.log.info(f"   supplier_extraction.categories_completed: {len(completed_categories)} categories")
+        self.log.info(
+            f"   supplier_extraction.categories_completed: {len(completed_categories)} categories"
+        )
         self.log.info(f"   has_evidence_of_work: {has_evidence_of_work}")
 
         if is_fresh_start_flag and has_evidence_of_work:
-            self.log.warning("🚨 STATE CONTRADICTION DETECTED - PREVENTING start_processing() CALL...")
-            self.log.warning(f"   Fresh start flag=True but evidence shows {successful_products} successful products")
+            self.log.warning(
+                "🚨 STATE CONTRADICTION DETECTED - PREVENTING start_processing() CALL..."
+            )
+            self.log.warning(
+                f"   Fresh start flag=True but evidence shows {successful_products} successful products"
+            )
             self.log.warning(f"   and {len(completed_categories)} completed categories")
             self.state_manager.state_data["is_fresh_start"] = False
             self.log.info("✅ State contradiction resolved - preserved existing progress")
@@ -1615,38 +2097,46 @@ class PassiveExtractionWorkflow:
             self.linking_map = self._load_linking_map(self.supplier_name)
 
             # --- CUSTOM CATEGORY LOGIC ---
-            if self.workflow_config.get('use_predefined_categories'):
+            if self.workflow_config.get("use_predefined_categories"):
                 self.log.info("CUSTOM MODE: Using predefined category list.")
                 category_urls_to_scrape = await self._get_predefined_categories(self.supplier_name)
                 if not category_urls_to_scrape:
-                    self.log.error("CUSTOM MODE FAILED: No URLs found in predefined list. Aborting.")
+                    self.log.error(
+                        "CUSTOM MODE FAILED: No URLs found in predefined list. Aborting."
+                    )
                     return []
                 # 🚨 DYNAMIC CATEGORY CALCULATION: Calculate categories needed based on max_products / max_products_per_category
                 import math
-                
+
                 system_config = self.config_loader.get_system_config()
-                max_products = system_config.get('max_products')
-                max_products_per_category = system_config.get('max_products_per_category')
-                
+                max_products = system_config.get("max_products")
+                max_products_per_category = system_config.get("max_products_per_category")
+
                 def is_infinite_mode(max_products, max_products_per_category):
                     """Detect infinite mode based on multiple indicators"""
                     mp = max_products or 0
                     mppc = max_products_per_category or 0
-                    
-                    return any([
-                        mp <= 0,                    # Zero or negative
-                        mppc <= 0,                  # Zero or negative  
-                        mp >= 99999,                # High value threshold
-                        mppc >= 99999,              # High value threshold
-                    ])
-                
+
+                    return any(
+                        [
+                            mp <= 0,  # Zero or negative
+                            mppc <= 0,  # Zero or negative
+                            mp >= 99999,  # High value threshold
+                            mppc >= 99999,  # High value threshold
+                        ]
+                    )
+
                 # Apply infinite mode detection
                 total_available_categories = len(category_urls_to_scrape)
-                
+
                 if is_infinite_mode(max_products, max_products_per_category):
                     # INFINITE MODE: Process all available categories
-                    self.log.info(f"🌟 INFINITE MODE DETECTED: max_products={max_products}, max_products_per_category={max_products_per_category}")
-                    self.log.info(f"📋 Processing ALL {total_available_categories} predefined categories (infinite mode)")
+                    self.log.info(
+                        f"🌟 INFINITE MODE DETECTED: max_products={max_products}, max_products_per_category={max_products_per_category}"
+                    )
+                    self.log.info(
+                        f"📋 Processing ALL {total_available_categories} predefined categories (infinite mode)"
+                    )
                     # No slicing - use all categories
                 else:
                     # FINITE MODE: Safe calculation with error handling
@@ -1654,24 +2144,38 @@ class PassiveExtractionWorkflow:
                         if max_products > 0 and max_products_per_category > 0:
                             categories_needed = math.ceil(max_products / max_products_per_category)
                             categories_needed = min(categories_needed, total_available_categories)
-                            
-                            self.log.info(f"📊 FINITE MODE: {max_products} max_products ÷ {max_products_per_category} max_products_per_category = {categories_needed} categories needed")
+
+                            self.log.info(
+                                f"📊 FINITE MODE: {max_products} max_products ÷ {max_products_per_category} max_products_per_category = {categories_needed} categories needed"
+                            )
                             category_urls_to_scrape = category_urls_to_scrape[:categories_needed]
-                            self.log.info(f"📋 Processing {len(category_urls_to_scrape)} predefined categories (finite mode)")
+                            self.log.info(
+                                f"📋 Processing {len(category_urls_to_scrape)} predefined categories (finite mode)"
+                            )
                         else:
                             # Fallback to infinite mode
-                            self.log.warning(f"⚠️ Invalid finite mode values, falling back to infinite mode")
-                            self.log.info(f"📋 Processing ALL {total_available_categories} predefined categories (fallback infinite mode)")
+                            self.log.warning(
+                                f"⚠️ Invalid finite mode values, falling back to infinite mode"
+                            )
+                            self.log.info(
+                                f"📋 Processing ALL {total_available_categories} predefined categories (fallback infinite mode)"
+                            )
                     except Exception as e:
                         # Any error defaults to infinite mode
                         self.log.error(f"❌ Calculation error: {e}, falling back to infinite mode")
-                        self.log.info(f"📋 Processing ALL {total_available_categories} predefined categories (error fallback)")
+                        self.log.info(
+                            f"📋 Processing ALL {total_available_categories} predefined categories (error fallback)"
+                        )
             else:
                 # Original AI-based category selection
                 self.log.info("STANDARD MODE: Using AI-based hierarchical category selection.")
-                category_urls_to_scrape = await self._hierarchical_category_selection(self.workflow_config.get('supplier_url'), self.supplier_name)
+                category_urls_to_scrape = await self._hierarchical_category_selection(
+                    self.workflow_config.get("supplier_url"), self.supplier_name
+                )
                 if not category_urls_to_scrape:
-                    self.log.warning("No categories selected for scraping. Workflow cannot continue.")
+                    self.log.warning(
+                        "No categories selected for scraping. Workflow cannot continue."
+                    )
                     return []
 
             # Check hybrid processing configuration (from full config, not system section)
@@ -1679,41 +2183,66 @@ class PassiveExtractionWorkflow:
             if hybrid_config.get("enabled", False):
                 self.log.info("🔄 HYBRID PROCESSING MODE: Enabled")
                 return await self._run_hybrid_processing_mode(
-                    self.workflow_config.get('supplier_url'), self.supplier_name, category_urls_to_scrape, 
-                    max_products_per_category, max_products_to_process, 
-                    max_analyzed_products, max_products_per_cycle, supplier_extraction_batch_size
+                    self.workflow_config.get("supplier_url"),
+                    self.supplier_name,
+                    category_urls_to_scrape,
+                    max_products_per_category,
+                    max_products_to_process,
+                    max_analyzed_products,
+                    max_products_per_cycle,
+                    supplier_extraction_batch_size,
                 )
-            
+
             supplier_products = await self._extract_supplier_products(
-                self.workflow_config.get('supplier_url'), self.supplier_name, category_urls_to_scrape, max_products_per_category, max_products_to_process, supplier_extraction_batch_size
+                self.workflow_config.get("supplier_url"),
+                self.supplier_name,
+                category_urls_to_scrape,
+                max_products_per_category,
+                max_products_to_process,
+                supplier_extraction_batch_size,
             )
 
             if not supplier_products:
-                self.log.warning(f"No products extracted from {self.supplier_name}. Workflow cannot continue.")
+                self.log.warning(
+                    f"No products extracted from {self.supplier_name}. Workflow cannot continue."
+                )
                 return []
 
             self.results_summary["total_supplier_products"] = len(supplier_products)
-            self.log.info(f"Successfully got {len(supplier_products)} products from {self.supplier_name}")
-            
+            self.log.info(
+                f"Successfully got {len(supplier_products)} products from {self.supplier_name}"
+            )
+
             # Save supplier products to cache immediately after extraction using centralized path management
-            supplier_cache_file = str(path_manager.get_output_path('cached_products', f"{self.supplier_name.replace('.', '-')}_products_cache.json"))
+            supplier_cache_file = str(
+                path_manager.get_output_path(
+                    "cached_products", f"{self.supplier_name.replace('.', '-')}_products_cache.json"
+                )
+            )
             self.log.info(f"🔍 DEBUG: supplier_cache_dir = '{self.supplier_cache_dir}'")
             self.log.info(f"🔍 DEBUG: supplier_cache_file = '{supplier_cache_file}'")
             # 🚨 ATOMIC FIX 8: Save products to cache atomically
             new_count = self._save_products_to_cache(supplier_products, supplier_cache_file)
-            self.log.info(f"💾 ATOMIC INITIAL SAVE: Saved {len(supplier_products)} products ({new_count} new) to cache")
+            self.log.info(
+                f"💾 ATOMIC INITIAL SAVE: Saved {len(supplier_products)} products ({new_count} new) to cache"
+            )
 
             # Filter products based on price and validity
             valid_supplier_products = [
-                p for p in supplier_products
-                if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+                p
+                for p in supplier_products
+                if p.get("title")
+                and isinstance(p.get("price"), (float, int))
+                and p.get("price", 0) > 0
+                and p.get("url")
             ]
             price_filtered_products = [
-                p for p in valid_supplier_products
-                if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+                p for p in valid_supplier_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
             ]
-            self.log.info(f"Found {len(valid_supplier_products)} valid supplier products, {len(price_filtered_products)} within price range [£{MIN_PRICE}-£{MAX_PRICE}]")
-            
+            self.log.info(
+                f"Found {len(valid_supplier_products)} valid supplier products, {len(price_filtered_products)} within price range [£{MIN_PRICE}-£{MAX_PRICE}]"
+            )
+
             # Clamp resume index against the actual product list length (avoid empty slices)
             n = len(price_filtered_products)
             upper = max(0, n - 1)
@@ -1722,133 +2251,186 @@ class PassiveExtractionWorkflow:
                     f"📋 Resume index {self.last_processed_index} > max {upper}; clamping to {upper}."
                 )
                 self.last_processed_index = upper
-            
+
             # Apply max_products_to_process limit starting from resume index
             if max_products_to_process <= 0:
                 # Unlimited mode - process all remaining products
-                products_to_analyze = price_filtered_products[self.last_processed_index:]
-                self.log.info(f"🔄 UNLIMITED MODE: Processing ALL {len(products_to_analyze)} remaining products starting from index {self.last_processed_index}")
+                products_to_analyze = price_filtered_products[self.last_processed_index :]
+                self.log.info(
+                    f"🔄 UNLIMITED MODE: Processing ALL {len(products_to_analyze)} remaining products starting from index {self.last_processed_index}"
+                )
             else:
                 # Limited mode - process up to max_products_to_process starting from resume index
                 end_index = min(self.last_processed_index + max_products_to_process, n)
-                products_to_analyze = price_filtered_products[self.last_processed_index:end_index]
-                self.log.info(f"🔄 LIMITED MODE: Processing {len(products_to_analyze)} products (from index {self.last_processed_index} to {end_index-1})")
-            
+                products_to_analyze = price_filtered_products[self.last_processed_index : end_index]
+                self.log.info(
+                    f"🔄 LIMITED MODE: Processing {len(products_to_analyze)} products (from index {self.last_processed_index} to {end_index-1})"
+                )
+
             # Update processing state with total products to analyze
             # 🚨 FIX 2: Use total cache count instead of current filtered batch
-            total_products_for_state = getattr(self, 'total_cache_count', len(price_filtered_products))
-            self.state_manager.update_processing_index(self.last_processed_index, total_products_for_state)
+            total_products_for_state = getattr(
+                self, "total_cache_count", len(price_filtered_products)
+            )
+            self.state_manager.update_processing_index(
+                self.last_processed_index, total_products_for_state
+            )
 
             # Batch processing logic - group products by max_products_per_cycle
             batch_size = max_products_per_cycle
             total_batches = (len(products_to_analyze) + batch_size - 1) // batch_size
-            self.log.info(f"🚀 BATCH PROCESSING: {len(products_to_analyze)} products in {total_batches} batches of {batch_size}")
+            self.log.info(
+                f"🚀 BATCH PROCESSING: {len(products_to_analyze)} products in {total_batches} batches of {batch_size}"
+            )
 
             # Process products in batches
             for batch_num in range(total_batches):
                 start_idx = batch_num * batch_size
                 end_idx = min(start_idx + batch_size, len(products_to_analyze))
                 batch_products = products_to_analyze[start_idx:end_idx]
-                
-                self.log.info(f"🔄 Processing batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-                
+
+                self.log.info(
+                    f"🔄 Processing batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+                )
+
                 # Process each product in the current batch
                 for i, product_data in enumerate(batch_products):
                     # Calculate the absolute index in the full product list (considering resume index)
                     current_index = self.last_processed_index + start_idx + i + 1
                     # 🚨 FIX 2: Show correct total in log messages
-                    total_for_display = getattr(self, 'total_cache_count', len(price_filtered_products))
-                    self.log.info(f"--- Processing supplier product {current_index}/{total_for_display}: '{product_data.get('title')}' ---")
-                    
+                    total_for_display = getattr(
+                        self, "total_cache_count", len(price_filtered_products)
+                    )
+                    self.log.info(
+                        f"--- Processing supplier product {current_index}/{total_for_display}: '{product_data.get('title')}' ---"
+                    )
+
                     # 🚨 FIX: Update state manager with consistent index tracking
-                    if hasattr(self, 'state_manager') and self.state_manager:
+                    if hasattr(self, "state_manager") and self.state_manager:
                         # Use unified state update method
                         self.state_manager.update_processing_index(current_index, total_for_display)
-                        
+
                         # Also update detailed progress for category tracking
-                        if hasattr(self.state_manager, 'update_supplier_extraction_progress'):
+                        if hasattr(self.state_manager, "update_supplier_extraction_progress"):
                             self.state_manager.update_supplier_extraction_progress(
                                 category_index=batch_num + 1,
                                 total_categories=self._authoritative_total_categories(),
                                 subcategory_index=i + 1,
                                 total_subcategories=len(batch_products),
-                                category_url=product_data.get('source_url', 'unknown'),
-                                extraction_phase="supplier"
+                                category_url=product_data.get("source_url", "unknown"),
+                                extraction_phase="supplier",
                             )
-                        
+
                         # Save state after every product to ensure resumability
                         self.state_manager.save_state()
-                    
+
                     # 🔧 AUTHENTICATION FALLBACK CHECK
                     if self._check_authentication_fallback_needed():
-                        self.log.warning("🔐 Authentication fallback needed - attempting re-authentication...")
+                        self.log.warning(
+                            "🔐 Authentication fallback needed - attempting re-authentication..."
+                        )
                         auth_success = await self._perform_authentication_fallback()
                         if not auth_success:
-                            self.log.error("❌ Authentication fallback failed - continuing with current session")
-                    
-                    self.log.info(f"🔍 DEBUG: Updating processing index to {current_index}/{len(price_filtered_products)}")
-                    self.state_manager.update_processing_index(current_index, len(price_filtered_products))
+                            self.log.error(
+                                "❌ Authentication fallback failed - continuing with current session"
+                            )
+
+                    self.log.info(
+                        f"🔍 DEBUG: Updating processing index to {current_index}/{len(price_filtered_products)}"
+                    )
+                    self.state_manager.update_processing_index(
+                        current_index, len(price_filtered_products)
+                    )
                     # Verify the update worked
                     current_state = self.state_manager.get_state_summary()
-                    self.log.info(f"🔍 DEBUG: State after update - last_processed_index: {current_state.get('progress', 'unknown')}")
-                    
+                    self.log.info(
+                        f"🔍 DEBUG: State after update - last_processed_index: {current_state.get('progress', 'unknown')}"
+                    )
+
                     # 🚨 CRITICAL FIX: Amazon Analysis Resumption Logic
                     # Check linking map to avoid re-processing already analyzed Amazon products
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     supplier_url = product_data.get("url")
-                    
+
                     # 🚀 HASH OPTIMIZATION: Check if this product already exists in linking map (Amazon analysis completed)
                     # Using O(1) hash lookup instead of O(n) linear search for 3,650x performance improvement
-                    already_in_linking_map, existing_entry = self.hash_optimizer.check_product_in_linking_map(
+                    (
+                        already_in_linking_map,
+                        existing_entry,
+                    ) = self.hash_optimizer.check_product_in_linking_map(
                         supplier_ean=supplier_ean, supplier_url=supplier_url
                     )
                     if already_in_linking_map and existing_entry:
-                        self.log.info(f"✅ AMAZON SKIP: Product '{product_data.get('title')}' already in linking map (ASIN: {existing_entry.get('amazon_asin')}) - skipping Amazon analysis")
+                        self.log.info(
+                            f"✅ AMAZON SKIP: Product '{product_data.get('title')}' already in linking map (ASIN: {existing_entry.get('amazon_asin')}) - skipping Amazon analysis"
+                        )
                         self.log.debug(f"🚀 HASH LOOKUP: O(1) lookup found existing entry instantly")
-                    
+
                     # Check if product has been previously processed in state manager
                     is_already_processed = self.state_manager.is_product_processed(supplier_url)
-                    
+
                     # Skip if already processed OR already in linking map (Amazon analysis complete)
                     if is_already_processed or already_in_linking_map:
                         if is_already_processed:
-                            self.log.info(f"SUPPLIER SKIP: Product already processed in state: {supplier_url}")
-                        
+                            self.log.info(
+                                f"SUPPLIER SKIP: Product already processed in state: {supplier_url}"
+                            )
+
                         # If in linking map but not marked as processed, update state
                         if already_in_linking_map and not is_already_processed:
-                            self.state_manager.mark_product_processed(supplier_url, "completed_from_linking_map")
-                            self.log.info(f"📋 Updated state: Marked product as completed from linking map")
-                        
+                            self.state_manager.mark_product_processed(
+                                supplier_url, "completed_from_linking_map"
+                            )
+                            self.log.info(
+                                f"📋 Updated state: Marked product as completed from linking map"
+                            )
+
                         continue  # Skip further processing - Amazon analysis already complete
 
                     # 🚨 LOGIN SCRIPT TRIGGER - Before Amazon product detail extraction as required
-                    await self._trigger_authentication_check(f"amazon_extraction_product_{processed_products}")
-                    
+                    await self._trigger_authentication_check(
+                        f"amazon_extraction_product_{processed_products}"
+                    )
+
                     # Extract Amazon data
-                    self.log.info(f"🔍 DEBUG: About to extract Amazon data for product: '{product_data.get('title')}'")
-                    self.log.info(f"🔍 DEBUG: Product EAN/barcode: {product_data.get('ean')} / {product_data.get('barcode')}")
-                    
+                    self.log.info(
+                        f"🔍 DEBUG: About to extract Amazon data for product: '{product_data.get('title')}'"
+                    )
+                    self.log.info(
+                        f"🔍 DEBUG: Product EAN/barcode: {product_data.get('ean')} / {product_data.get('barcode')}"
+                    )
+
                     amazon_data = await self._get_amazon_data(product_data)
-                    
+
                     self.log.info(f"🔍 DEBUG: Amazon data extraction result: {type(amazon_data)}")
                     if amazon_data:
-                        self.log.info(f"🔍 DEBUG: Amazon data keys: {list(amazon_data.keys()) if isinstance(amazon_data, dict) else 'not a dict'}")
+                        self.log.info(
+                            f"🔍 DEBUG: Amazon data keys: {list(amazon_data.keys()) if isinstance(amazon_data, dict) else 'not a dict'}"
+                        )
                         if isinstance(amazon_data, dict) and "error" not in amazon_data:
-                            self.log.info(f"🔍 DEBUG: Amazon ASIN extracted: {amazon_data.get('asin')}")
-                        
+                            self.log.info(
+                                f"🔍 DEBUG: Amazon ASIN extracted: {amazon_data.get('asin')}"
+                            )
+
                     if not amazon_data or "error" in amazon_data:
-                        self.log.warning(f"Could not retrieve valid Amazon data for '{product_data.get('title')}'. Creating no-match linking entry to prevent reprocessing.")
+                        self.log.warning(
+                            f"Could not retrieve valid Amazon data for '{product_data.get('title')}'. Creating no-match linking entry to prevent reprocessing."
+                        )
                         self.log.warning(f"🔍 DEBUG: Amazon data failure: {amazon_data}")
-                        
+
                         # 🚨 FIX: Create no-match linking entry to prevent infinite reprocessing loops
                         supplier_ean = product_data.get("ean") or product_data.get("barcode")
                         if supplier_ean == "None" or supplier_ean is None:
                             supplier_ean = None
-                            
+
                         # Determine the reason for no match
-                        error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                        error_info = (
+                            amazon_data.get("error")
+                            if isinstance(amazon_data, dict)
+                            else "No Amazon data returned"
+                        )
                         no_match_reason = f"Amazon search failed: {error_info}"
-                        
+
                         # Create no-match linking entry
                         no_match_entry = {
                             "supplier_ean": supplier_ean,
@@ -1858,19 +2440,25 @@ class PassiveExtractionWorkflow:
                             "supplier_price": product_data.get("price"),
                             "amazon_price": None,
                             "match_method": "none",  # NEW: Indicates no match found
-                            "confidence": 0,    # NEW: No confidence for failed matches
+                            "confidence": 0,  # NEW: No confidence for failed matches
                             "created_at": datetime.now().isoformat(),
                             "supplier_url": product_data.get("url"),
-                            "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                            "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                         }
-                        
+
                         # Add no-match entry to linking map using optimized method
                         self._add_linking_map_entry_optimized(no_match_entry)
-                        self.log.info(f"✅ Added NO-MATCH linking entry: {supplier_ean or 'NO_EAN'} → NO MATCH ({no_match_reason})")
-                        self.log.info(f"🔍 DEBUG: Current linking_map size: {len(self.linking_map)} entries")
-                        
+                        self.log.info(
+                            f"✅ Added NO-MATCH linking entry: {supplier_ean or 'NO_EAN'} → NO MATCH ({no_match_reason})"
+                        )
+                        self.log.info(
+                            f"🔍 DEBUG: Current linking_map size: {len(self.linking_map)} entries"
+                        )
+
                         # Mark as processed to prevent state manager reprocessing
-                        self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                        self.state_manager.mark_product_processed(
+                            product_data.get("url"), "failed_amazon_extraction"
+                        )
                         continue
 
                     # Save the Amazon data with the correct filename
@@ -1878,41 +2466,64 @@ class PassiveExtractionWorkflow:
                     # Ensure we don't get None values
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                    
+
                     # Use supplier product title when EAN is not available
                     if not supplier_ean:
                         # Sanitize supplier product title for filename
                         supplier_title = product_data.get("title", "NO_TITLE")
                         # Remove/replace characters that aren't safe for filenames
                         import re
-                        filename_identifier = re.sub(r'[<>:"/\\|?*]', '_', supplier_title)
-                        filename_identifier = re.sub(r'\s+', '_', filename_identifier)  # Replace spaces with underscores
-                        filename_identifier = filename_identifier[:50]  # Limit length to prevent long filenames
-                        self.log.info(f"🔧 Using supplier title for Amazon cache filename: '{supplier_title}' -> '{filename_identifier}'")
+
+                        filename_identifier = re.sub(r'[<>:"/\\|?*]', "_", supplier_title)
+                        filename_identifier = re.sub(
+                            r"\s+", "_", filename_identifier
+                        )  # Replace spaces with underscores
+                        filename_identifier = filename_identifier[
+                            :50
+                        ]  # Limit length to prevent long filenames
+                        self.log.info(
+                            f"🔧 Using supplier title for Amazon cache filename: '{supplier_title}' -> '{filename_identifier}'"
+                        )
                     else:
                         filename_identifier = supplier_ean
-                    
+
                     asin = amazon_data.get("asin", "NO_ASIN")
-                    amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
+                    amazon_cache_path = str(
+                        path_manager.get_output_path(
+                            "FBA_ANALYSIS",
+                            "amazon_cache",
+                            f"amazon_{asin}_{filename_identifier}.json",
+                        )
+                    )
                     success = self.save_guardian.save_json_atomic(amazon_cache_path, amazon_data)
                     if success:
                         self.log.info(f"Saved Amazon data to {amazon_cache_path}")
                     else:
                         self.log.error(f"❌ Failed to save Amazon data to {amazon_cache_path}")
 
-                    self.log.info(f"🔍 DEBUG: supplier_ean='{supplier_ean}', asin='{asin}', product_ean='{product_data.get('ean')}'")
-                    self.log.info(f"🔍 DEBUG: Checking linking conditions - supplier_ean valid: {bool(supplier_ean)}, asin valid: {bool(asin and asin != 'NO_ASIN')}")
-                    
+                    self.log.info(
+                        f"🔍 DEBUG: supplier_ean='{supplier_ean}', asin='{asin}', product_ean='{product_data.get('ean')}'"
+                    )
+                    self.log.info(
+                        f"🔍 DEBUG: Checking linking conditions - supplier_ean valid: {bool(supplier_ean)}, asin valid: {bool(asin and asin != 'NO_ASIN')}"
+                    )
+
                     # Get actual search method used (fixed logic)
                     actual_search_method = amazon_data.get("_search_method_used", "unknown")
-                    
+
                     # Create linking entry with accurate method and confidence
                     self.log.info(f"🔍 DEBUG: Linking map entry conditions check:")
-                    self.log.info(f"   supplier_ean: '{supplier_ean}' (valid: {bool(supplier_ean)})")
-                    self.log.info(f"   product_title: '{product_data.get('title')}' (valid: {bool(product_data.get('title'))})")
+                    self.log.info(
+                        f"   supplier_ean: '{supplier_ean}' (valid: {bool(supplier_ean)})"
+                    )
+                    self.log.info(
+                        f"   product_title: '{product_data.get('title')}' (valid: {bool(product_data.get('title'))})"
+                    )
                     self.log.info(f"   asin: '{asin}' (valid: {bool(asin and asin != 'NO_ASIN')})")
-                    self.log.info(f"   overall condition: {bool((supplier_ean or product_data.get('title')) and asin and asin != 'NO_ASIN')}")
-                    
+                    self.log.info(
+                        f"   overall condition: {bool((supplier_ean or product_data.get('title')) and asin and asin != 'NO_ASIN')}"
+                    )
+
                     if (supplier_ean or product_data.get("title")) and asin and asin != "NO_ASIN":
                         # Determine confidence based on actual search success, not just supplier data availability
                         if actual_search_method == "EAN":
@@ -1921,7 +2532,7 @@ class PassiveExtractionWorkflow:
                             confidence = "medium"  # Title search worked
                         else:
                             confidence = "low"  # Unknown method
-                            
+
                         linking_entry = {
                             "supplier_ean": supplier_ean,
                             "amazon_asin": asin,
@@ -1932,81 +2543,120 @@ class PassiveExtractionWorkflow:
                             "match_method": actual_search_method,  # Use actual method, not assumption
                             "confidence": confidence,
                             "created_at": datetime.now().isoformat(),
-                            "supplier_url": product_data.get("url")
+                            "supplier_url": product_data.get("url"),
                         }
                         # 🚀 HASH OPTIMIZATION: Use optimized method to add entry and update indexes
                         self._add_linking_map_entry_optimized(linking_entry)
-                        self.log.info(f"✅ Added linking map entry: {actual_search_method.upper()} search {supplier_ean or 'NO_EAN'} → ASIN {asin}")
-                        self.log.info(f"🔍 DEBUG: Current linking_map size: {len(self.linking_map)} entries")
+                        self.log.info(
+                            f"✅ Added linking map entry: {actual_search_method.upper()} search {supplier_ean or 'NO_EAN'} → ASIN {asin}"
+                        )
+                        self.log.info(
+                            f"🔍 DEBUG: Current linking_map size: {len(self.linking_map)} entries"
+                        )
                         self.log.info(f"🔍 DEBUG: Linking entry created: {linking_entry}")
-                        
+
                         # 🚨 CRITICAL FIX: Check financial report trigger after each linking map entry
                         financial_batch_size = self.config_loader.get_financial_batch_size()
                         current_linking_map_count = len(self.linking_map)
-                        
-                        if current_linking_map_count > 0 and current_linking_map_count % financial_batch_size == 0:
+
+                        if (
+                            current_linking_map_count > 0
+                            and current_linking_map_count % financial_batch_size == 0
+                        ):
                             try:
-                                self.log.info(f"🚨 FINANCIAL REPORT TRIGGER: Reached {current_linking_map_count} linking map entries (trigger every {financial_batch_size})")
+                                self.log.info(
+                                    f"🚨 FINANCIAL REPORT TRIGGER: Reached {current_linking_map_count} linking map entries (trigger every {financial_batch_size})"
+                                )
                                 from tools.FBA_Financial_calculator import run_calculations
+
                                 financial_results = run_calculations(self.supplier_name)
-                                if financial_results and financial_results.get('statistics', {}).get('output_file'):
-                                    self.log.info(f"✅ Financial report EXECUTED: {financial_results['statistics']['output_file']}")
+                                if financial_results and financial_results.get(
+                                    "statistics", {}
+                                ).get("output_file"):
+                                    self.log.info(
+                                        f"✅ Financial report EXECUTED: {financial_results['statistics']['output_file']}"
+                                    )
                                 else:
-                                    self.log.warning("⚠️ Financial report executed but no file path returned")
+                                    self.log.warning(
+                                        "⚠️ Financial report executed but no file path returned"
+                                    )
                             except ImportError as ie:
                                 self.log.error(f"❌ Could not import FBA_Financial_calculator: {ie}")
                             except Exception as e:
                                 self.log.error(f"❌ Error executing financial report: {e}")
                         elif current_linking_map_count > 0:
-                            next_trigger_count = ((current_linking_map_count // financial_batch_size) + 1) * financial_batch_size
-                            self.log.info(f"💡 FINANCIAL REPORT TRIGGER: Next trigger at {next_trigger_count} linking map entries (current: {current_linking_map_count}, trigger frequency: {financial_batch_size})")
+                            next_trigger_count = (
+                                (current_linking_map_count // financial_batch_size) + 1
+                            ) * financial_batch_size
+                            self.log.info(
+                                f"💡 FINANCIAL REPORT TRIGGER: Next trigger at {next_trigger_count} linking map entries (current: {current_linking_map_count}, trigger frequency: {financial_batch_size})"
+                            )
                     else:
-                        self.log.error(f"❌ CRITICAL: Could not create linking map entry - condition failed!")
-                        self.log.error(f"   supplier_ean: '{supplier_ean}' (bool: {bool(supplier_ean)})")
-                        self.log.error(f"   product_title: '{product_data.get('title')}' (bool: {bool(product_data.get('title'))})")
-                        self.log.error(f"   asin: '{asin}' (bool: {bool(asin and asin != 'NO_ASIN')})")
-                        self.log.error(f"   This means NO linking map entries will be created and saved!")
+                        self.log.error(
+                            f"❌ CRITICAL: Could not create linking map entry - condition failed!"
+                        )
+                        self.log.error(
+                            f"   supplier_ean: '{supplier_ean}' (bool: {bool(supplier_ean)})"
+                        )
+                        self.log.error(
+                            f"   product_title: '{product_data.get('title')}' (bool: {bool(product_data.get('title'))})"
+                        )
+                        self.log.error(
+                            f"   asin: '{asin}' (bool: {bool(asin and asin != 'NO_ASIN')})"
+                        )
+                        self.log.error(
+                            f"   This means NO linking map entries will be created and saved!"
+                        )
 
                     # Perform financial analysis for individual product
                     try:
                         # Import financial calculation functions directly to avoid full cache dependency
                         # Already imported at top of file - from FBA_Financial_calculator import financials as calc_financials
-                        
+
                         # Extract supplier price with validation from the linking map entry
                         supplier_price_inc_vat = linking_entry.get("supplier_price", 0)
-                        
+
                         # 🔧 AUTHENTICATION FALLBACK: Record price status for monitoring
                         has_supplier_price = supplier_price_inc_vat and supplier_price_inc_vat > 0
                         self._record_product_price_status(product_data, has_supplier_price)
                         if isinstance(supplier_price_inc_vat, str):
                             # Clean price string and convert to float
                             import re
-                            price_clean = re.sub(r'[^0-9.]', '', supplier_price_inc_vat)
+
+                            price_clean = re.sub(r"[^0-9.]", "", supplier_price_inc_vat)
                             supplier_price_inc_vat = float(price_clean) if price_clean else 0
                         elif supplier_price_inc_vat is None:
                             supplier_price_inc_vat = 0
-                            
+
                         # Calculate financial metrics for this specific product
                         # 🚨 FIX: Use correct function signature - pass individual values, not full objects
                         try:
-                            supplier_price = float(product_data.get('price', 0))
-                            amazon_price = float(amazon_data.get('current_price') or amazon_data.get('price', 0))
-                            
+                            supplier_price = float(product_data.get("price", 0))
+                            amazon_price = float(
+                                amazon_data.get("current_price") or amazon_data.get("price", 0)
+                            )
+
                             if amazon_price > 0:
                                 financials = calc_financials(
                                     supplier_price=supplier_price,
                                     amazon_price=amazon_price,
                                     amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                                     amazon_rating=amazon_data.get("rating", 0),
-                                    amazon_review_count=amazon_data.get("reviews", 0)
+                                    amazon_review_count=amazon_data.get("reviews", 0),
                                 )
                                 if financials:
-                                    self.log.info(f"✅ Financial analysis complete for {product_data.get('title')}")
+                                    self.log.info(
+                                        f"✅ Financial analysis complete for {product_data.get('title')}"
+                                    )
                                 else:
-                                    self.log.warning(f"⚠️ Financial calculation returned empty for {product_data.get('title')}")
+                                    self.log.warning(
+                                        f"⚠️ Financial calculation returned empty for {product_data.get('title')}"
+                                    )
                                     financials = None
                             else:
-                                self.log.warning(f"❌ No valid Amazon price found for {product_data.get('title')}")
+                                self.log.warning(
+                                    f"❌ No valid Amazon price found for {product_data.get('title')}"
+                                )
                                 financials = None
                         except (ValueError, TypeError) as e:
                             self.log.error(f"Financial calculation error: {e}")
@@ -2014,41 +2664,66 @@ class PassiveExtractionWorkflow:
                             financials = None
                         except Exception as e:
                             self.log.error(f"Unexpected financial calculation error: {e}")
-                            self.log.debug(f"Product data: {product_data.get('title')}, Amazon price fields: {list(amazon_data.keys()) if isinstance(amazon_data, dict) else 'Not a dict'}")
+                            self.log.debug(
+                                f"Product data: {product_data.get('title')}, Amazon price fields: {list(amazon_data.keys()) if isinstance(amazon_data, dict) else 'Not a dict'}"
+                            )
                             financials = None
-                        
+
                         if not financials:
-                            self.log.warning(f"Financial calculation returned empty for '{product_data.get('title')}'")
+                            self.log.warning(
+                                f"Financial calculation returned empty for '{product_data.get('title')}'"
+                            )
                             financials = {}
-                            
+
                     except Exception as e:
-                        self.log.error(f"Financial calculation failed for '{product_data.get('title')}': {e}")
-                        self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
+                        self.log.error(
+                            f"Financial calculation failed for '{product_data.get('title')}': {e}"
+                        )
+                        self.state_manager.mark_product_processed(
+                            product_data.get("url"), "failed_financial_calculation"
+                        )
                         # Continue with empty financials rather than failing completely
                         financials = {}
 
                     # Combine all data
-                    combined_data = {**product_data, "amazon_data": amazon_data, "financials": financials}
-                                
+                    combined_data = {
+                        **product_data,
+                        "amazon_data": amazon_data,
+                        "financials": financials,
+                    }
+
                     # Check for profitability
-                    if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                        self.log.info(f"✅ Profitable product found: '{product_data.get('title')}' (ROI: {financials.get('ROI'):.2f}%, Profit: £{financials.get('NetProfit'):.2f})")
+                    if (
+                        financials.get("ROI", 0) > MIN_ROI_PERCENT
+                        and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                    ):
+                        self.log.info(
+                            f"✅ Profitable product found: '{product_data.get('title')}' (ROI: {financials.get('ROI'):.2f}%, Profit: £{financials.get('NetProfit'):.2f})"
+                        )
                         profitable_results.append(combined_data)
                         self.results_summary["profitable_products"] += 1
-                        self.state_manager.mark_product_processed(product_data.get("url"), "profitable")
+                        self.state_manager.mark_product_processed(
+                            product_data.get("url"), "profitable"
+                        )
                     else:
-                        self.log.info(f"Product not profitable: '{product_data.get('title')}' (ROI: {financials.get('ROI', 0):.2f}%, Profit: £{financials.get('NetProfit', 0):.2f})")
-                        self.state_manager.mark_product_processed(product_data.get("url"), "not_profitable")
+                        self.log.info(
+                            f"Product not profitable: '{product_data.get('title')}' (ROI: {financials.get('ROI', 0):.2f}%, Profit: £{financials.get('NetProfit', 0):.2f})"
+                        )
+                        self.state_manager.mark_product_processed(
+                            product_data.get("url"), "not_profitable"
+                        )
 
                     # Save state periodically using configurable batch sizes
                     overall_product_index = start_idx + i + 1
                     linking_map_batch = self.system_config.get("linking_map_batch_size", 1)
-                    
+
                     if overall_product_index % linking_map_batch == 0:
                         self.state_manager.save_state(preserve_interruption_state=True)
                         self._save_linking_map(self.supplier_name)
-                        self.log.info(f"📊 Periodic save at product {overall_product_index} (linking_map_batch_size: {linking_map_batch})")
-                        
+                        self.log.info(
+                            f"📊 Periodic save at product {overall_product_index} (linking_map_batch_size: {linking_map_batch})"
+                        )
+
                         # 🚨 CRITICAL FIX #4: SMART MEMORY MANAGEMENT
                         # Implement periodic memory clearing with sliding window approach
                         self._perform_smart_memory_management(overall_product_index, batch_products)
@@ -2059,143 +2734,178 @@ class PassiveExtractionWorkflow:
                 self.log.info("🔍 DEBUG: Calling state_manager.complete_processing()...")
                 self.state_manager.complete_processing()
                 self.log.info("✅ State manager processing completed")
-                
-                self.log.info(f"🔍 DEBUG: Calling _save_linking_map with supplier_name='{self.supplier_name}'...")
+
+                self.log.info(
+                    f"🔍 DEBUG: Calling _save_linking_map with supplier_name='{self.supplier_name}'..."
+                )
                 self._save_linking_map(self.supplier_name)
                 self.log.info("✅ Linking map save completed")
-                
-                self.log.info(f"🔍 DEBUG: Calling _save_final_report with {len(profitable_results)} profitable results...")
+
+                self.log.info(
+                    f"🔍 DEBUG: Calling _save_final_report with {len(profitable_results)} profitable results..."
+                )
                 self._save_final_report(profitable_results, self.supplier_name)
                 self.log.info("✅ Final report save completed")
-                
+
             except Exception as final_save_error:
-                self.log.error(f"❌ CRITICAL: Error during final save phase: {final_save_error}", exc_info=True)
-                self.log.error("This explains why linking map and financial reports are not being saved!")
+                self.log.error(
+                    f"❌ CRITICAL: Error during final save phase: {final_save_error}", exc_info=True
+                )
+                self.log.error(
+                    "This explains why linking map and financial reports are not being saved!"
+                )
             # This must happen regardless of whether products were processed or skipped
             self.log.info("🔍 DEBUG: Starting mandatory final save and completion phase...")
             try:
                 self.log.info("🔍 DEBUG: Calling state_manager.complete_processing()...")
                 self.state_manager.complete_processing()
                 self.log.info("✅ State manager processing completed")
-                
-                self.log.info(f"🔍 DEBUG: Calling _save_linking_map with supplier_name='{self.supplier_name}'...")
+
+                self.log.info(
+                    f"🔍 DEBUG: Calling _save_linking_map with supplier_name='{self.supplier_name}'..."
+                )
                 self._save_linking_map(self.supplier_name)
                 self.log.info("✅ Linking map save completed")
-                
-                self.log.info(f"🔍 DEBUG: Calling _save_final_report with {len(profitable_results)} profitable results...")
+
+                self.log.info(
+                    f"🔍 DEBUG: Calling _save_final_report with {len(profitable_results)} profitable results..."
+                )
                 self._save_final_report(profitable_results, self.supplier_name)
                 self.log.info("✅ Final report save completed")
-                
+
             except Exception as final_save_error:
-                self.log.error(f"❌ CRITICAL: Error during mandatory final save phase: {final_save_error}", exc_info=True)
-                self.log.error("This explains why linking map and financial reports are not being saved!")
-            
+                self.log.error(
+                    f"❌ CRITICAL: Error during mandatory final save phase: {final_save_error}",
+                    exc_info=True,
+                )
+                self.log.error(
+                    "This explains why linking map and financial reports are not being saved!"
+                )
+
             try:
                 self.log.info("🧮 Generating comprehensive financial report...")
                 financial_results = run_calculations(self.supplier_name)
-                if financial_results and financial_results.get('statistics', {}).get('output_file'):
-                    self.log.info(f"✅ Financial report generated: {financial_results['statistics']['output_file']}")
+                if financial_results and financial_results.get("statistics", {}).get("output_file"):
+                    self.log.info(
+                        f"✅ Financial report generated: {financial_results['statistics']['output_file']}"
+                    )
                 else:
                     self.log.warning("⚠️ Financial report generated but no file path returned")
             except ImportError as ie:
                 self.log.error(f"❌ Could not import FBA_Financial_calculator: {ie}")
             except Exception as e:
                 self.log.error(f"❌ Error generating financial report: {e}")
-            
+
             self.log.info(f"📊 Processing state file saved: {self.state_manager.state_file_path}")
             self.log.info(f"📊 Final state summary: {self.state_manager.get_state_summary()}")
-            
+
             # 🚀 HASH OPTIMIZATION: Log comprehensive performance summary
             self.log_hash_optimization_summary()
-            
+
             # 🧪 HASH OPTIMIZATION: Run performance benchmark
             if len(self.linking_map) > 50:  # Only benchmark if we have sufficient data
-                benchmark_results = self.benchmark_hash_performance(sample_size=min(100, len(self.linking_map)//2))
+                benchmark_results = self.benchmark_hash_performance(
+                    sample_size=min(100, len(self.linking_map) // 2)
+                )
                 if benchmark_results:
-                    self.log.info(f"🧪 BENCHMARK: Hash optimization validated with {benchmark_results.get('performance_improvement', 0):.1f}x improvement")
-            
+                    self.log.info(
+                        f"🧪 BENCHMARK: Hash optimization validated with {benchmark_results.get('performance_improvement', 0):.1f}x improvement"
+                    )
+
             # 🚨 SENTINEL MONITORING: Finalize monitoring and generate summary
             self.sentinel_monitor.finalize_monitoring()
-            
+
             self.log.info("--- Passive Extraction Workflow Finished ---")
             self.log.info(f"Summary: {self.results_summary}")
-        
+
             return profitable_results
 
         except Exception as e:
-            self.log.error(f"Unexpected error occurred during workflow execution: {e}", exc_info=True)
+            self.log.error(
+                f"Unexpected error occurred during workflow execution: {e}", exc_info=True
+            )
             return []
 
-
-    async def _process_gap_products(self, gap_size: int, supplier_cache_count: int, linking_map_count: int) -> List[Dict[str, Any]]:
+    async def _process_gap_products(
+        self, gap_size: int, supplier_cache_count: int, linking_map_count: int
+    ) -> List[Dict[str, Any]]:
         """
         Process the gap between cache and linking map entries.
         This processes cached products that haven't been analyzed on Amazon yet.
         """
         self.log.info(f"🔄 Starting gap processing: {gap_size} products need Amazon analysis")
-        
+
         profitable_results = []
-        
+
         # Load cached products
         supplier_cache_file, _ = self._find_actual_supplier_cache_file(self.supplier_name)
         if not supplier_cache_file:
             self.log.error("❌ No supplier cache file found for gap processing")
             return profitable_results
-        
+
         try:
-            with open(supplier_cache_file, 'r', encoding='utf-8') as f:
+            with open(supplier_cache_file, "r", encoding="utf-8") as f:
                 all_cached_products = json.load(f)
         except Exception as e:
             self.log.error(f"❌ Failed to load cached products: {e}")
             return profitable_results
-        
+
         # Get products that need processing (from linking_map_count to supplier_cache_count)
         gap_products = all_cached_products[linking_map_count:supplier_cache_count]
-        
-        self.log.info(f"📊 Gap processing: Processing products {linking_map_count+1} to {supplier_cache_count}")
-        
+
+        self.log.info(
+            f"📊 Gap processing: Processing products {linking_map_count+1} to {supplier_cache_count}"
+        )
+
         # Process each gap product
         for i, product_data in enumerate(gap_products):
             current_gap_index = i + 1
             overall_product_index = linking_map_count + current_gap_index
-            
-            self.log.info(f"--- Processing gap product {current_gap_index}/{gap_size}: '{product_data.get('title')}' ---")
-            
+
+            self.log.info(
+                f"--- Processing gap product {current_gap_index}/{gap_size}: '{product_data.get('title')}' ---"
+            )
+
             # Update gap processing progress
             self.state_manager.update_gap_processing_progress(
-                current_gap_index, 
-                len([r for r in profitable_results if r.get('profitable', False)]),
-                product_data.get('url', '')
+                current_gap_index,
+                len([r for r in profitable_results if r.get("profitable", False)]),
+                product_data.get("url", ""),
             )
-            
+
             # Check if already processed
             supplier_url = product_data.get("url")
             if self.state_manager.is_product_processed(supplier_url):
                 self.log.info("Product already processed: skipping")
                 continue
-            
+
             # 🚀 HASH OPTIMIZATION: Check if already in linking map using O(1) lookup
             supplier_ean = product_data.get("ean") or product_data.get("barcode")
-            already_in_linking_map, existing_entry = self.hash_optimizer.check_product_in_linking_map(
+            (
+                already_in_linking_map,
+                existing_entry,
+            ) = self.hash_optimizer.check_product_in_linking_map(
                 supplier_ean=supplier_ean, supplier_url=supplier_url
             )
             if already_in_linking_map:
                 self.log.info(f"✅ Product already in linking map - skipping (O(1) hash lookup)")
-                self.log.debug(f"🚀 HASH LOOKUP: Found existing entry with ASIN: {existing_entry.get('amazon_asin') if existing_entry else 'N/A'}")
-            
+                self.log.debug(
+                    f"🚀 HASH LOOKUP: Found existing entry with ASIN: {existing_entry.get('amazon_asin') if existing_entry else 'N/A'}"
+                )
+
             if already_in_linking_map:
                 continue
-            
+
             # Process through Amazon analysis
             try:
                 amazon_data = await self._get_amazon_data(product_data)
-                
+
                 if amazon_data and amazon_data.get("asin"):
                     # Create successful linking map entry
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                    
+
                     actual_search_method = amazon_data.get("_search_method_used", "unknown")
                     if actual_search_method == "EAN":
                         confidence = "high"
@@ -2203,7 +2913,7 @@ class PassiveExtractionWorkflow:
                         confidence = "medium"
                     else:
                         confidence = "low"
-                    
+
                     linking_entry = {
                         "supplier_ean": supplier_ean,
                         "amazon_asin": amazon_data.get("asin"),
@@ -2214,17 +2924,19 @@ class PassiveExtractionWorkflow:
                         "match_method": actual_search_method,
                         "confidence": confidence,
                         "created_at": datetime.now().isoformat(),
-                        "supplier_url": product_data.get("url")
+                        "supplier_url": product_data.get("url"),
                     }
                     # 🚀 HASH OPTIMIZATION: Use optimized method to add entry and update indexes
                     self._add_linking_map_entry_optimized(linking_entry)
-                    
+
                     # Run financial analysis
                     financial_result = await self._run_financial_analysis(product_data, amazon_data)
-                    
-                    if financial_result and financial_result.get('profitable', False):
+
+                    if financial_result and financial_result.get("profitable", False):
                         profitable_results.append(financial_result)
-                        self.log.info(f"✅ Profitable gap product found: {product_data.get('title')}")
+                        self.log.info(
+                            f"✅ Profitable gap product found: {product_data.get('title')}"
+                        )
                     else:
                         self.log.info(f"❌ Not profitable gap product: {product_data.get('title')}")
                 else:
@@ -2232,11 +2944,15 @@ class PassiveExtractionWorkflow:
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Gap processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -2246,71 +2962,79 @@ class PassiveExtractionWorkflow:
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"❌ No Amazon match for gap product: {product_data.get('title')} - Added no-match linking entry")
-                
+                    self.log.info(
+                        f"❌ No Amazon match for gap product: {product_data.get('title')} - Added no-match linking entry"
+                    )
+
                 # Mark as processed
                 self.state_manager.mark_product_processed(supplier_url, "completed_gap_processing")
-                
+
                 # Save periodically
                 if current_gap_index % 5 == 0:
                     self._save_linking_map(self.supplier_name)
                     self.state_manager.save_state(preserve_interruption_state=True)
                     self.log.info(f"📊 Gap processing checkpoint: {current_gap_index}/{gap_size}")
-                
+
             except Exception as e:
                 self.log.error(f"❌ Error processing gap product {current_gap_index}: {e}")
                 continue
-        
+
         # Final save
         self._save_linking_map(self.supplier_name)
         self.state_manager.save_state(preserve_interruption_state=True)
-        
-        self.log.info(f"✅ Gap processing completed: {len(profitable_results)} profitable products found")
+
+        self.log.info(
+            f"✅ Gap processing completed: {len(profitable_results)} profitable products found"
+        )
         return profitable_results
         """Process the gap products (products in cache but not in linking map)"""
         self.log.info(f"🔄 Starting gap processing for {gap_size} products")
-        
+
         profitable_results = []
-        
+
         # Load cached products
         supplier_cache_file, _ = self._find_actual_supplier_cache_file(self.supplier_name)
         if not supplier_cache_file:
             self.log.error("❌ No supplier cache file found for gap processing")
             return profitable_results
-        
+
         try:
-            with open(supplier_cache_file, 'r', encoding='utf-8') as f:
+            with open(supplier_cache_file, "r", encoding="utf-8") as f:
                 all_cached_products = json.load(f)
         except Exception as e:
             self.log.error(f"❌ Error loading cached products: {e}")
             return profitable_results
-        
+
         # 🚀 HASH OPTIMIZATION: Get products that need processing using O(1) hash lookup
         # Replace O(n) URL set creation with O(1) hash-based processing
         processed_urls_set = self.hash_optimizer.get_processed_urls_set()
-        
+
         gap_products = []
         for product in all_cached_products:
             product_url = product.get("url")
             if product_url and product_url not in processed_urls_set:
                 gap_products.append(product)
-        
-        self.log.info(f"🚀 HASH OPTIMIZATION: Gap processing using O(1) lookups on {len(processed_urls_set)} processed URLs")
-        
+
+        self.log.info(
+            f"🚀 HASH OPTIMIZATION: Gap processing using O(1) lookups on {len(processed_urls_set)} processed URLs"
+        )
+
         self.log.info(f"📊 Found {len(gap_products)} products to process in gap")
-        
+
         # Process gap products
         for i, product_data in enumerate(gap_products[:gap_size]):
-            self.log.info(f"--- Processing gap product {i + 1}/{gap_size}: '{product_data.get('title')}' ---")
-            
+            self.log.info(
+                f"--- Processing gap product {i + 1}/{gap_size}: '{product_data.get('title')}' ---"
+            )
+
             try:
                 amazon_data = await self._get_amazon_data(product_data)
                 if amazon_data and amazon_data.get("asin"):
@@ -2318,82 +3042,96 @@ class PassiveExtractionWorkflow:
                     linking_entry = self._create_linking_map_entry(product_data, amazon_data)
                     # 🚀 HASH OPTIMIZATION: Use optimized method to add entry and update indexes
                     self._add_linking_map_entry_optimized(linking_entry)
-                    
+
                     # Check profitability
                     if self._is_profitable(product_data, amazon_data):
-                        profitable_results.append({
-                            "supplier_data": product_data,
-                            "amazon_data": amazon_data,
-                            "linking_entry": linking_entry
-                        })
+                        profitable_results.append(
+                            {
+                                "supplier_data": product_data,
+                                "amazon_data": amazon_data,
+                                "linking_entry": linking_entry,
+                            }
+                        )
                         self.log.info(f"✅ PROFITABLE GAP: {product_data.get('title')}")
-                    
+
                     # Update gap processing progress
                     self.state_manager.update_gap_processing_progress(
                         i + 1, len(profitable_results), product_data.get("url", "")
                     )
-                
+
             except Exception as e:
                 self.log.error(f"❌ Error processing gap product: {e}")
-        
+
         return profitable_results
 
     def _load_linking_map(self, supplier_name: str) -> List[Dict[str, str]]:
         """Load linking map from supplier-specific JSON file using centralized path management"""
         # Use path_manager for standardized, canonical dotted path construction
         linking_map_path = str(get_linking_map_path(supplier_name=supplier_name))
-        
+
         # Only use canonical path - no fallback patterns
         if os.path.exists(linking_map_path):
             try:
-                with open(linking_map_path, 'r', encoding='utf-8') as f:
+                with open(linking_map_path, "r", encoding="utf-8") as f:
                     raw_data = json.load(f)
-                    
+
                     # Handle both formats: convert old dict format to new array format
                     if isinstance(raw_data, dict):
                         # Old simple format: {"EAN": "ASIN", "EAN2": "ASIN2"} -> convert to array
                         linking_map = []
                         for ean, asin in raw_data.items():
-                            linking_map.append({
-                                "supplier_product_identifier": f"EAN_{ean}",
-                                "supplier_title_snippet": "",
-                                "chosen_amazon_asin": asin,
-                                "amazon_title_snippet": "",
-                                "amazon_ean_on_page": ean,
-                                "match_method": "EAN_cached"
-                            })
-                        self.log.info(f"✅ Converted linking map from dict format to array format from {linking_map_path} with {len(linking_map)} entries")
+                            linking_map.append(
+                                {
+                                    "supplier_product_identifier": f"EAN_{ean}",
+                                    "supplier_title_snippet": "",
+                                    "chosen_amazon_asin": asin,
+                                    "amazon_title_snippet": "",
+                                    "amazon_ean_on_page": ean,
+                                    "match_method": "EAN_cached",
+                                }
+                            )
+                        self.log.info(
+                            f"✅ Converted linking map from dict format to array format from {linking_map_path} with {len(linking_map)} entries"
+                        )
                     elif isinstance(raw_data, list):
                         # New detailed format: [{"supplier_product_identifier": "EAN_123", "chosen_amazon_asin": "ABC", ...}]
                         linking_map = raw_data
-                        self.log.info(f"✅ Loaded linking map (array format) from {linking_map_path} with {len(linking_map)} entries")
+                        self.log.info(
+                            f"✅ Loaded linking map (array format) from {linking_map_path} with {len(linking_map)} entries"
+                        )
                     else:
-                        self.log.error(f"Unexpected linking map format: {type(raw_data)} - Creating new map")
+                        self.log.error(
+                            f"Unexpected linking map format: {type(raw_data)} - Creating new map"
+                        )
                         return []
-                        
+
                     # 🚀 HASH OPTIMIZATION: Build hash indexes for O(1) lookups
                     self.linking_map = linking_map
                     self.hash_optimizer.build_indexes(linking_map)
-                    self.log.info(f"🚀 HASH INDEXES BUILT: Ready for O(1) lookups on {len(linking_map)} entries")
-                    
+                    self.log.info(
+                        f"🚀 HASH INDEXES BUILT: Ready for O(1) lookups on {len(linking_map)} entries"
+                    )
+
                     return linking_map
             except (json.JSONDecodeError, UnicodeDecodeError, Exception) as e:
                 self.log.error(f"Error loading linking map from {linking_map_path}: {e}")
                 return []  # Return empty list on error
-        
+
         # No valid linking map found at canonical path
         self.log.info(f"✅ No existing linking map found at {linking_map_path} - Creating new map")
-        
+
         # 🚀 HASH OPTIMIZATION: Initialize empty hash indexes
         self.linking_map = []
         self.hash_optimizer.build_indexes([])
-        
+
         return []
 
     def _save_linking_map(self, supplier_name: str):
         """Save linking map to supplier-specific JSON file using Windows atomic save"""
-        self.log.info(f"🔍 DEBUG: _save_linking_map called with {len(self.linking_map)} entries for supplier {supplier_name}")
-        
+        self.log.info(
+            f"🔍 DEBUG: _save_linking_map called with {len(self.linking_map)} entries for supplier {supplier_name}"
+        )
+
         # 🚨 SENTINEL MONITORING: Track linking map size before save
         previous_size = 0
         linking_map_path = get_linking_map_path(supplier_name)
@@ -2401,69 +3139,85 @@ class PassiveExtractionWorkflow:
         self.sentinel_monitor.check_path_variants(str(linking_map_path), "linking_map_access")
         if linking_map_path.exists():
             try:
-                with open(linking_map_path, 'r', encoding='utf-8') as f:
+                with open(linking_map_path, "r", encoding="utf-8") as f:
                     existing_data = json.load(f)
                     previous_size = len(existing_data) if isinstance(existing_data, list) else 0
             except Exception as e:
                 self.log.warning(f"⚠️ Could not read existing linking map for size comparison: {e}")
-        
+
         sample_entry = self.linking_map[0] if self.linking_map else {}
-        truncated_sample = {k: str(v)[:50] + '...' if len(str(v)) > 50 else v for k, v in sample_entry.items()}
-        self.log.info(f"🔍 DEBUG: linking_map type: {type(self.linking_map)}, entries: {len(self.linking_map)}, sample: {truncated_sample}")
-        
+        truncated_sample = {
+            k: str(v)[:50] + "..." if len(str(v)) > 50 else v for k, v in sample_entry.items()
+        }
+        self.log.info(
+            f"🔍 DEBUG: linking_map type: {type(self.linking_map)}, entries: {len(self.linking_map)}, sample: {truncated_sample}"
+        )
+
         if not self.linking_map:
-            self.log.warning("⚠️ CRITICAL: Empty linking map - nothing to save. This suggests linking map entries are not being created!")
+            self.log.warning(
+                "⚠️ CRITICAL: Empty linking map - nothing to save. This suggests linking map entries are not being created!"
+            )
             # 🚨 SENTINEL MONITORING: Alert on empty linking map
             self.sentinel_monitor.check_linking_map_shrinkage(0, previous_size)
             return
-            
+
         # Use consistent path naming with get_linking_map_path
         try:
             self.log.info(f"🔍 DEBUG: Target file path: {linking_map_path}")
-            
+
         except Exception as path_error:
             self.log.error(f"❌ CRITICAL: Failed to create linking map path: {path_error}")
             return
-        
+
         # 🔧 ATOMIC SAVE: Use Windows Save Guardian with alt-temp strategy
-        self.log.info(f"🔧 ATOMIC SAVE: Attempting to save {len(self.linking_map)} entries using atomic strategy...")
-        
+        self.log.info(
+            f"🔧 ATOMIC SAVE: Attempting to save {len(self.linking_map)} entries using atomic strategy..."
+        )
+
         try:
             # 🚨 SENTINEL MONITORING: Track save attempt
             current_size = len(self.linking_map)
             save_success = False
             retry_count = 1
-            
+
             # 🛡️ Use Windows Save Guardian with anti-truncation protection
             success = self.save_guardian.save_json_atomic(
-                linking_map_path, 
-                self.linking_map, 
-                min_entries_guard=1000
+                linking_map_path, self.linking_map, min_entries_guard=1000
             )
-            
+
             if success:
                 save_success = True
-                self.log.info(f"✅ Successfully saved linking map with {len(self.linking_map)} entries to {linking_map_path}")
-                
+                self.log.info(
+                    f"✅ Successfully saved linking map with {len(self.linking_map)} entries to {linking_map_path}"
+                )
+
                 # Verify the file was actually created and has content
                 if linking_map_path.exists():
                     file_size = linking_map_path.stat().st_size
-                    self.log.info(f"✅ VERIFICATION: File exists at {linking_map_path} with size {file_size} bytes")
-                    
+                    self.log.info(
+                        f"✅ VERIFICATION: File exists at {linking_map_path} with size {file_size} bytes"
+                    )
+
                     # 🚀 HASH OPTIMIZATION: Rebuild hash indexes after saving linking map
                     self.hash_optimizer.build_indexes(self.linking_map)
-                    self.log.info(f"🚀 HASH INDEXES REBUILT: Updated indexes for {len(self.linking_map)} entries")
-                    
+                    self.log.info(
+                        f"🚀 HASH INDEXES REBUILT: Updated indexes for {len(self.linking_map)} entries"
+                    )
+
                     # 🚨 SENTINEL MONITORING: Check for linking map shrinkage
                     self.sentinel_monitor.check_linking_map_shrinkage(current_size, previous_size)
-                    self.sentinel_monitor.track_save_retry("windows_save_guardian", True, retry_count)
+                    self.sentinel_monitor.track_save_retry(
+                        "windows_save_guardian", True, retry_count
+                    )
                 else:
                     self.log.error(f"❌ CRITICAL: File was not created at {linking_map_path}")
-                    self.sentinel_monitor.track_save_retry("windows_save_guardian", False, retry_count)
+                    self.sentinel_monitor.track_save_retry(
+                        "windows_save_guardian", False, retry_count
+                    )
             else:
                 self.log.error(f"❌ CRITICAL: Windows Save Guardian failed for {linking_map_path}")
                 self.sentinel_monitor.track_save_retry("windows_save_guardian", False, retry_count)
-                
+
         except Exception as e:
             self.log.error(f"❌ CRITICAL: Error in Windows Save Guardian: {e}", exc_info=True)
             self.sentinel_monitor.track_save_retry("windows_save_guardian", False, retry_count)
@@ -2480,32 +3234,36 @@ class PassiveExtractionWorkflow:
         return "neutral"
 
     # ------------------------------------------------------------------
-    def _save_category_manifest(self, supplier_name: str, category_url: str, urls: List[str]) -> str:
+    def _save_category_manifest(
+        self, supplier_name: str, category_url: str, urls: List[str]
+    ) -> str:
         """Persist the ground-truth list of product URLs for a category with atomic write using WindowsSaveGuardian."""
         from utils.normalization import normalize_url
         from utils.windows_save_guardian import WindowsSaveGuardian
         import re
-        
+
         # Generate category slug for consistent naming
-        slug = re.sub(r"[^a-z0-9]+", "-", category_url.lower()).strip("-")[:50]  # Limit length for filesystem
+        slug = re.sub(r"[^a-z0-9]+", "-", category_url.lower()).strip("-")[
+            :50
+        ]  # Limit length for filesystem
         manifest_dir = Path("OUTPUTS") / "manifests" / supplier_name
         manifest_dir.mkdir(parents=True, exist_ok=True)
         manifest_path = manifest_dir / f"{slug}.json"
-        
+
         # Normalize URLs for consistency
         normalized_urls = [normalize_url(u) for u in urls]
-        
+
         # Check for existing manifest to detect overwrites
         overwritten = False
         prev_count = None
         if manifest_path.exists():
             try:
-                prev_data = json.loads(manifest_path.read_text(encoding='utf-8'))
+                prev_data = json.loads(manifest_path.read_text(encoding="utf-8"))
                 prev_count = prev_data.get("count", 0)
                 overwritten = True
             except Exception as e:
                 self.log.warning(f"Could not read existing manifest for {category_url}: {e}")
-        
+
         # Create manifest document with all required fields
         doc = {
             "category_url": category_url,
@@ -2513,7 +3271,7 @@ class PassiveExtractionWorkflow:
             "product_urls": normalized_urls,
             "count": len(normalized_urls),
             "supplier_name": supplier_name,
-            "slug": slug
+            "slug": slug,
         }
 
     def _normalize_url_for_filtering(self, url):
@@ -2532,57 +3290,61 @@ class PassiveExtractionWorkflow:
             clean_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
 
             # Remove 'www.' prefix for consistency
-            clean_url = re.sub(r'^(https?://)www\.', r'\1', clean_url)
+            clean_url = re.sub(r"^(https?://)www\.", r"\1", clean_url)
 
             # Standardize case and remove trailing slash
-            clean_url = clean_url.lower().rstrip('/')
+            clean_url = clean_url.lower().rstrip("/")
 
             return clean_url
 
         except Exception as e:
             log.debug(f"URL normalization failed for '{url}': {e}")
-            return url.lower().rstrip('/')  # Basic fallback
-        
+            return url.lower().rstrip("/")  # Basic fallback
+
         # Use WindowsSaveGuardian for atomic write
         guardian = WindowsSaveGuardian()
         success = guardian.save_json_atomic(manifest_path, doc)
-        
+
         if success:
             # Log manifest save with appropriate format
             self.log.info(f"📝 MANIFEST: {len(normalized_urls)} URLs → {manifest_path}")
-            
+
             # Log manifest overwrite if applicable
             if overwritten and prev_count is not None:
                 # Generate category index for logging (approximate from current processing state)
-                category_index = getattr(self, '_current_category_index', 0)
-                self.log.info(f"MANIFEST UPDATE[C{category_index} {slug}]: overwritten=true prev={prev_count} curr={len(normalized_urls)}")
-                
+                category_index = getattr(self, "_current_category_index", 0)
+                self.log.info(
+                    f"MANIFEST UPDATE[C{category_index} {slug}]: overwritten=true prev={prev_count} curr={len(normalized_urls)}"
+                )
+
                 # Log count mismatch warning if significant difference
                 if abs(prev_count - len(normalized_urls)) > 0:
-                    self.log.warning(f"MANIFEST COUNT CHANGE: {category_url} changed from {prev_count} to {len(normalized_urls)} URLs")
-            
+                    self.log.warning(
+                        f"MANIFEST COUNT CHANGE: {category_url} changed from {prev_count} to {len(normalized_urls)} URLs"
+                    )
+
             return str(manifest_path)
         else:
             self.log.error(f"❌ Failed to save manifest for {category_url}")
             raise RuntimeError(f"Failed to save category manifest: {manifest_path}")
-    
+
     def _set_current_category_index(self, index: int):
         """Set current category index for manifest logging."""
         self._current_category_index = index
-    
+
     def _generate_category_slug(self, category_url: str) -> str:
         """Generate readable slug from category URL path"""
         try:
             from urllib.parse import urlparse
             import re
-            
+
             # Parse URL and extract path
             parsed = urlparse(category_url)
-            path = parsed.path.strip('/')
-            
+            path = parsed.path.strip("/")
+
             # Get the last meaningful part of the path
             if path:
-                path_parts = path.split('/')
+                path_parts = path.split("/")
                 # Take the last part, or second-to-last if last is very short
                 if len(path_parts) > 1 and len(path_parts[-1]) < 5:
                     slug_base = path_parts[-2] if len(path_parts) > 1 else path_parts[-1]
@@ -2590,37 +3352,42 @@ class PassiveExtractionWorkflow:
                     slug_base = path_parts[-1]
             else:
                 # Fallback to domain if no path
-                slug_base = parsed.netloc.replace('www.', '').replace('.', '-')
-            
+                slug_base = parsed.netloc.replace("www.", "").replace(".", "-")
+
             # Clean up the slug
-            slug = re.sub(r'[^a-z0-9]+', '-', slug_base.lower()).strip('-')
-            
+            slug = re.sub(r"[^a-z0-9]+", "-", slug_base.lower()).strip("-")
+
             # Limit length and ensure it's not empty
-            slug = slug[:30] if slug else 'unknown'
-            
+            slug = slug[:30] if slug else "unknown"
+
             return slug
-            
+
         except Exception as e:
             self.log.warning(f"Failed to generate slug for {category_url}: {e}")
-            return 'unknown'
-    
-    def _create_normalized_linking_entry(self, product_data: Dict[str, Any], amazon_data: Dict[str, Any], 
-                                       confidence: str = "medium", search_method: str = "unknown") -> Dict[str, Any]:
+            return "unknown"
+
+    def _create_normalized_linking_entry(
+        self,
+        product_data: Dict[str, Any],
+        amazon_data: Dict[str, Any],
+        confidence: str = "medium",
+        search_method: str = "unknown",
+    ) -> Dict[str, Any]:
         """Create a normalized linking map entry with consistent EAN and URL normalization."""
         from utils.normalization import normalize_url, normalize_ean
-        
+
         # Extract and normalize EAN
         supplier_ean = product_data.get("ean") or product_data.get("barcode")
         if supplier_ean == "None" or supplier_ean is None:
             supplier_ean = None
         else:
             supplier_ean = normalize_ean(supplier_ean)
-        
+
         # Extract and normalize URL
         supplier_url = product_data.get("url")
         if supplier_url:
             supplier_url = normalize_url(supplier_url)
-        
+
         # Create normalized linking entry
         linking_entry = {
             "supplier_ean": supplier_ean,
@@ -2630,16 +3397,18 @@ class PassiveExtractionWorkflow:
             "amazon_title": amazon_data.get("title"),
             "confidence": confidence,
             "search_method": search_method,
-            "created_at": datetime.utcnow().isoformat() + "Z"
+            "created_at": datetime.utcnow().isoformat() + "Z",
         }
-        
+
         return linking_entry
 
     async def _collect_urls_only(self, category_url: str, max_products: int) -> List[str]:
         """Collect product URLs only without extracting product data"""
         try:
             # Use the scraper's URL collection method without product extraction
-            all_product_urls = await self.supplier_scraper._collect_all_product_urls(category_url, max_products)
+            all_product_urls = await self.supplier_scraper._collect_all_product_urls(
+                category_url, max_products
+            )
 
             # Store the discovered count for state manager integration
             self.supplier_scraper.last_discovered_count = len(all_product_urls)
@@ -2651,8 +3420,10 @@ class PassiveExtractionWorkflow:
 
     # Removed _scrape_with_retries_filtered method - confirmed broken and leads to extraction failures
     # Use _scrape_with_retries instead for successful product extraction per project memory
-    
-    def _load_cached_products_for_urls(self, urls: List[str], supplier_name: str) -> List[Dict[str, Any]]:
+
+    def _load_cached_products_for_urls(
+        self, urls: List[str], supplier_name: str
+    ) -> List[Dict[str, Any]]:
         """Load cached products for specific URLs that need Amazon analysis only"""
         try:
             # Load supplier cache
@@ -2660,24 +3431,28 @@ class PassiveExtractionWorkflow:
             if not actual_cache_file:
                 self.log.warning(f"No cache file found for {supplier_name}")
                 return []
-            
-            with open(actual_cache_file, 'r', encoding='utf-8') as f:
+
+            with open(actual_cache_file, "r", encoding="utf-8") as f:
                 cached_products = json.load(f)
-            
+
             # Filter to only products with URLs in the specified list
             matching_products = []
             for product in cached_products:
-                if product.get('url') in urls:
+                if product.get("url") in urls:
                     matching_products.append(product)
-            
-            self.log.info(f"📋 CACHE LOAD: Found {len(matching_products)} cached products for {len(urls)} URLs")
+
+            self.log.info(
+                f"📋 CACHE LOAD: Found {len(matching_products)} cached products for {len(urls)} URLs"
+            )
             return matching_products
-            
+
         except Exception as e:
             self.log.error(f"Failed to load cached products for URLs: {e}")
             return []
 
-    async def _scrape_with_retries(self, url: str, max_products_per_category: int, product_accumulator: List[Dict[str, Any]]):
+    async def _scrape_with_retries(
+        self, url: str, max_products_per_category: int, product_accumulator: List[Dict[str, Any]]
+    ):
         """Wrapper around supplier scraper with exponential backoff retries."""
         from tenacity import retry, stop_after_attempt, wait_exponential, before_sleep_log
         import logging
@@ -2697,9 +3472,9 @@ class PassiveExtractionWorkflow:
     # ──────────────────────── ③  Enhanced State tracking helpers ──────────────────────
     def _load_history(self):
         """Load comprehensive scraping history to prevent duplicate processing"""
-        if self.state_path and Path(self.state_path).exists(): # MODIFIED HERE
+        if self.state_path and Path(self.state_path).exists():  # MODIFIED HERE
             try:
-                history = json.loads(Path(self.state_path).read_text()) # AND HERE for consistency
+                history = json.loads(Path(self.state_path).read_text())  # AND HERE for consistency
                 # Ensure all required keys exist with backward compatibility
                 default_history = {
                     "categories_scraped": [],
@@ -2712,7 +3487,7 @@ class PassiveExtractionWorkflow:
                     "scrape_sessions": [],
                     "category_performance": {},
                     "url_hash_cache": {},
-                    "ai_decision_history": []  # New field for AI decisions
+                    "ai_decision_history": [],  # New field for AI decisions
                 }
                 # Merge with defaults to handle missing keys
                 for key, default_value in default_history.items():
@@ -2735,10 +3510,12 @@ class PassiveExtractionWorkflow:
             Dictionary containing AI memory data
         """
         try:
-            ai_cache_file = os.path.join(AI_CATEGORY_CACHE_DIR, f"{supplier_name.replace('.', '_')}_ai_category_cache.json")
+            ai_cache_file = os.path.join(
+                AI_CATEGORY_CACHE_DIR, f"{supplier_name.replace('.', '_')}_ai_category_cache.json"
+            )
 
             if os.path.exists(ai_cache_file):
-                with open(ai_cache_file, 'r', encoding='utf-8') as f:
+                with open(ai_cache_file, "r", encoding="utf-8") as f:
                     content = f.read().strip()
                     if not content or content == "{}":  # File is empty or just empty JSON
                         log.info(f"🧠 AI cache file is empty for {supplier_name} - starting fresh")
@@ -2748,7 +3525,7 @@ class PassiveExtractionWorkflow:
                             "total_products_processed": 0,
                             "ai_history": [],
                             "total_ai_calls": 0,
-                            "price_phase": "low"
+                            "price_phase": "low",
                         }
                     ai_cache_data = json.loads(content)
 
@@ -2771,7 +3548,9 @@ class PassiveExtractionWorkflow:
                     session_context = entry.get("session_context", {})
                     total_products_processed += session_context.get("total_products_processed", 0)
 
-                log.info(f"🧠 AI Memory loaded: {len(previously_suggested_urls)} previously suggested URLs, {total_products_processed} products processed")
+                log.info(
+                    f"🧠 AI Memory loaded: {len(previously_suggested_urls)} previously suggested URLs, {total_products_processed} products processed"
+                )
                 log.debug(f"🧠 Previously suggested URLs: {list(previously_suggested_urls)}")
 
                 return {
@@ -2779,7 +3558,7 @@ class PassiveExtractionWorkflow:
                     "total_products_processed": total_products_processed,
                     "ai_history": ai_history,
                     "total_ai_calls": ai_cache_data.get("total_ai_calls", 0),
-                    "price_phase": ai_cache_data.get("price_phase", "low")  # Default to Phase 1
+                    "price_phase": ai_cache_data.get("price_phase", "low"),  # Default to Phase 1
                 }
             else:
                 log.info(f"🧠 No AI cache file found for {supplier_name} - starting fresh")
@@ -2793,7 +3572,7 @@ class PassiveExtractionWorkflow:
             "total_products_processed": 0,
             "ai_history": [],
             "total_ai_calls": 0,
-            "price_phase": "low"  # Default to Phase 1
+            "price_phase": "low",  # Default to Phase 1
         }
 
     def _get_default_history(self):
@@ -2809,7 +3588,7 @@ class PassiveExtractionWorkflow:
             "scrape_sessions": [],
             "category_performance": {},
             "url_hash_cache": {},
-            "ai_decision_history": []  # New field for AI decisions
+            "ai_decision_history": [],  # New field for AI decisions
         }
 
     async def _get_predefined_categories(self, supplier_name: str) -> list:
@@ -2817,13 +3596,19 @@ class PassiveExtractionWorkflow:
         log.info(f"Attempting to load predefined categories for {supplier_name}")
         try:
             # Robust path construction using pathlib
-            config_path = Path(__file__).parent.parent / "config" / f"{supplier_name.replace('.co.uk', '')}_categories.json"
-            
+            config_path = (
+                Path(__file__).parent.parent
+                / "config"
+                / f"{supplier_name.replace('.co.uk', '')}_categories.json"
+            )
+
             if config_path.exists():
-                with open(config_path, 'r', encoding='utf-8') as f:
+                with open(config_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
                     category_urls = data.get("category_urls", [])
-                    log.info(f"✅ Successfully loaded {len(category_urls)} predefined category URLs from {config_path}")
+                    log.info(
+                        f"✅ Successfully loaded {len(category_urls)} predefined category URLs from {config_path}"
+                    )
                     return category_urls
             else:
                 log.warning(f"⚠️ Predefined category file not found at {config_path}")
@@ -2843,19 +3628,21 @@ class PassiveExtractionWorkflow:
         if self.state_path:
             # Add current timestamp
             hist["last_scrape_timestamp"] = datetime.now().isoformat()
-            
+
             # Use atomic write to prevent corruption
             # Ensure self.state_path is a Path object for .with_suffix and os.replace
             state_path_obj = Path(self.state_path)
             temp_path = state_path_obj.with_suffix(".tmp")
             try:
-                with open(temp_path, 'w', encoding='utf-8') as f:
+                with open(temp_path, "w", encoding="utf-8") as f:
                     json.dump(hist, f, indent=2, ensure_ascii=False)
-                os.replace(temp_path, state_path_obj) # Use Path object here too
-                log.debug(f"History saved with {len(hist.get('categories_scraped', []))} categories, {len(hist.get('pages_visited', []))} pages")
+                os.replace(temp_path, state_path_obj)  # Use Path object here too
+                log.debug(
+                    f"History saved with {len(hist.get('categories_scraped', []))} categories, {len(hist.get('pages_visited', []))} pages"
+                )
             except Exception as e:
                 log.error(f"Failed to save history: {e}")
-                if os.path.exists(temp_path): # os.path.exists is fine for string or Path
+                if os.path.exists(temp_path):  # os.path.exists is fine for string or Path
                     try:
                         os.remove(temp_path)
                     except:
@@ -2863,13 +3650,15 @@ class PassiveExtractionWorkflow:
 
     def _record_ai_decision(self, hist: dict, ai_response: dict):
         """Record AI decision for future reference and learning"""
-        hist.setdefault("ai_decision_history", []).append({
-            "timestamp": datetime.utcnow().isoformat(timespec="seconds"),
-            "categories_suggested": ai_response["top_3_urls"],
-            "skip_urls": ai_response["skip_urls"],
-            "reasoning": ai_response.get("detailed_reasoning", {}),
-            "progression_strategy": ai_response.get("progression_strategy", "unknown")
-        })
+        hist.setdefault("ai_decision_history", []).append(
+            {
+                "timestamp": datetime.utcnow().isoformat(timespec="seconds"),
+                "categories_suggested": ai_response["top_3_urls"],
+                "skip_urls": ai_response["skip_urls"],
+                "reasoning": ai_response.get("detailed_reasoning", {}),
+                "progression_strategy": ai_response.get("progression_strategy", "unknown"),
+            }
+        )
         # DEPRECATED: Replaced by EnhancedStateManager to prevent state conflicts
         # self._save_history(hist)
 
@@ -2877,7 +3666,7 @@ class PassiveExtractionWorkflow:
         """Check if URL has been previously scraped using multiple tracking methods"""
         if not url:
             return False
-            
+
         # Direct URL check
         if url in hist.get("categories_scraped", []):
             return True
@@ -2885,34 +3674,36 @@ class PassiveExtractionWorkflow:
             return True
         if url in hist.get("subpages_scraped", []):
             return True
-            
+
         # URL hash check for similar URLs (handles pagination, query params)
         import hashlib
+
         url_hash = hashlib.md5(url.encode()).hexdigest()
         if url_hash in hist.get("url_hash_cache", {}):
             cached_url = hist["url_hash_cache"][url_hash]
             log.debug(f"URL hash match found: {url} matches previously scraped {cached_url}")
             return True
-            
+
         # Normalize URL and check (remove trailing slashes, query params for base comparison)
         from urllib.parse import urlparse, parse_qs
+
         parsed = urlparse(url)
         base_url = f"{parsed.scheme}://{parsed.netloc}{parsed.path.rstrip('/')}"
-        
+
         for scraped_url in hist.get("categories_scraped", []) + hist.get("pages_visited", []):
             scraped_parsed = urlparse(scraped_url)
             scraped_base = f"{scraped_parsed.scheme}://{scraped_parsed.netloc}{scraped_parsed.path.rstrip('/')}"
             if base_url == scraped_base:
                 log.debug(f"Base URL match: {url} matches {scraped_url}")
                 return True
-                
+
         return False
 
     def _add_url_to_history(self, url: str, hist: dict, url_type: str = "page"):
         """Add URL to appropriate history list and hash cache"""
         if not url:
             return
-            
+
         # Add to appropriate list
         if url_type == "category":
             if url not in hist.get("categories_scraped", []):
@@ -2923,12 +3714,13 @@ class PassiveExtractionWorkflow:
         else:  # default to pages_visited
             if url not in hist.get("pages_visited", []):
                 hist.setdefault("pages_visited", []).append(url)
-        
+
         # Add to hash cache
         import hashlib
+
         url_hash = hashlib.md5(url.encode()).hexdigest()
         hist.setdefault("url_hash_cache", {})[url_hash] = url
-        
+
         log.debug(f"Added {url_type} URL to history: {url}")
 
     def _record_category_performance(self, category_url: str, products_found: int, hist: dict):
@@ -2936,7 +3728,7 @@ class PassiveExtractionWorkflow:
         hist.setdefault("category_performance", {})[category_url] = {
             "products_found": products_found,
             "last_scraped": datetime.now().isoformat(),
-            "performance_score": min(products_found / 10.0, 1.0)  # Normalize to 0-1 scale
+            "performance_score": min(products_found / 10.0, 1.0),  # Normalize to 0-1 scale
         }
 
     def _get_category_performance_summary(self, hist: dict) -> str:
@@ -2944,16 +3736,20 @@ class PassiveExtractionWorkflow:
         performance = hist.get("category_performance", {})
         if not performance:
             return "No previous category performance data available."
-        
+
         summary_lines = ["Previous category performance:"]
-        sorted_categories = sorted(performance.items(), key=lambda x: x[1]["performance_score"], reverse=True)
-        
+        sorted_categories = sorted(
+            performance.items(), key=lambda x: x[1]["performance_score"], reverse=True
+        )
+
         for url, metrics in sorted_categories[:5]:  # Top 5 performing categories
-            summary_lines.append(f"- {url}: {metrics['products_found']} products (score: {metrics['performance_score']:.2f})")
-        
+            summary_lines.append(
+                f"- {url}: {metrics['products_found']} products (score: {metrics['performance_score']:.2f})"
+            )
+
         if len(sorted_categories) > 5:
             summary_lines.append(f"... and {len(sorted_categories) - 5} more categories")
-            
+
         return "\n".join(summary_lines)
 
     # ──────────────────────── PHASE 3: SUBCATEGORY DEDUPLICATION ──────────────────────────
@@ -2961,70 +3757,74 @@ class PassiveExtractionWorkflow:
         """
         Detect parent-child URL relationships to prevent double processing.
         Returns dict where keys are parent URLs and values are lists of child URLs.
-        
+
         Example:
         Input: ['/health-beauty.html', '/health-beauty/cosmetics.html', '/gifts-toys.html']
         Output: {'/health-beauty.html': ['/health-beauty/cosmetics.html'], '/gifts-toys.html': []}
         """
         from urllib.parse import urlparse
-        
+
         parent_child_map = {}
         processed_urls = set()
-        
+
         # Sort URLs by path depth (shorter paths first)
-        sorted_urls = sorted(urls, key=lambda url: urlparse(url).path.count('/'))
-        
+        sorted_urls = sorted(urls, key=lambda url: urlparse(url).path.count("/"))
+
         for url in sorted_urls:
             if url in processed_urls:
                 continue
-                
+
             parsed_url = urlparse(url)
-            url_path = parsed_url.path.rstrip('/')
-            
+            url_path = parsed_url.path.rstrip("/")
+
             # Find potential child URLs
             child_urls = []
             for other_url in sorted_urls:
                 if other_url == url or other_url in processed_urls:
                     continue
-                    
+
                 other_parsed = urlparse(other_url)
-                other_path = other_parsed.path.rstrip('/')
-                
+                other_path = other_parsed.path.rstrip("/")
+
                 # Check if other_url is a child of current url
                 # Child URL should start with parent path + '/'
-                if other_path.startswith(url_path + '/') and other_path != url_path:
+                if other_path.startswith(url_path + "/") and other_path != url_path:
                     # Additional validation: ensure it's direct child, not grandchild
-                    remaining_path = other_path[len(url_path + '/'):]
-                    if '/' not in remaining_path or remaining_path.count('/') <= 1:
+                    remaining_path = other_path[len(url_path + "/") :]
+                    if "/" not in remaining_path or remaining_path.count("/") <= 1:
                         child_urls.append(other_url)
                         processed_urls.add(other_url)
-            
+
             parent_child_map[url] = child_urls
             processed_urls.add(url)
-            
-        log.info(f"Parent-child URL analysis: {len(parent_child_map)} parent categories, "
-                f"{sum(len(children) for children in parent_child_map.values())} child categories")
-        
+
+        log.info(
+            f"Parent-child URL analysis: {len(parent_child_map)} parent categories, "
+            f"{sum(len(children) for children in parent_child_map.values())} child categories"
+        )
+
         return parent_child_map
 
-    async def _filter_urls_by_subcategory_deduplication(self, category_urls: List[str]) -> List[str]:
+    async def _filter_urls_by_subcategory_deduplication(
+        self, category_urls: List[str]
+    ) -> List[str]:
         """
         Apply subcategory deduplication logic: only include subcategories if parent category has <2 products.
-        
+
         This prevents double processing of URLs like:
         - /health-beauty.html AND /health-beauty/cosmetics.html
         - /gifts-toys.html AND /gifts-toys/toys-games.html
         """
         if not category_urls:
             return category_urls
-            
+
         # Detect parent-child relationships
         parent_child_map = self._detect_parent_child_urls(category_urls)
-        
+
         # Validate each parent category for product count
         filtered_urls = []
         validation_cache = {}  # Cache validation results to avoid duplicate checks
-        
+
         for parent_url, child_urls in parent_child_map.items():
             # Check parent category product count (use cache if available)
             if parent_url not in validation_cache:
@@ -3032,25 +3832,31 @@ class PassiveExtractionWorkflow:
                 validation_cache[parent_url] = validation_result
             else:
                 validation_result = validation_cache[parent_url]
-            
+
             parent_product_count = validation_result.get("product_count", 0)
-            
+
             # CORE LOGIC: Apply subcategory deduplication rule
             if parent_product_count >= 2:
                 # Parent has sufficient products - skip subcategories, use pagination only
                 filtered_urls.append(parent_url)
-                log.info(f"✅ PARENT CATEGORY SUFFICIENT: {parent_url} ({parent_product_count} products) "
-                        f"- SKIPPING {len(child_urls)} subcategories: {child_urls}")
+                log.info(
+                    f"✅ PARENT CATEGORY SUFFICIENT: {parent_url} ({parent_product_count} products) "
+                    f"- SKIPPING {len(child_urls)} subcategories: {child_urls}"
+                )
             else:
                 # Parent has <2 products - include subcategories for more products
                 filtered_urls.append(parent_url)
                 filtered_urls.extend(child_urls)
-                log.info(f"⚠️  PARENT CATEGORY INSUFFICIENT: {parent_url} ({parent_product_count} products) "
-                        f"- INCLUDING {len(child_urls)} subcategories: {child_urls}")
-        
-        log.info(f"SUBCATEGORY DEDUPLICATION: Reduced {len(category_urls)} URLs to {len(filtered_urls)} "
-                f"(eliminated {len(category_urls) - len(filtered_urls)} redundant subcategories)")
-        
+                log.info(
+                    f"⚠️  PARENT CATEGORY INSUFFICIENT: {parent_url} ({parent_product_count} products) "
+                    f"- INCLUDING {len(child_urls)} subcategories: {child_urls}"
+                )
+
+        log.info(
+            f"SUBCATEGORY DEDUPLICATION: Reduced {len(category_urls)} URLs to {len(filtered_urls)} "
+            f"(eliminated {len(category_urls) - len(filtered_urls)} redundant subcategories)"
+        )
+
         return filtered_urls
 
     # ──────────────────────── ②  Enhanced AI method ──────────────────────────
@@ -3069,14 +3875,18 @@ class PassiveExtractionWorkflow:
         available_categories = []
         for c in discovered_categories:
             if (
-                self._classify_url(c["url"]) == "friendly" and
-                c["url"] not in prev_cats and
-                not any(prev_url in c["url"] or c["url"] in prev_url for prev_url in prev_cats)
+                self._classify_url(c["url"]) == "friendly"
+                and c["url"] not in prev_cats
+                and not any(prev_url in c["url"] or c["url"] in prev_url for prev_url in prev_cats)
             ):
                 available_categories.append(c)
 
         # Limit to reasonable number for AI processing
-        category_limit = self.system_config.get("ai_features", {}).get("category_selection", {}).get("max_categories_per_request", 3)
+        category_limit = (
+            self.system_config.get("ai_features", {})
+            .get("category_selection", {})
+            .get("max_categories_per_request", 3)
+        )
         friendly = available_categories[:category_limit]
         formatted = "\n".join(f'- {c["name"]}: {c["url"]}' for c in friendly)
 
@@ -3086,7 +3896,9 @@ class PassiveExtractionWorkflow:
             memory_context = f"\n\n🧠 IMPORTANT - PREVIOUSLY SUGGESTED CATEGORIES (DO NOT REPEAT):\n"
             for i, prev_cat in enumerate(prev_cats[-10:], 1):  # Show last 10 to avoid token limit
                 memory_context += f"{i}. {prev_cat}\n"
-            memory_context += "\n⚠️ You MUST suggest DIFFERENT categories that have NOT been suggested before!"
+            memory_context += (
+                "\n⚠️ You MUST suggest DIFFERENT categories that have NOT been suggested before!"
+            )
 
         # Add failure tracking from AI memory
         ai_memory = self._load_ai_memory(supplier_name)
@@ -3199,7 +4011,9 @@ Return ONLY valid JSON, no additional text."""
         # Log API call details for debugging
         log.info(f"🤖 OpenAI API Call - Model: {model_to_use}, Max Tokens: 1200")
         log.info(f"🤖 Prompt Length: {len(prompt)} characters")
-        log.debug(f"🤖 Full Prompt: {prompt[:500]}..." if len(prompt) > 500 else f"🤖 Full Prompt: {prompt}")
+        log.debug(
+            f"🤖 Full Prompt: {prompt[:500]}..." if len(prompt) > 500 else f"🤖 Full Prompt: {prompt}"
+        )
 
         raw = await asyncio.to_thread(
             self.ai_client.chat.completions.create,
@@ -3210,8 +4024,10 @@ Return ONLY valid JSON, no additional text."""
         )
 
         # Log token usage
-        if hasattr(raw, 'usage') and raw.usage:
-            log.info(f"🤖 Token Usage - Input: {raw.usage.prompt_tokens}, Output: {raw.usage.completion_tokens}, Total: {raw.usage.total_tokens}")
+        if hasattr(raw, "usage") and raw.usage:
+            log.info(
+                f"🤖 Token Usage - Input: {raw.usage.prompt_tokens}, Output: {raw.usage.completion_tokens}, Total: {raw.usage.total_tokens}"
+            )
 
         # Save detailed API call log
         self._save_api_call_log(prompt, raw, model_to_use, "category_suggestion")
@@ -3225,34 +4041,47 @@ Return ONLY valid JSON, no additional text."""
                 self.log.warning(f"AI JSON missing keys: {required - set(ai)} - adding defaults")
                 # Add missing keys with defaults
                 if "top_3_urls" not in ai:
-                    ai["top_3_urls"] = [c["url"] for c in discovered_categories
-                                      if self._classify_url(c["url"]) == "friendly"
-                                      and c["url"] not in (previous_categories or [])][:3]
+                    ai["top_3_urls"] = [
+                        c["url"]
+                        for c in discovered_categories
+                        if self._classify_url(c["url"]) == "friendly"
+                        and c["url"] not in (previous_categories or [])
+                    ][:3]
                 if "secondary_urls" not in ai:
                     ai["secondary_urls"] = []
                 if "skip_urls" not in ai:
                     ai["skip_urls"] = []
-            
+
             # Ensure lists are actually lists
             for key in ["top_3_urls", "secondary_urls", "skip_urls"]:
                 if not isinstance(ai[key], list):
                     self.log.warning(f"AI JSON '{key}' is not a list - fixing")
                     ai[key] = [ai[key]] if ai[key] else []
-                    
+
         except Exception as e:
             self.log.error("AI JSON invalid → %s – falling back to heuristic list", e)
-            friendly_urls = [c["url"] for c in discovered_categories
-                             if self._classify_url(c["url"]) == "friendly"
-                             and c["url"] not in (previous_categories or [])][:3]
-            ai = {"top_3_urls": friendly_urls,
-                  "secondary_urls": [],
-                  "skip_urls": [],
-                  "detailed_reasoning": {"fallback": "heuristic-friendly"},
-                  "progression_strategy": "simple-first-3"}
+            friendly_urls = [
+                c["url"]
+                for c in discovered_categories
+                if self._classify_url(c["url"]) == "friendly"
+                and c["url"] not in (previous_categories or [])
+            ][:3]
+            ai = {
+                "top_3_urls": friendly_urls,
+                "secondary_urls": [],
+                "skip_urls": [],
+                "detailed_reasoning": {"fallback": "heuristic-friendly"},
+                "progression_strategy": "simple-first-3",
+            }
 
         # hard filter avoid patterns
         ai["top_3_urls"] = [u for u in ai["top_3_urls"] if self._classify_url(u) != "avoid"]
-        ai["skip_urls"]  = list(set(ai.get("skip_urls",[]) + [u for u in ai["top_3_urls"] if self._classify_url(u)=="avoid"]))
+        ai["skip_urls"] = list(
+            set(
+                ai.get("skip_urls", [])
+                + [u for u in ai["top_3_urls"] if self._classify_url(u) == "avoid"]
+            )
+        )
         return ai
 
     async def _validate_category_productivity(self, url: str) -> dict:
@@ -3268,20 +4097,23 @@ Return ONLY valid JSON, no additional text."""
                         "url": url,
                         "product_count": 0,
                         "is_productive": False,
-                        "error": f"HTTP {response.status}"
+                        "error": f"HTTP {response.status}",
                     }
 
                 html_content = await response.text()
 
             # Use the same product detection logic as the scraper
             from bs4 import BeautifulSoup
-            soup = BeautifulSoup(html_content, 'html.parser')
+
+            soup = BeautifulSoup(html_content, "html.parser")
 
             # Try configured selectors first
             product_elements = []
             try:
                 supplier_config = self.web_scraper.get_supplier_config(url)
-                if supplier_config and supplier_config.get("selectors", {}).get("product_container"):
+                if supplier_config and supplier_config.get("selectors", {}).get(
+                    "product_container"
+                ):
                     product_selector = supplier_config["selectors"]["product_container"]
                     product_elements = soup.select(product_selector)
             except Exception as e:
@@ -3290,11 +4122,11 @@ Return ONLY valid JSON, no additional text."""
             # Fallback to generic selectors if no configured ones work
             if not product_elements:
                 generic_selectors = [
-                    'div.product',
-                    '.product-item',
-                    '.product-container',
+                    "div.product",
+                    ".product-item",
+                    ".product-container",
                     '[class*="product"]',
-                    '.item'
+                    ".item",
                 ]
                 for selector in generic_selectors:
                     product_elements = soup.select(selector)
@@ -3304,23 +4136,20 @@ Return ONLY valid JSON, no additional text."""
             product_count = len(product_elements)
             is_productive = product_count >= 2  # Minimum 2 products required
 
-            log.info(f"Category validation: {url} -> {product_count} products (productive: {is_productive})")
+            log.info(
+                f"Category validation: {url} -> {product_count} products (productive: {is_productive})"
+            )
 
             return {
                 "url": url,
                 "product_count": product_count,
                 "is_productive": is_productive,
-                "validation_method": "product_count_check"
+                "validation_method": "product_count_check",
             }
 
         except Exception as e:
             log.warning(f"Category productivity validation failed for {url}: {e}")
-            return {
-                "url": url,
-                "product_count": 0,
-                "is_productive": False,
-                "error": str(e)
-            }
+            return {"url": url, "product_count": 0, "is_productive": False, "error": str(e)}
 
     def _optimize_category_urls(self, urls: list, price_range: str = "low") -> list:
         """DEPRECATED: URL optimization is now handled by supplier-specific extraction scripts"""
@@ -3352,6 +4181,7 @@ Return ONLY valid JSON, no additional text."""
 
             # Create API logs directory using proper path management (claude.md standards)
             from utils.path_manager import get_api_log_path
+
             log_file = get_api_log_path("openai")  # This creates the proper path
 
             # Create log entry
@@ -3361,17 +4191,25 @@ Return ONLY valid JSON, no additional text."""
                 "model": model,
                 "prompt_length": len(prompt),
                 "prompt": prompt,
-                "response_content": response.choices[0].message.content if response.choices else "No response",
+                "response_content": response.choices[0].message.content
+                if response.choices
+                else "No response",
                 "usage": {
-                    "prompt_tokens": response.usage.prompt_tokens if hasattr(response, 'usage') and response.usage else 0,
-                    "completion_tokens": response.usage.completion_tokens if hasattr(response, 'usage') and response.usage else 0,
-                    "total_tokens": response.usage.total_tokens if hasattr(response, 'usage') and response.usage else 0
-                }
+                    "prompt_tokens": response.usage.prompt_tokens
+                    if hasattr(response, "usage") and response.usage
+                    else 0,
+                    "completion_tokens": response.usage.completion_tokens
+                    if hasattr(response, "usage") and response.usage
+                    else 0,
+                    "total_tokens": response.usage.total_tokens
+                    if hasattr(response, "usage") and response.usage
+                    else 0,
+                },
             }
 
             # Save to daily log file (already created by get_api_log_path)
-            with open(log_file, 'a', encoding='utf-8') as f:
-                f.write(json.dumps(log_entry, ensure_ascii=False) + '\n')
+            with open(log_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(log_entry, ensure_ascii=False) + "\n")
 
             log.info(f"💾 API call logged to {log_file}")
 
@@ -3387,7 +4225,9 @@ Return ONLY valid JSON, no additional text."""
         # Default to Phase 1 (low price range)
         return "low"
 
-    def _store_phase_2_continuation_point(self, category_url: str, page_num: int, products_scraped: int):
+    def _store_phase_2_continuation_point(
+        self, category_url: str, page_num: int, products_scraped: int
+    ):
         """Store pagination state for Phase 2 continuation"""
         try:
             from utils.path_manager import get_phase_continuation_path
@@ -3400,18 +4240,18 @@ Return ONLY valid JSON, no additional text."""
             continuation_data = {}
             if continuation_file.exists():
                 try:
-                    with open(continuation_file, 'r', encoding='utf-8') as f:
+                    with open(continuation_file, "r", encoding="utf-8") as f:
                         continuation_data = json.load(f)
                 except Exception as e:
                     log.warning(f"Could not load continuation points: {e}")
 
             # Store continuation point for this category
-            base_url = category_url.split('?')[0]  # Remove any existing parameters
+            base_url = category_url.split("?")[0]  # Remove any existing parameters
             continuation_data[base_url] = {
                 "last_page": page_num,
                 "products_scraped": products_scraped,
                 "timestamp": datetime.now().isoformat(),
-                "phase_1_complete": True
+                "phase_1_complete": True,
             }
 
             # Save updated continuation points using atomic save
@@ -3419,7 +4259,9 @@ Return ONLY valid JSON, no additional text."""
             if not success:
                 self.log.error(f"❌ Failed to save continuation data to {continuation_file}")
 
-            log.info(f"📍 Stored Phase 2 continuation point for {base_url}: page {page_num}, {products_scraped} products")
+            log.info(
+                f"📍 Stored Phase 2 continuation point for {base_url}: page {page_num}, {products_scraped} products"
+            )
 
         except Exception as e:
             log.error(f"Failed to store Phase 2 continuation point: {e}")
@@ -3429,10 +4271,13 @@ Return ONLY valid JSON, no additional text."""
         try:
             from pathlib import Path
 
-            cache_file_path = Path(AI_CATEGORY_CACHE_DIR) / f"{supplier_name.replace('.', '_')}_ai_category_cache.json"
+            cache_file_path = (
+                Path(AI_CATEGORY_CACHE_DIR)
+                / f"{supplier_name.replace('.', '_')}_ai_category_cache.json"
+            )
 
             if cache_file_path.exists():
-                with open(cache_file_path, 'r', encoding='utf-8') as f:
+                with open(cache_file_path, "r", encoding="utf-8") as f:
                     cache_data = json.load(f)
 
                 # Add Phase 2 marker to cache
@@ -3440,9 +4285,13 @@ Return ONLY valid JSON, no additional text."""
                     "timestamp": datetime.now().isoformat(),
                     "phase_transition": f"Phase 1 (£{self.min_price}-£{self.price_midpoint}) complete, starting Phase 2 (£{self.price_midpoint}-£{MAX_PRICE})",
                     "phase_1_summary": {
-                        "total_categories_processed": len(current_memory.get("previously_suggested_urls", [])),
-                        "total_products_processed": current_memory.get("total_products_processed", 0)
-                    }
+                        "total_categories_processed": len(
+                            current_memory.get("previously_suggested_urls", [])
+                        ),
+                        "total_products_processed": current_memory.get(
+                            "total_products_processed", 0
+                        ),
+                    },
                 }
 
                 cache_data["ai_suggestion_history"].append(phase_2_entry)
@@ -3452,7 +4301,7 @@ Return ONLY valid JSON, no additional text."""
                 # Reset category suggestions for Phase 2 but keep history
                 cache_data["phase_2_started"] = datetime.now().isoformat()
 
-                with open(cache_file_path, 'w', encoding='utf-8') as f:
+                with open(cache_file_path, "w", encoding="utf-8") as f:
                     json.dump(cache_data, f, indent=2, ensure_ascii=False)
 
                 log.info(f"🔄 Phase 2 transition recorded in AI cache: {cache_file_path}")
@@ -3545,7 +4394,7 @@ Return ONLY valid JSON, no additional text."""
 
             # 🚨 CRITICAL FIX: Windows native path handling
             original_path = str(path_obj)
-            
+
             # Use standard Windows path handling
             directory = path_obj.parent
             directory.mkdir(parents=True, exist_ok=True)
@@ -3555,8 +4404,10 @@ Return ONLY valid JSON, no additional text."""
             # Get cache control configuration
             cache_config = self.system_config.get("supplier_cache_control", {})
             if cache_config.get("enabled", True):
-                self.log.info(f"💾 CACHE SAVE: Starting save of {len(products)} products to cache...")
-                
+                self.log.info(
+                    f"💾 CACHE SAVE: Starting save of {len(products)} products to cache..."
+                )
+
             self.log.info(f"🔍 DEBUG: Final path for file operations: {final_path}")
 
             # 🚨 ATOMIC FIX 1: Atomic read-modify-write operation
@@ -3565,23 +4416,25 @@ Return ONLY valid JSON, no additional text."""
                 existing_products = []
                 if os.path.exists(final_path):
                     try:
-                        with open(final_path, 'r', encoding='utf-8') as f:
+                        with open(final_path, "r", encoding="utf-8") as f:
                             existing_products = json.load(f)
-                        self.log.info(f"🔍 ATOMIC: Loaded {len(existing_products)} existing products for deduplication")
+                        self.log.info(
+                            f"🔍 ATOMIC: Loaded {len(existing_products)} existing products for deduplication"
+                        )
                     except Exception as e:
                         self.log.warning(f"Could not load existing cache for deduplication: {e}")
 
                 # 🚨 ATOMIC FIX 2: Deterministic deduplication with URL normalization
                 existing_urls = set()
                 existing_eans = set()
-                
+
                 for p in existing_products:
-                    url = p.get('url', '').strip().lower()  # Normalize URLs
-                    ean = p.get('ean', '')
-                    
+                    url = p.get("url", "").strip().lower()  # Normalize URLs
+                    ean = p.get("ean", "")
+
                     if url:
                         existing_urls.add(url)
-                    if ean and ean != 'None' and ean.strip():
+                    if ean and ean != "None" and ean.strip():
                         existing_eans.add(ean.strip())
 
                 new_products = []
@@ -3591,34 +4444,40 @@ Return ONLY valid JSON, no additional text."""
 
                 for p in products:
                     # 🚨 ATOMIC FIX 3: Consistent URL normalization for comparison
-                    product_url = p.get('url', '').strip().lower()
-                    product_ean = p.get('ean', '').strip() if p.get('ean') else ''
+                    product_url = p.get("url", "").strip().lower()
+                    product_ean = p.get("ean", "").strip() if p.get("ean") else ""
                     scanned += 1
 
                     # Reduced logging: only periodic debug updates during scan
                     if self.log.isEnabledFor(logging.DEBUG) and scanned % 100 == 0:
-                        self.log.debug(f"🔍 DEDUP SCAN: scanned={scanned} url_dupes={url_duplicates_skipped} ean_dupes={ean_duplicates_skipped}")
-                    
+                        self.log.debug(
+                            f"🔍 DEDUP SCAN: scanned={scanned} url_dupes={url_duplicates_skipped} ean_dupes={ean_duplicates_skipped}"
+                        )
+
                     if product_url and product_url in existing_urls:
                         url_duplicates_skipped += 1
                         continue
 
-                    if product_ean and product_ean != 'None' and product_ean in existing_eans:
+                    if product_ean and product_ean != "None" and product_ean in existing_eans:
                         ean_duplicates_skipped += 1
                         continue
 
                     new_products.append(p)
                     if product_url:
                         existing_urls.add(product_url)
-                    if product_ean and product_ean != 'None':
+                    if product_ean and product_ean != "None":
                         existing_eans.add(product_ean)
 
                 if url_duplicates_skipped > 0 or ean_duplicates_skipped > 0:
-                    self.log.info(f"🔄 ATOMIC DEDUPLICATION: Skipped {url_duplicates_skipped} URL duplicates and {ean_duplicates_skipped} EAN duplicates.")
+                    self.log.info(
+                        f"🔄 ATOMIC DEDUPLICATION: Skipped {url_duplicates_skipped} URL duplicates and {ean_duplicates_skipped} EAN duplicates."
+                    )
 
                 # 🚨 ATOMIC FIX 4: Log deduplication results for debugging
-                self.log.info(f"🔍 ATOMIC RESULT: {len(existing_products)} existing + {len(new_products)} new = {len(existing_products) + len(new_products)} total")
-                
+                self.log.info(
+                    f"🔍 ATOMIC RESULT: {len(existing_products)} existing + {len(new_products)} new = {len(existing_products) + len(new_products)} total"
+                )
+
                 return existing_products + new_products, len(new_products)
 
             # 🚨 ATOMIC FIX 5: Execute atomic operation and use Windows Save Guardian
@@ -3628,29 +4487,37 @@ Return ONLY valid JSON, no additional text."""
             if new_count == 0:
                 self.log.info("🔍 DEDUP SUMMARY: 0 new; skipped re-scan")
                 return 0
-            
+
             # Use Windows Save Guardian for atomic write with file locking
             success = self.save_guardian.save_json_atomic(final_path, all_products)
-            
+
             if success:
                 file_size = os.path.getsize(final_path)
-                self.log.info(f"✅ ATOMICALLY saved {len(all_products)} products ({new_count} new) to cache: {os.path.basename(final_path)} (size: {file_size} bytes)")
-                
+                self.log.info(
+                    f"✅ ATOMICALLY saved {len(all_products)} products ({new_count} new) to cache: {os.path.basename(final_path)} (size: {file_size} bytes)"
+                )
+
                 # 🚨 ATOMIC FIX 6: Update in-memory cache to match disk state
-                if hasattr(self, '_current_all_products'):
+                if hasattr(self, "_current_all_products"):
                     self._current_all_products = all_products.copy()
-                    self.log.debug(f"🔄 SYNC: In-memory cache synchronized with disk cache ({len(all_products)} products)")
-                    
+                    self.log.debug(
+                        f"🔄 SYNC: In-memory cache synchronized with disk cache ({len(all_products)} products)"
+                    )
+
                 return new_count  # Return count of new products added
             else:
                 self.log.error(f"❌ ATOMIC SAVE FAILED: Windows Save Guardian failed to save cache")
                 raise RuntimeError(f"Atomic cache save failed: {final_path}")
 
         except Exception as e:
-            self.log.error(f"❌ An unexpected error occurred during atomic cache save: {e}", exc_info=True)
+            self.log.error(
+                f"❌ An unexpected error occurred during atomic cache save: {e}", exc_info=True
+            )
             return 0
 
-    def _check_category_exhaustion_status(self, discovered_categories: list, processed_categories: list) -> dict:
+    def _check_category_exhaustion_status(
+        self, discovered_categories: list, processed_categories: list
+    ) -> dict:
         """Check how many categories of each type remain to be processed"""
         friendly_total = 0
         friendly_processed = 0
@@ -3679,14 +4546,19 @@ Return ONLY valid JSON, no additional text."""
             "neutral_processed": neutral_processed,
             "neutral_remaining": neutral_remaining,
             "should_continue": friendly_remaining > 0 or neutral_remaining > 0,
-            "phase": "friendly" if friendly_remaining > 0 else ("neutral" if neutral_remaining > 0 else "complete")
+            "phase": "friendly"
+            if friendly_remaining > 0
+            else ("neutral" if neutral_remaining > 0 else "complete"),
         }
 
     # ──────────────────────── ④  Hierarchical selector ───────────────────────
     async def _hierarchical_category_selection(self, supplier_url, supplier_name):
         # DEPRECATED: Replaced by EnhancedStateManager to prevent state conflicts
         # hist = self._load_history()
-        hist = {"categories_scraped": [], "ai_suggested_categories": []}  # Minimal hist for legacy compatibility
+        hist = {
+            "categories_scraped": [],
+            "ai_suggested_categories": [],
+        }  # Minimal hist for legacy compatibility
 
         # 🧠 FIXED: Load AI memory from AI cache file, not processing state
         ai_memory = self._load_ai_memory(supplier_name)
@@ -3698,29 +4570,39 @@ Return ONLY valid JSON, no additional text."""
             log.warning(f"No categories discovered for {supplier_url}, using fallback")
             # Fallback to basic homepage categories
             basic_cats = await self.web_scraper.get_homepage_categories(supplier_url)
-            discovered_categories = [{"name": url.split('/')[-1] or "category", "url": url} for url in basic_cats[:10]]
+            discovered_categories = [
+                {"name": url.split("/")[-1] or "category", "url": url} for url in basic_cats[:10]
+            ]
 
         # PHASE 3: SUBCATEGORY DEDUPLICATION - Apply before AI processing
-        log.info(f"PHASE 3: Applying subcategory deduplication to {len(discovered_categories)} discovered categories")
+        log.info(
+            f"PHASE 3: Applying subcategory deduplication to {len(discovered_categories)} discovered categories"
+        )
         category_urls_only = [cat["url"] for cat in discovered_categories]
-        filtered_category_urls = await self._filter_urls_by_subcategory_deduplication(category_urls_only)
-        
+        filtered_category_urls = await self._filter_urls_by_subcategory_deduplication(
+            category_urls_only
+        )
+
         # Rebuild discovered_categories with filtered URLs
         filtered_discovered_categories = []
         for cat in discovered_categories:
             if cat["url"] in filtered_category_urls:
                 filtered_discovered_categories.append(cat)
-        
+
         # Update discovered_categories with filtered results
         original_count = len(discovered_categories)
         discovered_categories = filtered_discovered_categories
         eliminated_count = original_count - len(discovered_categories)
-        
-        log.info(f"PHASE 3 RESULT: Eliminated {eliminated_count} redundant subcategories, "
-                f"proceeding with {len(discovered_categories)} optimized categories")
+
+        log.info(
+            f"PHASE 3 RESULT: Eliminated {eliminated_count} redundant subcategories, "
+            f"proceeding with {len(discovered_categories)} optimized categories"
+        )
 
         # Check category exhaustion status using AI memory instead of processing state
-        exhaustion_status = self._check_category_exhaustion_status(discovered_categories, ai_memory["previously_suggested_urls"])
+        exhaustion_status = self._check_category_exhaustion_status(
+            discovered_categories, ai_memory["previously_suggested_urls"]
+        )
         log.info(f"Category exhaustion status: {exhaustion_status}")
 
         # Determine current price phase based on AI memory
@@ -3728,21 +4610,27 @@ Return ONLY valid JSON, no additional text."""
         log.info(f"Current price phase: {current_price_phase}")
 
         if not exhaustion_status["should_continue"] and current_price_phase == "low":
-            log.info(f"All categories processed in Phase 1 (£{self.min_price}-£{self.price_midpoint}). Moving to Phase 2 (£{self.price_midpoint}-£{MAX_PRICE})...")
+            log.info(
+                f"All categories processed in Phase 1 (£{self.min_price}-£{self.price_midpoint}). Moving to Phase 2 (£{self.price_midpoint}-£{MAX_PRICE})..."
+            )
             # Reset AI memory for Phase 2 but keep track of Phase 1 completion
             self._reset_ai_memory_for_phase_2(supplier_name, ai_memory)
             current_price_phase = "medium"
         elif not exhaustion_status["should_continue"] and current_price_phase == "medium":
-            log.info("All FBA-friendly and neutral categories have been processed in both phases. Scraping complete.")
+            log.info(
+                "All FBA-friendly and neutral categories have been processed in both phases. Scraping complete."
+            )
             return []
 
         # 🧠 FIXED: Pass AI memory instead of processing state history
         ai_suggestions = await self._get_ai_suggested_categories_enhanced(
-            supplier_url, supplier_name, discovered_categories,
+            supplier_url,
+            supplier_name,
+            discovered_categories,
             previous_categories=ai_memory["previously_suggested_urls"],
             processed_products=ai_memory["total_products_processed"],
         )
-        
+
         # Validate category productivity (Solution 3)
         log.info("Validating AI-suggested categories for product content...")
         validated_urls = []
@@ -3754,9 +4642,13 @@ Return ONLY valid JSON, no additional text."""
 
             if validation_result["is_productive"]:
                 validated_urls.append(url)
-                log.info(f"✅ Category validated: {url} ({validation_result['product_count']} products)")
+                log.info(
+                    f"✅ Category validated: {url} ({validation_result['product_count']} products)"
+                )
             else:
-                log.warning(f"❌ Category rejected: {url} ({validation_result['product_count']} products - below minimum of 2)")
+                log.warning(
+                    f"❌ Category rejected: {url} ({validation_result['product_count']} products - below minimum of 2)"
+                )
                 # Add to skip_urls in AI suggestions
                 if url not in ai_suggestions.get("skip_urls", []):
                     ai_suggestions.setdefault("skip_urls", []).append(url)
@@ -3787,13 +4679,23 @@ Return ONLY valid JSON, no additional text."""
         # Apply URL optimization to validated URLs FIRST
         if validated_urls:
             log.info("Applying URL optimization parameters...")
-            optimized_urls = self._optimize_category_urls(validated_urls, price_range=current_price_phase)
-            log.info(f"Optimized {len(validated_urls)} URLs with product display parameters for {current_price_phase} price phase")
+            optimized_urls = self._optimize_category_urls(
+                validated_urls, price_range=current_price_phase
+            )
+            log.info(
+                f"Optimized {len(validated_urls)} URLs with product display parameters for {current_price_phase} price phase"
+            )
 
             # Update AI suggestions with optimized URLs and failure tracking
             ai_suggestions["optimized_urls"] = optimized_urls
-            ai_suggestions["failed_urls"] = [r["url"] for r in validation_results if not r["is_productive"]]
-            ai_suggestions["failed_url_errors"] = {r["url"]: r.get("error", "Unknown") for r in validation_results if not r["is_productive"]}
+            ai_suggestions["failed_urls"] = [
+                r["url"] for r in validation_results if not r["is_productive"]
+            ]
+            ai_suggestions["failed_url_errors"] = {
+                r["url"]: r.get("error", "Unknown")
+                for r in validation_results
+                if not r["is_productive"]
+            }
 
             # 🔧 FIX: Replace top_3_urls with optimized URLs for caching
             ai_suggestions["top_3_urls"] = optimized_urls[:3]  # Keep only top 3 optimized URLs
@@ -3805,7 +4707,7 @@ Return ONLY valid JSON, no additional text."""
             fallback_categories = [
                 f"{supplier_url.rstrip('/')}/pound-lines.html",
                 f"{supplier_url.rstrip('/')}/household.html",
-                f"{supplier_url.rstrip('/')}/health-beauty.html"
+                f"{supplier_url.rstrip('/')}/health-beauty.html",
             ]
             # Validate fallback categories
             fallback_validated = []
@@ -3828,13 +4730,16 @@ Return ONLY valid JSON, no additional text."""
         # 🧠 FIXED: Save AI category suggestions to cache AFTER URL optimization
         try:
             Path(AI_CATEGORY_CACHE_DIR).mkdir(parents=True, exist_ok=True)
-            cache_file_path = Path(AI_CATEGORY_CACHE_DIR) / f"{supplier_name.replace('.', '_')}_ai_category_cache.json"
+            cache_file_path = (
+                Path(AI_CATEGORY_CACHE_DIR)
+                / f"{supplier_name.replace('.', '_')}_ai_category_cache.json"
+            )
 
             # Load existing cache data
             existing_cache = {}
             if cache_file_path.exists():
                 try:
-                    with open(cache_file_path, 'r', encoding='utf-8') as f:
+                    with open(cache_file_path, "r", encoding="utf-8") as f:
                         existing_cache = json.load(f)
                 except Exception as e:
                     log.warning(f"Could not load existing AI cache: {e}")
@@ -3844,15 +4749,21 @@ Return ONLY valid JSON, no additional text."""
                 "timestamp": datetime.now().isoformat(),
                 "session_context": {
                     "categories_discovered": len(discovered_categories),
-                    "total_products_processed": ai_memory["total_products_processed"] if isinstance(ai_memory["total_products_processed"], int) else 0,
-                    "previous_categories_count": len(ai_memory["previously_suggested_urls"]) if ai_memory["previously_suggested_urls"] else 0
+                    "total_products_processed": ai_memory["total_products_processed"]
+                    if isinstance(ai_memory["total_products_processed"], int)
+                    else 0,
+                    "previous_categories_count": len(ai_memory["previously_suggested_urls"])
+                    if ai_memory["previously_suggested_urls"]
+                    else 0,
                 },
                 "ai_suggestions": ai_suggestions,  # Now contains optimized URLs
                 "validation_summary": {
                     "total_suggested": len(ai_suggestions.get("top_3_urls", [])),
                     "productive_categories": len(validated_urls),
-                    "rejected_categories": len([r for r in validation_results if not r["is_productive"]])
-                }
+                    "rejected_categories": len(
+                        [r for r in validation_results if not r["is_productive"]]
+                    ),
+                },
             }
 
             # Initialize or update cache structure
@@ -3863,7 +4774,7 @@ Return ONLY valid JSON, no additional text."""
                     "created": datetime.now().isoformat(),
                     "last_updated": datetime.now().isoformat(),
                     "total_ai_calls": 1,
-                    "ai_suggestion_history": [new_entry]
+                    "ai_suggestion_history": [new_entry],
                 }
             else:
                 # Append to existing history
@@ -3873,7 +4784,7 @@ Return ONLY valid JSON, no additional text."""
                 cache_data["last_updated"] = datetime.now().isoformat()
 
             # Save updated cache data
-            with open(cache_file_path, 'w', encoding='utf-8') as f:
+            with open(cache_file_path, "w", encoding="utf-8") as f:
                 json.dump(cache_data, f, indent=2, ensure_ascii=False)
 
             log.info(f"🧠 Saved AI category suggestions to cache: {cache_file_path}")
@@ -3883,51 +4794,71 @@ Return ONLY valid JSON, no additional text."""
 
         return optimized_urls
 
-    async def _extract_supplier_products(self, supplier_url: str, supplier_name: str, category_urls: List[str], max_products_per_category: int, max_products_to_process: int = None, supplier_extraction_batch_size: int = 3) -> List[Dict[str, Any]]:
+    async def _extract_supplier_products(
+        self,
+        supplier_url: str,
+        supplier_name: str,
+        category_urls: List[str],
+        max_products_per_category: int,
+        max_products_to_process: int = None,
+        supplier_extraction_batch_size: int = 3,
+    ) -> List[Dict[str, Any]]:
         """Extract products from a list of category URLs with overall product limit enforcement."""
         import json  # Import at function level to ensure availability
-        
+
         # 🔄 SUPPLIER CACHE FRESHNESS CHECK
         # If we have cached products and processing state indicates progress, skip supplier scraping
         actual_cache_file, cache_count = self._find_actual_supplier_cache_file(supplier_name)
-        
-        if actual_cache_file and hasattr(self, 'state_manager') and self.state_manager:
+
+        if actual_cache_file and hasattr(self, "state_manager") and self.state_manager:
             try:
                 # Check if we have processing state indicating previous progress
-                if hasattr(self.state_manager, 'state_data') and self.state_manager.state_data:
-                    last_index = self.state_manager.state_data.get('last_processed_index', 0)
-                    processing_status = self.state_manager.state_data.get('processing_status', 'not_started')
-                    
+                if hasattr(self.state_manager, "state_data") and self.state_manager.state_data:
+                    last_index = self.state_manager.state_data.get("last_processed_index", 0)
+                    processing_status = self.state_manager.state_data.get(
+                        "processing_status", "not_started"
+                    )
+
                     # Check cache file age (fresh within 24 hours)
                     import time
+
                     cache_age_hours = (time.time() - os.path.getmtime(actual_cache_file)) / 3600
                     cache_is_fresh = cache_age_hours < 24
-                    
+
                     if last_index > 0 and cache_is_fresh:
                         # Check if supplier extraction is complete before returning cache
                         import json
-                        with open(actual_cache_file, 'r', encoding='utf-8') as f:
+
+                        with open(actual_cache_file, "r", encoding="utf-8") as f:
                             cached_products = json.load(f)
-                        
+
                         # 🚨 CRITICAL FIX: Use system_progression as canonical source of truth
-                        sp = self.state_manager.state_data.get('system_progression', {})
+                        sp = self.state_manager.state_data.get("system_progression", {})
                         extraction_progress = sp  # Use system_progression data
-                        products_extracted = sp.get('current_product_index_in_category', len(cached_products))
-                        
+                        products_extracted = sp.get(
+                            "current_product_index_in_category", len(cached_products)
+                        )
+
                         # 🚨 HYBRID MODE FIX: Check if current chunk categories are already in cache
                         chunk_category_urls = set(category_urls)
                         products_for_chunk_categories = [
-                            product for product in cached_products 
-                            if product.get('source_url', '') in chunk_category_urls
+                            product
+                            for product in cached_products
+                            if product.get("source_url", "") in chunk_category_urls
                         ]
-                        
+
                         # 🚨 RESUMPTION FIX: Check cache but always perform fresh extraction
                         if len(products_for_chunk_categories) > 0:
-                            if hasattr(self, 'last_processed_index') and self.last_processed_index > 0:
+                            if (
+                                hasattr(self, "last_processed_index")
+                                and self.last_processed_index > 0
+                            ):
                                 self.log.info(
                                     f"🔄 RESUMPTION DETECTED: Found {len(products_for_chunk_categories)} cached products but resuming from index {self.last_processed_index}"
                                 )
-                                self.log.info("🔄 EXTRACTION NEEDED: Continuing supplier extraction to complete interrupted category")
+                                self.log.info(
+                                    "🔄 EXTRACTION NEEDED: Continuing supplier extraction to complete interrupted category"
+                                )
                             else:
                                 self.log.info(
                                     f"🔄 CHUNK CACHE REFERENCE: {len(products_for_chunk_categories)} cached products exist for current chunk categories – performing fresh extraction to detect updates"
@@ -3937,125 +4868,176 @@ Return ONLY valid JSON, no additional text."""
                             self.log.info(
                                 f"🔄 CHUNK CACHE MISS: No cached products found for chunk categories: {list(chunk_category_urls)}"
                             )
-                            self.log.info("🔄 EXTRACTION NEEDED: Continuing with supplier extraction for new categories")
+                            self.log.info(
+                                "🔄 EXTRACTION NEEDED: Continuing with supplier extraction for new categories"
+                            )
                         # Fall through to continue with supplier extraction regardless of cache state
-                        
+
                     elif last_index > 0 and not cache_is_fresh:
-                        self.log.info(f"🔄 CACHE STALE: Cache age {cache_age_hours:.1f}h > 24h threshold, proceeding with fresh scraping")
+                        self.log.info(
+                            f"🔄 CACHE STALE: Cache age {cache_age_hours:.1f}h > 24h threshold, proceeding with fresh scraping"
+                        )
                         # Reset processing index since we're re-scraping (product list may have changed)
-                        if hasattr(self, 'last_processed_index'):
+                        if hasattr(self, "last_processed_index"):
                             self.last_processed_index = 0
                             self.log.info(f"⚠️ Reset processing index to 0 due to stale cache")
                     elif last_index > 0:
                         # This handles the case where cache exists but extraction was incomplete
                         import json
-                        with open(actual_cache_file, 'r', encoding='utf-8') as f:
+
+                        with open(actual_cache_file, "r", encoding="utf-8") as f:
                             cached_products = json.load(f)
                         # 🚨 CRITICAL FIX: Use system_progression as canonical source
-                        sp = self.state_manager.state_data.get('system_progression', {})
+                        sp = self.state_manager.state_data.get("system_progression", {})
                         extraction_progress = sp  # Use system_progression data
-                        products_extracted = sp.get('current_product_index_in_category', len(cached_products))
-                        
-                        self.log.info(f"🔄 SUPPLIER EXTRACTION INCOMPLETE: {products_extracted}/{max_products_per_category} products extracted")
-                        self.log.info(f"🔄 RESUMPTION: Continuing supplier scraping from product {products_extracted + 1}")
+                        products_extracted = sp.get(
+                            "current_product_index_in_category", len(cached_products)
+                        )
+
+                        self.log.info(
+                            f"🔄 SUPPLIER EXTRACTION INCOMPLETE: {products_extracted}/{max_products_per_category} products extracted"
+                        )
+                        self.log.info(
+                            f"🔄 RESUMPTION: Continuing supplier scraping from product {products_extracted + 1}"
+                        )
                         # Set the starting counter to resume from where we left off
-                        if not hasattr(self, '_supplier_product_counter'):
+                        if not hasattr(self, "_supplier_product_counter"):
                             self._supplier_product_counter = products_extracted
-                            self.log.info(f"📊 RESUMPTION: Setting product counter to {self._supplier_product_counter}")
+                            self.log.info(
+                                f"📊 RESUMPTION: Setting product counter to {self._supplier_product_counter}"
+                            )
                     else:
-                        self.log.info(f"🔄 NO PROCESSING PROGRESS: index={last_index}, proceeding with scraping")
-                        
+                        self.log.info(
+                            f"🔄 NO PROCESSING PROGRESS: index={last_index}, proceeding with scraping"
+                        )
+
             except Exception as e:
-                self.log.warning(f"⚠️ Error checking supplier cache freshness: {e}, proceeding with scraping")
-        
+                self.log.warning(
+                    f"⚠️ Error checking supplier cache freshness: {e}, proceeding with scraping"
+                )
+
         # Proceed with normal supplier scraping with batching
         # supplier_extraction_batch_size is now passed as a parameter
         self.log.info(f"🕷️ PERFORMING SUPPLIER SCRAPING from {len(category_urls)} categories")
         self.log.info(f"📦 Using supplier extraction batch size: {supplier_extraction_batch_size}")
-        
+
         # Process categories in batches for better memory management
         all_products = []
         # Mapping of category_url -> full list of product URLs for manifest generation
         self.category_manifests = {}
-        
+
         # 🚨 CRITICAL FIX: Load existing cached products and filter against linking map
-        actual_cache_file, existing_cache_count = self._find_actual_supplier_cache_file(supplier_name)
+        actual_cache_file, existing_cache_count = self._find_actual_supplier_cache_file(
+            supplier_name
+        )
         if actual_cache_file:
             try:
-                with open(actual_cache_file, 'r', encoding='utf-8') as f:
+                with open(actual_cache_file, "r", encoding="utf-8") as f:
                     existing_cached_products = json.load(f)
-                
+
                 # 🚨 CRITICAL FIX: Filter against linking map to only return unprocessed products
                 if self.linking_map and len(self.linking_map) > 0:
                     # Build hash set for O(1) lookup performance
-                    processed_urls = {entry.get("supplier_url") for entry in self.linking_map 
-                                    if entry.get("supplier_url")}
-                    processed_eans = {entry.get("supplier_ean") for entry in self.linking_map 
-                                    if entry.get("supplier_ean")}
-                    
+                    processed_urls = {
+                        entry.get("supplier_url")
+                        for entry in self.linking_map
+                        if entry.get("supplier_url")
+                    }
+                    processed_eans = {
+                        entry.get("supplier_ean")
+                        for entry in self.linking_map
+                        if entry.get("supplier_ean")
+                    }
+
                     # Filter out already processed products
                     unprocessed_products = []
                     for product in existing_cached_products:
                         if isinstance(product, dict) and not product.get("_cache_metadata"):
                             product_url = product.get("url", "")
                             product_ean = product.get("ean", "") or product.get("barcode", "")
-                            
+
                             # Skip if already in linking map (processed by either EAN or URL)
-                            if (product_ean and product_ean in processed_eans) or \
-                               (product_url and product_url in processed_urls):
+                            if (product_ean and product_ean in processed_eans) or (
+                                product_url and product_url in processed_urls
+                            ):
                                 continue
-                            
+
                             unprocessed_products.append(product)
-                    
+
                     all_products = unprocessed_products
-                    self.log.info(f"🔍 FILTERING APPLIED: {len(existing_cached_products)} total → {len(unprocessed_products)} unprocessed ({len(processed_urls)} already in linking map)")
-                    self.log.info(f"📊 EFFICIENCY GAIN: {((len(existing_cached_products) - len(unprocessed_products)) / max(len(existing_cached_products), 1) * 100):.1f}% products skipped (already processed)")
+                    self.log.info(
+                        f"🔍 FILTERING APPLIED: {len(existing_cached_products)} total → {len(unprocessed_products)} unprocessed ({len(processed_urls)} already in linking map)"
+                    )
+                    self.log.info(
+                        f"📊 EFFICIENCY GAIN: {((len(existing_cached_products) - len(unprocessed_products)) / max(len(existing_cached_products), 1) * 100):.1f}% products skipped (already processed)"
+                    )
                 else:
                     # No linking map available, process all cached products
                     all_products = existing_cached_products.copy()
-                    self.log.info(f"⚠️ NO LINKING MAP: Processing all {len(existing_cached_products)} cached products (no filtering applied)")
-                    
+                    self.log.info(
+                        f"⚠️ NO LINKING MAP: Processing all {len(existing_cached_products)} cached products (no filtering applied)"
+                    )
+
             except Exception as e:
                 self.log.warning(f"⚠️ Could not load existing cache during resumption: {e}")
                 all_products = []  # Fallback to empty list
-        
+
         # Store as instance variable for progress callback access
         self._current_all_products = all_products
-        category_batches = [category_urls[i:i + supplier_extraction_batch_size] for i in range(0, len(category_urls), supplier_extraction_batch_size)]
-        
+        category_batches = [
+            category_urls[i : i + supplier_extraction_batch_size]
+            for i in range(0, len(category_urls), supplier_extraction_batch_size)
+        ]
+
         # Get progress tracking configuration
         progress_config = self.system_config.get("supplier_extraction_progress", {})
         cache_config = self.system_config.get("supplier_cache_control", {})
-        
+
         # Initialize extraction progress tracking
         if progress_config.get("enabled", True):
-            self.log.info(f"📊 PROGRESS TRACKING: Extracting from {len(category_urls)} categories in {len(category_batches)} batches")
-        
+            self.log.info(
+                f"📊 PROGRESS TRACKING: Extracting from {len(category_urls)} categories in {len(category_batches)} batches"
+            )
+
         for batch_num, category_batch in enumerate(category_batches, 1):
             # Check if we've reached the overall product limit before starting a new batch
             if max_products_to_process and len(all_products) >= max_products_to_process:
-                self.log.info(f"🛑 STOPPING: Reached max_products_to_process limit of {max_products_to_process} products before batch {batch_num}")
+                self.log.info(
+                    f"🛑 STOPPING: Reached max_products_to_process limit of {max_products_to_process} products before batch {batch_num}"
+                )
                 break
-                
-            self.log.info(f"📦 Processing category batch {batch_num}/{len(category_batches)} ({len(category_batch)} categories)")
-            
+
+            self.log.info(
+                f"📦 Processing category batch {batch_num}/{len(category_batches)} ({len(category_batch)} categories)"
+            )
+
             # 🚨 LOGIN SCRIPT TRIGGER - At start of every supplier category extraction after Amazon product detail extraction
             # This ensures authentication is verified before each new category batch processing
             await self._trigger_authentication_check(f"category_batch_{batch_num}")
-            
+
             for subcategory_index, category_url in enumerate(category_batch, 1):
                 # Update detailed progress tracking
-                if progress_config.get("enabled", True) and hasattr(self, 'state_manager'):
-                    if self.system_config.get("pipeline_toggles", {}).get("resume_abs_index_math", True):
-                        resume_cat_idx = self.state_manager.state_data["system_progression"].get("current_category_index", 0)
-                        category_index = resume_cat_idx + ((batch_num - 1) * supplier_extraction_batch_size) + subcategory_index
+                if progress_config.get("enabled", True) and hasattr(self, "state_manager"):
+                    if self.system_config.get("pipeline_toggles", {}).get(
+                        "resume_abs_index_math", True
+                    ):
+                        resume_cat_idx = self.state_manager.state_data["system_progression"].get(
+                            "current_category_index", 0
+                        )
+                        category_index = (
+                            resume_cat_idx
+                            + ((batch_num - 1) * supplier_extraction_batch_size)
+                            + subcategory_index
+                        )
                     else:
-                        category_index = (batch_num - 1) * supplier_extraction_batch_size + subcategory_index
+                        category_index = (
+                            batch_num - 1
+                        ) * supplier_extraction_batch_size + subcategory_index
                     # Initialize category tracking for precise resumption
                     self.state_manager.initialize_category_processing(
                         category_index=category_index - 1,
                         category_url=category_url,
-                        total_categories=self._authoritative_total_categories()
+                        total_categories=self._authoritative_total_categories(),
                     )
                     self.state_manager.update_supplier_extraction_progress(
                         category_index=category_index,
@@ -4065,66 +5047,112 @@ Return ONLY valid JSON, no additional text."""
                         batch_number=batch_num,
                         total_batches=len(category_batches),
                         category_url=category_url,
-                        extraction_phase="supplier"
+                        extraction_phase="supplier",
                     )
-                    
-                    if progress_config.get("progress_display", {}).get("show_subcategory_progress", True):
-                        self.log.info(f"🔄 EXTRACTION PROGRESS: Processing subcategory {subcategory_index}/{len(category_batch)} in batch {batch_num} (Category {category_index}/{len(category_urls)})")
-                
+
+                    if progress_config.get("progress_display", {}).get(
+                        "show_subcategory_progress", True
+                    ):
+                        self.log.info(
+                            f"🔄 EXTRACTION PROGRESS: Processing subcategory {subcategory_index}/{len(category_batch)} in batch {batch_num} (Category {category_index}/{len(category_urls)})"
+                        )
+
                 # Setup progress callback for individual product tracking
-                if hasattr(self.supplier_scraper, 'set_progress_callback'):
-                    self.supplier_scraper.set_progress_callback(self._create_product_progress_callback(category_url, progress_config))
+                if hasattr(self.supplier_scraper, "set_progress_callback"):
+                    self.supplier_scraper.set_progress_callback(
+                        self._create_product_progress_callback(category_url, progress_config)
+                    )
                 # Check if we've reached the overall product limit
                 if max_products_to_process and len(all_products) >= max_products_to_process:
-                    self.log.info(f"🛑 STOPPING: Reached max_products_to_process limit of {max_products_to_process} products")
+                    self.log.info(
+                        f"🛑 STOPPING: Reached max_products_to_process limit of {max_products_to_process} products"
+                    )
                     break
-                    
+
                 self.log.info(f"Scraping category: {category_url}")
 
                 # 🚨 SURGICAL FIX: PRE-EXTRACTION URL COLLECTION AND FILTERING
                 # First, collect URLs without extracting product data
-                urls_for_manifest = await self._collect_urls_only(category_url, max_products_per_category)
-                
+                urls_for_manifest = await self._collect_urls_only(
+                    category_url, max_products_per_category
+                )
+
                 if not urls_for_manifest:
                     self.log.warning(f"No product URLs found for {category_url}")
                     continue
-                
+
                 # Generate category slug for logging
                 slug = self._generate_category_slug(category_url)
-                
+
                 # Use same absolute index calculation for consistency
-                if self.system_config.get("pipeline_toggles", {}).get("resume_abs_index_math", True):
-                    resume_cat_idx = self.state_manager.state_data["system_progression"].get("current_category_index", 0)
-                    category_index = resume_cat_idx + ((batch_num - 1) * supplier_extraction_batch_size) + subcategory_index
+                if self.system_config.get("pipeline_toggles", {}).get(
+                    "resume_abs_index_math", True
+                ):
+                    resume_cat_idx = self.state_manager.state_data["system_progression"].get(
+                        "current_category_index", 0
+                    )
+                    category_index = (
+                        resume_cat_idx
+                        + ((batch_num - 1) * supplier_extraction_batch_size)
+                        + subcategory_index
+                    )
                 else:
-                    category_index = (batch_num - 1) * supplier_extraction_batch_size + subcategory_index
-                
+                    category_index = (
+                        batch_num - 1
+                    ) * supplier_extraction_batch_size + subcategory_index
+
                 # Get pagination info from scraper
-                page_count = getattr(self.supplier_scraper, 'last_page_count', 1)
-                urls_per_page = getattr(self.supplier_scraper, 'last_urls_per_page', [])
-                
+                page_count = getattr(self.supplier_scraper, "last_page_count", 1)
+                urls_per_page = getattr(self.supplier_scraper, "last_urls_per_page", [])
+
                 # Log pagination summary as specified in requirements
                 if urls_per_page and len(urls_per_page) > 0:
                     urls_per_page_str = ",".join(map(str, urls_per_page))
-                    self.log.info(f"PAGINATION[C{category_index} {slug}]: pages={page_count} urls_page={urls_per_page_str} total={len(urls_for_manifest)}")
-                    
+                    self.log.info(
+                        f"PAGINATION[C{category_index} {slug}]: pages={page_count} urls_page={urls_per_page_str} total={len(urls_for_manifest)}"
+                    )
+
                     # Validate pagination completeness invariant
                     if sum(urls_per_page) != len(urls_for_manifest):
-                        self.log.warning(f"⚠️ PAGINATION MISMATCH: sum(urls_page)={sum(urls_per_page)} != total={len(urls_for_manifest)} for {category_url}")
+                        self.log.warning(
+                            f"⚠️ PAGINATION MISMATCH: sum(urls_page)={sum(urls_per_page)} != total={len(urls_for_manifest)} for {category_url}"
+                        )
                 else:
                     # Fallback for scrapers that don't provide per-page breakdown
-                    self.log.info(f"PAGINATION[C{category_index} {slug}]: pages={page_count} urls_page={len(urls_for_manifest)} total={len(urls_for_manifest)}")
+                    self.log.info(
+                        f"PAGINATION[C{category_index} {slug}]: pages={page_count} urls_page={len(urls_for_manifest)} total={len(urls_for_manifest)}"
+                    )
 
                 # 🚨 SURGICAL FIX: DETAILED TWO-STEP PRE-EXTRACTION FILTERING
-                self.log.info(f"🔗 DETAILED PRE-EXTRACTION FILTERING: Analyzing {len(urls_for_manifest)} collected URLs")
+                self.log.info(
+                    f"🔗 DETAILED PRE-EXTRACTION FILTERING: Analyzing {len(urls_for_manifest)} collected URLs"
+                )
 
                 # STEP 1: LINKING MAP FILTERING
                 # 🚨 SURGICAL FIX #1: UNIFIED FILTERING LOGIC (EAN + URL)
                 # Build hash sets for O(1) lookup performance against linking map
-                processed_urls = {entry.get("supplier_url") for entry in self.linking_map if entry.get("supplier_url")} if self.linking_map else set()
-                processed_eans = {entry.get("supplier_ean") for entry in self.linking_map if entry.get("supplier_ean")} if self.linking_map else set()
-                
-                self.log.debug(f"🔗 UNIFIED FILTER: Loaded {len(processed_eans)} EANs and {len(processed_urls)} URLs from linking map")
+                processed_urls = (
+                    {
+                        entry.get("supplier_url")
+                        for entry in self.linking_map
+                        if entry.get("supplier_url")
+                    }
+                    if self.linking_map
+                    else set()
+                )
+                processed_eans = (
+                    {
+                        entry.get("supplier_ean")
+                        for entry in self.linking_map
+                        if entry.get("supplier_ean")
+                    }
+                    if self.linking_map
+                    else set()
+                )
+
+                self.log.debug(
+                    f"🔗 UNIFIED FILTER: Loaded {len(processed_eans)} EANs and {len(processed_urls)} URLs from linking map"
+                )
 
                 # Filter URLs against linking map (SKIP_ENTIRELY)
                 skip_entirely_urls = []
@@ -4138,18 +5166,27 @@ Return ONLY valid JSON, no additional text."""
                         # 🚨 ENHANCEMENT: Try EAN-based filtering if product cache is available
                         # Load product from cache to get EAN for enhanced filtering
                         product_ean = None
-                        
+
                         # Build cache indexes if not already available
-                        if not hasattr(self, 'product_cache_ean_index') or not hasattr(self, 'product_cache_url_index'):
+                        if not hasattr(self, "product_cache_ean_index") or not hasattr(
+                            self, "product_cache_url_index"
+                        ):
                             cached_products = self._load_supplier_cache(supplier_name)
                             if cached_products:
-                                self.product_cache_ean_index = {p.get('ean'): p for p in cached_products if p.get('ean')}
-                                self.product_cache_url_index = {p.get('url'): p for p in cached_products if p.get('url')}
-                        
+                                self.product_cache_ean_index = {
+                                    p.get("ean"): p for p in cached_products if p.get("ean")
+                                }
+                                self.product_cache_url_index = {
+                                    p.get("url"): p for p in cached_products if p.get("url")
+                                }
+
                         # Get product EAN from cache if available
-                        if hasattr(self, 'product_cache_url_index') and url in self.product_cache_url_index:
-                            product_ean = self.product_cache_url_index[url].get('ean')
-                        
+                        if (
+                            hasattr(self, "product_cache_url_index")
+                            and url in self.product_cache_url_index
+                        ):
+                            product_ean = self.product_cache_url_index[url].get("ean")
+
                         # Secondary check: EAN-based filtering (when available)
                         if product_ean and product_ean in processed_eans:
                             skip_entirely_urls.append(url)
@@ -4161,9 +5198,9 @@ Return ONLY valid JSON, no additional text."""
                 # Load product cache for EAN/URL checking
                 product_cache_ean_index = set()
                 product_cache_url_index = set()
-                if hasattr(self, 'product_cache_ean_index'):
+                if hasattr(self, "product_cache_ean_index"):
                     product_cache_ean_index = self.product_cache_ean_index
-                if hasattr(self, 'product_cache_url_index'):
+                if hasattr(self, "product_cache_url_index"):
                     product_cache_url_index = self.product_cache_url_index
 
                 # Filter remaining URLs against product cache
@@ -4179,17 +5216,25 @@ Return ONLY valid JSON, no additional text."""
                         needs_full_extraction_urls.append(url)
 
                 # 🚨 ENHANCED TRANSPARENCY: Implement transparent filter classification logging
-                self.log.info(f"🔗 STEP 1 - LINKING MAP CHECK: {len(skip_entirely_urls)} complete (skipped)")
-                self.log.info(f"💾 STEP 2 - PRODUCT CACHE CHECK: {len(needs_amazon_only_urls)} have supplier data; {len(needs_full_extraction_urls)} need supplier extraction")
-                
+                self.log.info(
+                    f"🔗 STEP 1 - LINKING MAP CHECK: {len(skip_entirely_urls)} complete (skipped)"
+                )
+                self.log.info(
+                    f"💾 STEP 2 - PRODUCT CACHE CHECK: {len(needs_amazon_only_urls)} have supplier data; {len(needs_full_extraction_urls)} need supplier extraction"
+                )
+
                 # 🚨 SURGICAL FIX #3: FILTERING CONTRACT COMPLIANCE VERIFICATION
-                filter_invariant_check = len(urls_for_manifest) == (len(skip_entirely_urls) + len(needs_amazon_only_urls) + len(needs_full_extraction_urls))
+                filter_invariant_check = len(urls_for_manifest) == (
+                    len(skip_entirely_urls)
+                    + len(needs_amazon_only_urls)
+                    + len(needs_full_extraction_urls)
+                )
                 # Canonical invariant line for audit/verification (single line)
                 self.log.info(
                     f"🧮 Filter Invariant: in={len(urls_for_manifest)} == "
                     f"skip={len(skip_entirely_urls)} + amazon_only={len(needs_amazon_only_urls)} + full={len(needs_full_extraction_urls)}"
                 )
-                
+
                 # 🚨 CONTRACT ENFORCEMENT: Fail fast if filtering contract is violated
                 if not filter_invariant_check:
                     self.log.error(f"🚨 FILTERING CONTRACT VIOLATION: Totals don't match!")
@@ -4197,16 +5242,26 @@ Return ONLY valid JSON, no additional text."""
                     self.log.error(f"   Skip entirely: {len(skip_entirely_urls)}")
                     self.log.error(f"   Needs Amazon only: {len(needs_amazon_only_urls)}")
                     self.log.error(f"   Needs full extraction: {len(needs_full_extraction_urls)}")
-                    self.log.error(f"   Sum of outputs: {len(skip_entirely_urls) + len(needs_amazon_only_urls) + len(needs_full_extraction_urls)}")
-                    raise ValueError("Filtering contract violation: URL counts don't add up correctly")
-                
+                    self.log.error(
+                        f"   Sum of outputs: {len(skip_entirely_urls) + len(needs_amazon_only_urls) + len(needs_full_extraction_urls)}"
+                    )
+                    raise ValueError(
+                        "Filtering contract violation: URL counts don't add up correctly"
+                    )
+
                 # 🚨 CRITICAL TRANSPARENCY: Log specific product classification for visibility
                 if len(skip_entirely_urls) > 0:
-                    self.log.info(f"✅ SKIP_ENTIRELY ({len(skip_entirely_urls)}): {skip_entirely_urls[:5]}{'...' if len(skip_entirely_urls) > 5 else ''}")
+                    self.log.info(
+                        f"✅ SKIP_ENTIRELY ({len(skip_entirely_urls)}): {skip_entirely_urls[:5]}{'...' if len(skip_entirely_urls) > 5 else ''}"
+                    )
                 if len(needs_amazon_only_urls) > 0:
-                    self.log.info(f"🚀 NEEDS_AMAZON_ONLY ({len(needs_amazon_only_urls)}): {needs_amazon_only_urls[:5]}{'...' if len(needs_amazon_only_urls) > 5 else ''}")
+                    self.log.info(
+                        f"🚀 NEEDS_AMAZON_ONLY ({len(needs_amazon_only_urls)}): {needs_amazon_only_urls[:5]}{'...' if len(needs_amazon_only_urls) > 5 else ''}"
+                    )
                 if len(needs_full_extraction_urls) > 0:
-                    self.log.info(f"📊 NEEDS_FULL_EXTRACTION ({len(needs_full_extraction_urls)}): {needs_full_extraction_urls[:5]}{'...' if len(needs_full_extraction_urls) > 5 else ''}")
+                    self.log.info(
+                        f"📊 NEEDS_FULL_EXTRACTION ({len(needs_full_extraction_urls)}): {needs_full_extraction_urls[:5]}{'...' if len(needs_full_extraction_urls) > 5 else ''}"
+                    )
 
                 # 📊 EFFICIENCY METRICS
                 total_urls = len(urls_for_manifest)
@@ -4214,87 +5269,123 @@ Return ONLY valid JSON, no additional text."""
                 total_cached = len(needs_amazon_only_urls)
                 total_needs_extraction = len(needs_full_extraction_urls)
 
-                self.log.info(f"📈 FILTERING EFFICIENCY: {total_skipped}/{total_urls} = {(total_skipped/total_urls*100) if total_urls > 0 else 0:.1f}% already processed")
-                self.log.info(f"💾 CACHE UTILIZATION: {total_cached}/{total_urls} = {(total_cached/total_urls*100) if total_urls > 0 else 0:.1f}% have supplier data")
-                self.log.info(f"📊 EXTRACTION NEEDED: {total_needs_extraction}/{total_urls} = {(total_needs_extraction/total_urls*100) if total_urls > 0 else 0:.1f}% need fresh extraction")
+                self.log.info(
+                    f"📈 FILTERING EFFICIENCY: {total_skipped}/{total_urls} = {(total_skipped/total_urls*100) if total_urls > 0 else 0:.1f}% already processed"
+                )
+                self.log.info(
+                    f"💾 CACHE UTILIZATION: {total_cached}/{total_urls} = {(total_cached/total_urls*100) if total_urls > 0 else 0:.1f}% have supplier data"
+                )
+                self.log.info(
+                    f"📊 EXTRACTION NEEDED: {total_needs_extraction}/{total_urls} = {(total_needs_extraction/total_urls*100) if total_urls > 0 else 0:.1f}% need fresh extraction"
+                )
 
                 # 🚨 CRITICAL FIX: Only extract products that need full extraction
                 if needs_full_extraction_urls:
-                    self.log.info(f"🚀 PROCEEDING WITH EXTRACTION: {len(needs_full_extraction_urls)} products need full extraction")
-                    
+                    self.log.info(
+                        f"🚀 PROCEEDING WITH EXTRACTION: {len(needs_full_extraction_urls)} products need full extraction"
+                    )
+
                     # 🚨 SURGICAL FIX #3: CONTRACT COMPLIANCE - Track extraction promise
                     promised_extraction_count = len(needs_full_extraction_urls)
-                    self.log.info(f"📝 EXTRACTION CONTRACT: Promising to extract exactly {promised_extraction_count} products")
-                    
+                    self.log.info(
+                        f"📝 EXTRACTION CONTRACT: Promising to extract exactly {promised_extraction_count} products"
+                    )
+
                     # Use pre-filtered extraction method that respects filtering contract
                     # This ensures we process exactly the N products identified by filtering
                     products = await self.supplier_scraper.scrape_products_from_prefiltered_urls(
                         needs_full_extraction_urls, category_url, all_products
                     )
-                    
+
                     # 🚨 CONTRACT VERIFICATION: Ensure we extracted what we promised
                     actual_extraction_count = len(products)
                     contract_fulfilled = actual_extraction_count == promised_extraction_count
-                    
+
                     self.log.info(f"📝 EXTRACTION CONTRACT VERIFICATION:")
                     self.log.info(f"   Promised: {promised_extraction_count} products")
                     self.log.info(f"   Delivered: {actual_extraction_count} products")
-                    self.log.info(f"   Contract: {'✅ FULFILLED' if contract_fulfilled else '⚠️ PARTIAL'}")
-                    
+                    self.log.info(
+                        f"   Contract: {'✅ FULFILLED' if contract_fulfilled else '⚠️ PARTIAL'}"
+                    )
+
                     if not contract_fulfilled:
-                        self.log.warning(f"⚠️ EXTRACTION CONTRACT WARNING: Expected {promised_extraction_count}, got {actual_extraction_count}")
-                        self.log.warning(f"   This may indicate scraping issues or URL accessibility problems")
-                    
+                        self.log.warning(
+                            f"⚠️ EXTRACTION CONTRACT WARNING: Expected {promised_extraction_count}, got {actual_extraction_count}"
+                        )
+                        self.log.warning(
+                            f"   This may indicate scraping issues or URL accessibility problems"
+                        )
+
                 else:
-                    self.log.info(f"✅ NO EXTRACTION NEEDED: All products are either already processed or have cached supplier data")
+                    self.log.info(
+                        f"✅ NO EXTRACTION NEEDED: All products are either already processed or have cached supplier data"
+                    )
                     products = []
                     # 🚨 CRITICAL FIX: Skip to next category to prevent legacy path execution
                     continue
-                
+
                 # Add products that only need Amazon analysis to the accumulator
                 if needs_amazon_only_urls:
-                    self.log.info(f"📋 ADDING TO AMAZON ANALYSIS: {len(needs_amazon_only_urls)} products have supplier data and need Amazon analysis")
+                    self.log.info(
+                        f"📋 ADDING TO AMAZON ANALYSIS: {len(needs_amazon_only_urls)} products have supplier data and need Amazon analysis"
+                    )
                     # Load these products from cache and add to accumulator
-                    cached_products = self._load_cached_products_for_urls(needs_amazon_only_urls, supplier_name)
+                    cached_products = self._load_cached_products_for_urls(
+                        needs_amazon_only_urls, supplier_name
+                    )
                     if cached_products:
                         all_products.extend(cached_products)
-                        self.log.info(f"✅ Added {len(cached_products)} cached products to Amazon analysis queue")
+                        self.log.info(
+                            f"✅ Added {len(cached_products)} cached products to Amazon analysis queue"
+                        )
                 # 🚨 SURGICAL FIX: Update state manager with current category URL being processed
-                if hasattr(self, 'state_manager') and self.state_manager:
-                    if hasattr(self.state_manager, 'update_current_category_url'):
+                if hasattr(self, "state_manager") and self.state_manager:
+                    if hasattr(self.state_manager, "update_current_category_url"):
                         self.state_manager.update_current_category_url(category_url)
                     else:
                         # Fallback: directly update the category URL in supplier_extraction_progress
-                        if hasattr(self.state_manager, 'state_data'):
-                            self.state_manager.state_data.setdefault('supplier_extraction_progress', {})['current_category_url'] = category_url
+                        if hasattr(self.state_manager, "state_data"):
+                            self.state_manager.state_data.setdefault(
+                                "supplier_extraction_progress", {}
+                            )["current_category_url"] = category_url
                 if urls_for_manifest:
                     # Frozen category denominator per run (Step 3)
-                    if self.system_config.get("pipeline_toggles", {}).get("frozen_category_denominator", True):
+                    if self.system_config.get("pipeline_toggles", {}).get(
+                        "frozen_category_denominator", True
+                    ):
                         discovered_count = len(urls_for_manifest)  # pre-filter
                         # write both: discovery API (for visibility) and a frozen snapshot
-                        self.state_manager.update_discovered_products_in_category(category_url, discovered_count)
-                        self.state_manager.set_frozen_denominator(category_url, discovered_count)  # new helper
+                        self.state_manager.update_discovered_products_in_category(
+                            category_url, discovered_count
+                        )
+                        self.state_manager.set_frozen_denominator(
+                            category_url, discovered_count
+                        )  # new helper
                         self.state_manager.save_state(preserve_interruption_state=True)
-                        self.log.info(f"🔒 FROZEN DENOMINATOR: Category {category_url} → {discovered_count} products (snapshot taken)")
-                    
+                        self.log.info(
+                            f"🔒 FROZEN DENOMINATOR: Category {category_url} → {discovered_count} products (snapshot taken)"
+                        )
+
                     self._set_current_category_index(category_index)
                     self._save_category_manifest(supplier_name, category_url, urls_for_manifest)
-                    
+
                     # Update state manager with accurate totals for breadcrumb logging
-                    if hasattr(self, 'state_manager') and self.state_manager:
+                    if hasattr(self, "state_manager") and self.state_manager:
                         # Load total categories directly from config as authoritative source
                         total_categories = self._get_authoritative_category_count(category_urls)
-                        
+
                         # Update system progression with accurate totals
                         sp = self.state_manager.state_data.setdefault("system_progression", {})
-                        sp.update({
-                            "total_categories": total_categories,
-                            "current_category_index": category_index,
-                            "current_category_url": category_url,
-                            "total_products_in_current_category": len(urls_for_manifest),
-                            "current_product_index_in_category": 0
-                        })
-                
+                        sp.update(
+                            {
+                                "total_categories": total_categories,
+                                "current_category_index": category_index,
+                                "current_category_url": category_url,
+                                "total_products_in_current_category": len(urls_for_manifest),
+                                "current_product_index_in_category": 0,
+                            }
+                        )
+
                 self.category_manifests[category_url] = urls_for_manifest
                 self.log.info(
                     f"Finished scraping category {category_url}: Found {len(urls_for_manifest)} products across {page_count} pages."
@@ -4306,116 +5397,163 @@ Return ONLY valid JSON, no additional text."""
                 self.log.info(
                     f"📊 Category completed: {len(products)} raw products extracted, {len(all_products)} total products accumulated"
                 )
-                
+
                 # 🚨 SURGICAL FIX: Update state manager with discovered product count for accurate processing state
-                if hasattr(self, 'state_manager') and self.state_manager and len(products) > 0:
+                if hasattr(self, "state_manager") and self.state_manager and len(products) > 0:
                     # Get the actual discovered count from scraper (may be more than extracted due to URL cache filtering)
                     # This ensures processing state shows real-time discovery totals, not just processed totals
-                    discovered_count = getattr(self.supplier_scraper, 'last_discovered_count', len(products))
-                    self.state_manager.correct_category_totals_realtime(category_url, discovered_count)
-                    self.log.info(f"🔄 STATE UPDATE: Updated category {category_url} with {discovered_count} discovered products")
-                
+                    discovered_count = getattr(
+                        self.supplier_scraper, "last_discovered_count", len(products)
+                    )
+                    self.state_manager.correct_category_totals_realtime(
+                        category_url, discovered_count
+                    )
+                    self.log.info(
+                        f"🔄 STATE UPDATE: Updated category {category_url} with {discovered_count} discovered products"
+                    )
+
                 # 🚨 REMOVED: Category-based cache saving logic (now handled per-product in progress callback)
                 # This was causing the update_frequency_products to only save after complete categories
                 # instead of respecting the per-product frequency configuration
-                
+
                 # Check again after adding products from this category
                 if max_products_to_process and len(all_products) >= max_products_to_process:
                     # Trim to exact limit if we exceeded it
                     all_products = all_products[:max_products_to_process]
-                    self.log.info(f"🛑 TRIMMED: Limited to exactly {max_products_to_process} products")
+                    self.log.info(
+                        f"🛑 TRIMMED: Limited to exactly {max_products_to_process} products"
+                    )
                     break
-            
+
             # Batch completion logging
-            self.log.info(f"✅ Completed batch {batch_num}: {len(all_products)} total products extracted so far")
-                
+            self.log.info(
+                f"✅ Completed batch {batch_num}: {len(all_products)} total products extracted so far"
+            )
+
         # 🚨 CRITICAL FIX #1: LINKING MAP FILTERING
         # Filter out products that have already been processed (exist in linking map)
         # This prevents loading all 2,335 cached products when only 50-100 are unprocessed
-        unprocessed_products = self._filter_unprocessed_products_with_hash_lookup(all_products, supplier_name)
-        
+        unprocessed_products = self._filter_unprocessed_products_with_hash_lookup(
+            all_products, supplier_name
+        )
+
         if len(unprocessed_products) != len(all_products):
-            self.log.info(f"🔍 GAP PROCESSING FILTER: {len(all_products)} total cached products → {len(unprocessed_products)} unprocessed products")
-            self.log.info(f"🔍 FILTERING EFFICIENCY: Removed {len(all_products) - len(unprocessed_products)} already processed products")
+            self.log.info(
+                f"🔍 GAP PROCESSING FILTER: {len(all_products)} total cached products → {len(unprocessed_products)} unprocessed products"
+            )
+            self.log.info(
+                f"🔍 FILTERING EFFICIENCY: Removed {len(all_products) - len(unprocessed_products)} already processed products"
+            )
         else:
-            self.log.info(f"🔍 GAP PROCESSING FILTER: All {len(all_products)} products are unprocessed (first run or fresh cache)")
-        
+            self.log.info(
+                f"🔍 GAP PROCESSING FILTER: All {len(all_products)} products are unprocessed (first run or fresh cache)"
+            )
+
         return unprocessed_products
 
     def _create_product_progress_callback(self, category_url: str, progress_config: Dict[str, Any]):
         """Create a progress callback for individual product extraction with proper caching"""
         # Initialize a simple counter if it doesn't exist
-        if not hasattr(self, '_supplier_product_counter'):
+        if not hasattr(self, "_supplier_product_counter"):
             self._supplier_product_counter = 0
-            
-        def progress_callback(operation_type: str, product_index: int, total_products: int, product_url: str, product_data: dict = None):
-            if operation_type == 'supplier_extraction':
+
+        def progress_callback(
+            operation_type: str,
+            product_index: int,
+            total_products: int,
+            product_url: str,
+            product_data: dict = None,
+        ):
+            if operation_type == "supplier_extraction":
                 # 🚨 FIX: Update counter based on actual cache length, not callback attempts
-                if hasattr(self, '_current_all_products') and product_data:
+                if hasattr(self, "_current_all_products") and product_data:
                     # Only increment counter when product is actually added to cache
                     self._supplier_product_counter = len(self._current_all_products)
                 else:
                     # Fallback increment if cache not available
                     self._supplier_product_counter += 1
-                
-                if hasattr(self, 'state_manager') and self.state_manager:
+
+                if hasattr(self, "state_manager") and self.state_manager:
                     try:
                         # Update the main processing index during supplier extraction based on actual cache length
-                        actual_cache_count = len(getattr(self, '_current_all_products', []))
-                        self.state_manager.update_processing_index(actual_cache_count, total_products)
+                        actual_cache_count = len(getattr(self, "_current_all_products", []))
+                        self.state_manager.update_processing_index(
+                            actual_cache_count, total_products
+                        )
                         # Single-writer: update unified progression only
                         self.state_manager.update_progression_unified(
                             current_phase="supplier",
                             current_product_index_in_category=actual_cache_count,
                             total_categories=self._authoritative_total_categories(),
-                            current_category_url=category_url
+                            current_category_url=category_url,
                         )
-                        self.log.info(f"🔍 SUPPLIER STATE UPDATE: Index updated to {actual_cache_count}/{total_products}")
+                        self.log.info(
+                            f"🔍 SUPPLIER STATE UPDATE: Index updated to {actual_cache_count}/{total_products}"
+                        )
                     except Exception as e:
                         self.log.error(f"❌ SUPPLIER STATE UPDATE FAILED: {e}")
-                
+
                 # 🚨 DEFINITIVE FIX: Products are now added by scraper directly to shared list
                 # Progress callback only needs to track progress and trigger cache saves
-                if product_data and hasattr(self, '_current_all_products'):
-                    self.log.info(f"📊 PROGRESS: Product {self._supplier_product_counter} processed (total in cache: {len(self._current_all_products)})")
-                
+                if product_data and hasattr(self, "_current_all_products"):
+                    self.log.info(
+                        f"📊 PROGRESS: Product {self._supplier_product_counter} processed (total in cache: {len(self._current_all_products)})"
+                    )
+
                 # Simple index-based logging (matching Amazon analysis style)
                 if progress_config.get("progress_display", {}).get("show_product_progress", True):
-                    self.log.info(f"🔄 SUPPLIER EXTRACTION: Processing product {self._supplier_product_counter}")
-                
+                    self.log.info(
+                        f"🔄 SUPPLIER EXTRACTION: Processing product {self._supplier_product_counter}"
+                    )
+
                 # 🚨 NEW: Per-product cache saving logic (now works because list is populated)
                 cache_config = self.system_config.get("supplier_cache_control", {})
-                update_frequency = cache_config.get("update_frequency_products", 1)  # Use config value
-                
+                update_frequency = cache_config.get(
+                    "update_frequency_products", 1
+                )  # Use config value
+
                 # Debug logging for cache save logic
-                self.log.info(f"🔍 CACHE CHECK: Product {self._supplier_product_counter}, frequency={update_frequency}, enabled={cache_config.get('enabled', True)}")
-                self.log.info(f"🔍 CACHE CHECK: List length={len(getattr(self, '_current_all_products', []))}, modulo={self._supplier_product_counter % update_frequency}")
-                
+                self.log.info(
+                    f"🔍 CACHE CHECK: Product {self._supplier_product_counter}, frequency={update_frequency}, enabled={cache_config.get('enabled', True)}"
+                )
+                self.log.info(
+                    f"🔍 CACHE CHECK: List length={len(getattr(self, '_current_all_products', []))}, modulo={self._supplier_product_counter % update_frequency}"
+                )
+
                 # Skip redundant saves when nothing new was added
-                current_count = len(getattr(self, '_current_all_products', []))
+                current_count = len(getattr(self, "_current_all_products", []))
                 last_count = getattr(self, "_last_cache_count", None)
                 if last_count is not None and current_count == last_count:
                     self.log.debug("💤 PERIODIC SAVE SKIPPED: 0 new since last")
                     return
-                
-                if (cache_config.get("enabled", True) and 
-                    hasattr(self, '_current_all_products') and
-                    len(self._current_all_products) > 0 and
-                    self._supplier_product_counter % update_frequency == 0):
-                    
+
+                if (
+                    cache_config.get("enabled", True)
+                    and hasattr(self, "_current_all_products")
+                    and len(self._current_all_products) > 0
+                    and self._supplier_product_counter % update_frequency == 0
+                ):
                     # Use centralized path management for consistent cache file construction
                     cache_filename = f"{self.supplier_name.replace('.', '-')}_products_cache.json"
-                    cache_file_path = str(path_manager.get_output_path('cached_products', cache_filename))
-                    
+                    cache_file_path = str(
+                        path_manager.get_output_path("cached_products", cache_filename)
+                    )
+
                     # 🚨 ATOMIC FIX 7: Save current products to cache atomically
-                    new_count = self._save_products_to_cache(self._current_all_products, cache_file_path)
-                    self.log.info(f"💾 ATOMIC PERIODIC SAVE: Saved {len(self._current_all_products)} products ({new_count} new) to cache (every {update_frequency} products)")
-                    
+                    new_count = self._save_products_to_cache(
+                        self._current_all_products, cache_file_path
+                    )
+                    self.log.info(
+                        f"💾 ATOMIC PERIODIC SAVE: Saved {len(self._current_all_products)} products ({new_count} new) to cache (every {update_frequency} products)"
+                    )
+
                     # Track last cache count to avoid redundant saves
                     self._last_cache_count = current_count
-                    
+
                     # 🚨 ATOMIC FIX 9: Only update state AFTER successful cache write
-                    if hasattr(self, 'state_manager') and new_count >= 0:  # new_count >= 0 indicates successful save
+                    if (
+                        hasattr(self, "state_manager") and new_count >= 0
+                    ):  # new_count >= 0 indicates successful save
                         progress = self.state_manager.state_data["supplier_extraction_progress"]
                         # Use actual cache length from successful save
                         progress["products_extracted_total"] = len(self._current_all_products)
@@ -4423,50 +5561,56 @@ Return ONLY valid JSON, no additional text."""
                         progress["extraction_phase"] = "products"
                         progress["last_cache_save_count"] = new_count  # Track incremental saves
                         self.state_manager.save_state(preserve_interruption_state=True)
-                        self.log.debug(f"🔄 ATOMIC STATE: State synchronized with cache after saving {new_count} new products")
-                
+                        self.log.debug(
+                            f"🔄 ATOMIC STATE: State synchronized with cache after saving {new_count} new products"
+                        )
+
                 # 🚨 ATOMIC FIX 10: Separate state update for non-cache-save cycles (maintains progress tracking)
-                elif hasattr(self, 'state_manager'):
+                elif hasattr(self, "state_manager"):
                     progress = self.state_manager.state_data["supplier_extraction_progress"]
                     # Lightweight state update without cache write
                     progress["current_product_url"] = product_url
                     progress["extraction_phase"] = "products"
                     # Don't update products_extracted_total here - only after cache saves
                     self.state_manager.save_state(preserve_interruption_state=True)
-                    
+
         return progress_callback
 
-    def _check_amazon_cache_by_asin(self, asin: str, supplier_ean: str = None) -> Optional[Dict[str, Any]]:
+    def _check_amazon_cache_by_asin(
+        self, asin: str, supplier_ean: str = None
+    ) -> Optional[Dict[str, Any]]:
         """Check for existing Amazon cache data by ASIN with multiple filename patterns."""
-        
+
         # FIX 2: Amazon cache reuse logic - Enhanced ASIN/EAN matching
         amazon_cache_dir = self.amazon_cache_dir
-        
+
         # First: Check for exact EAN match
         if supplier_ean:
             exact_pattern = f"amazon_{asin}_{supplier_ean}.json"
             exact_file = os.path.join(amazon_cache_dir, exact_pattern)
             if os.path.exists(exact_file):
                 try:
-                    with open(exact_file, 'r', encoding='utf-8') as f:
+                    with open(exact_file, "r", encoding="utf-8") as f:
                         self.log.info(f"📋 Found exact EAN match in cache: {exact_pattern}")
                         return json.load(f)
                 except Exception as e:
                     self.log.error(f"Error loading exact EAN match cache: {e}")
-        
+
         # Second: Check for ASIN with different EAN - copy to new filename
         cache_patterns = [
             f"amazon_{asin}_*.json",  # ASIN with any suffix
-            f"amazon_{asin}.json"     # ASIN only
+            f"amazon_{asin}.json",  # ASIN only
         ]
-        
+
         for pattern in cache_patterns:
             cache_path_pattern = os.path.join(amazon_cache_dir, pattern)
-            matching_files = sorted(glob.glob(cache_path_pattern), key=os.path.getmtime, reverse=True)
+            matching_files = sorted(
+                glob.glob(cache_path_pattern), key=os.path.getmtime, reverse=True
+            )
 
             for cache_file in matching_files:
                 try:
-                    with open(cache_file, 'r', encoding='utf-8') as f:
+                    with open(cache_file, "r", encoding="utf-8") as f:
                         cached_data = json.load(f)
                 except Exception as e:
                     self.log.error(f"Error loading cached Amazon data from {cache_file}: {e}")
@@ -4494,146 +5638,187 @@ Return ONLY valid JSON, no additional text."""
 
                     if not os.path.exists(new_filepath):
                         try:
-                            with open(new_filepath, 'w', encoding='utf-8') as f:
+                            with open(new_filepath, "w", encoding="utf-8") as f:
                                 json.dump(cached_data, f, indent=2, ensure_ascii=False)
                             self.log.info(
                                 f"📋 Copied existing cache to EAN-specific file: {new_filename}"
                             )
                         except Exception as copy_error:
-                            self.log.error(f"Error copying cache to EAN-specific file: {copy_error}")
+                            self.log.error(
+                                f"Error copying cache to EAN-specific file: {copy_error}"
+                            )
 
                 self.log.info(f"📋 Found ASIN match in cache: {os.path.basename(cache_file)}")
                 return cached_data
-        
+
         return None
 
     async def _get_amazon_data(self, product_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Handle Amazon search logic (EAN first, then title)."""
         supplier_ean = product_data.get("ean")
-        if hasattr(self, 'state_manager'):
+        if hasattr(self, "state_manager"):
             self.state_manager.update_amazon_analysis_progress_new(product_data.get("url", ""))
-        
+
         # 🚨 FIX: Handle multiple EANs - use first valid EAN only for Amazon search
         if supplier_ean:
             original_ean = str(supplier_ean)
             # Extract first valid EAN (12-14 digits) from various formats: "123/456", "123 456", "123,456", etc.
             import re
-            ean_pattern = re.findall(r'\b\d{12,14}\b', original_ean)
+
+            ean_pattern = re.findall(r"\b\d{12,14}\b", original_ean)
             if ean_pattern and len(ean_pattern) > 1:
                 supplier_ean = ean_pattern[0]  # Use first valid EAN found
-                self.log.info(f"🔧 Multiple EANs detected, using first valid EAN for Amazon search: '{original_ean}' → '{supplier_ean}'")
-            elif '/' in original_ean or ' ' in original_ean.strip():
+                self.log.info(
+                    f"🔧 Multiple EANs detected, using first valid EAN for Amazon search: '{original_ean}' → '{supplier_ean}'"
+                )
+            elif "/" in original_ean or " " in original_ean.strip():
                 # Fallback: split by common separators and take first part
-                for separator in ['/', ' ', ',', ';', '|']:
+                for separator in ["/", " ", ",", ";", "|"]:
                     if separator in original_ean:
                         supplier_ean = original_ean.split(separator)[0].strip()
-                        self.log.info(f"🔧 Multiple EANs detected (separator '{separator}'), using first EAN: '{original_ean}' → '{supplier_ean}'")
+                        self.log.info(
+                            f"🔧 Multiple EANs detected (separator '{separator}'), using first EAN: '{original_ean}' → '{supplier_ean}'"
+                        )
                         break
-        
+
         amazon_product_data = None
         actual_search_method = None  # Track which method actually worked
-        
+
         # 🚨 FIX: Ensure null EAN products attempt title search
         if supplier_ean and supplier_ean.strip() and supplier_ean != "None":
             self.log.info(f"Attempting Amazon search using EAN: {supplier_ean}")
-            amazon_product_data = await self.extractor.search_by_ean_and_extract_data(supplier_ean, product_data["title"])
-            actual_search_method = amazon_product_data.get("_search_method_used", "EAN") if amazon_product_data else "EAN"
-            
+            amazon_product_data = await self.extractor.search_by_ean_and_extract_data(
+                supplier_ean, product_data["title"]
+            )
+            actual_search_method = (
+                amazon_product_data.get("_search_method_used", "EAN")
+                if amazon_product_data
+                else "EAN"
+            )
+
             if amazon_product_data and "error" not in amazon_product_data:
-                self.log.info(f"✅ EAN search successful for {supplier_ean}. Using EAN result without title fallback.")
+                self.log.info(
+                    f"✅ EAN search successful for {supplier_ean}. Using EAN result without title fallback."
+                )
                 amazon_product_data["_search_method_used"] = actual_search_method
                 return amazon_product_data
             else:
-                self.log.info(f"❌ EAN search failed for {supplier_ean}. Will fall back to title search.")
-        
+                self.log.info(
+                    f"❌ EAN search failed for {supplier_ean}. Will fall back to title search."
+                )
+
         # 🚨 FIX: Always attempt title search for null EAN or failed EAN search
         if not amazon_product_data:
-            if supplier_ean: 
+            if supplier_ean:
                 self.log.info("EAN search failed. Falling back to title search.")
-            else: 
+            else:
                 self.log.info("No EAN provided. Using title search.")
-                
-            amazon_search_results = await self.extractor.search_by_title_using_search_bar(product_data["title"])
-            
-            if amazon_search_results and "error" not in amazon_search_results and amazon_search_results.get("results"):
+
+            amazon_search_results = await self.extractor.search_by_title_using_search_bar(
+                product_data["title"]
+            )
+
+            if (
+                amazon_search_results
+                and "error" not in amazon_search_results
+                and amazon_search_results.get("results")
+            ):
                 self.log.info(f"✅ Title search successful for '{product_data['title']}'")
                 # Process title search results with existing logic
                 best_result = None
                 best_confidence = 0.0
-                
+
                 # Use configurable confidence threshold instead of hardcoded value
-                matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
+                matching_thresholds = self.system_config.get("performance", {}).get(
+                    "matching_thresholds", {}
+                )
                 min_confidence = matching_thresholds.get("title_similarity", 0.6)
-                
+
                 for result in amazon_search_results["results"][:3]:  # Check top 3 results
                     validation = self._validate_product_match(product_data, result)
                     confidence = validation.get("confidence", 0.0)
                     if confidence > best_confidence and confidence >= min_confidence:
                         best_confidence = confidence
                         best_result = result
-                
+
                 if best_result:
                     asin = best_result.get("asin")
                     if asin:
-                        self.log.info(f"🎯 Title match found: {best_result.get('title')} (confidence: {best_confidence:.2f})")
+                        self.log.info(
+                            f"🎯 Title match found: {best_result.get('title')} (confidence: {best_confidence:.2f})"
+                        )
                         amazon_product_data = await self.extractor.extract_data(asin)
                         if amazon_product_data:
                             amazon_product_data["_search_method_used"] = "title"
                             amazon_product_data["_match_confidence"] = best_confidence
                             return amazon_product_data
             else:
-                self.log.warning(f"❌ Both EAN and title searches failed for '{product_data['title']}'")
+                self.log.warning(
+                    f"❌ Both EAN and title searches failed for '{product_data['title']}'"
+                )
                 return None
-        
+
         return amazon_product_data
-        
+
         if supplier_ean:
             self.log.info(f"Attempting Amazon search using EAN: {supplier_ean}")
             self.results_summary["products_analyzed_ean"] += 1
-            
+
             # FIX 2: Enhanced Amazon cache reuse logic - Check cache before scraping
             # First try to find cached data by EAN before performing any searches
             cached_data = None
             found_asin = None
-            
+
             # PERFORMANCE OPTIMIZATION: Fast glob-based Amazon cache search using centralized path management
             amazon_cache_dir = str(path_manager.get_output_path("FBA_ANALYSIS", "amazon_cache"))
             if os.path.exists(amazon_cache_dir):
                 # Method 1: Fast EAN-based filename search using glob
                 ean_pattern = os.path.join(amazon_cache_dir, f"*{supplier_ean}*.json")
                 ean_matches = glob.glob(ean_pattern)
-                
+
                 if ean_matches:
                     # Found EAN match in filename - read the first match
                     cache_file = os.path.basename(ean_matches[0])
                     try:
-                        with open(ean_matches[0], 'r', encoding='utf-8') as f:
+                        with open(ean_matches[0], "r", encoding="utf-8") as f:
                             cached_data = json.load(f)
-                            found_asin = cached_data.get("asin") or cached_data.get("asin_extracted_from_page")
-                            self.log.info(f"📋 Found cached Amazon data for EAN {supplier_ean} in file: {cache_file} (fast search)")
+                            found_asin = cached_data.get("asin") or cached_data.get(
+                                "asin_extracted_from_page"
+                            )
+                            self.log.info(
+                                f"📋 Found cached Amazon data for EAN {supplier_ean} in file: {cache_file} (fast search)"
+                            )
                     except Exception as e:
                         self.log.debug(f"Error reading cache file {cache_file}: {e}")
-                
+
                 # 🚀 HASH OPTIMIZATION: Method 2 - If no EAN match found, try O(1) hash lookup for ASIN-based search
-                if not found_asin and hasattr(self, 'hash_optimizer'):
+                if not found_asin and hasattr(self, "hash_optimizer"):
                     existing_entry = self.hash_optimizer.get_entry_by_ean(supplier_ean)
                     if existing_entry:
-                        asin = existing_entry.get('amazon_asin') or existing_entry.get('chosen_amazon_asin')
+                        asin = existing_entry.get("amazon_asin") or existing_entry.get(
+                            "chosen_amazon_asin"
+                        )
                         if asin:
-                            self.log.debug(f"🚀 HASH LOOKUP: Found ASIN {asin} for EAN {supplier_ean} using O(1) lookup")
+                            self.log.debug(
+                                f"🚀 HASH LOOKUP: Found ASIN {asin} for EAN {supplier_ean} using O(1) lookup"
+                            )
                             # Fast ASIN-based glob search
                             asin_pattern = os.path.join(amazon_cache_dir, f"amazon_{asin}_*.json")
                             asin_matches = glob.glob(asin_pattern)
                             if asin_matches:
                                 cache_file = os.path.basename(asin_matches[0])
                                 try:
-                                    with open(asin_matches[0], 'r', encoding='utf-8') as f:
+                                    with open(asin_matches[0], "r", encoding="utf-8") as f:
                                         cached_data = json.load(f)
-                                        found_asin = cached_data.get("asin") or cached_data.get("asin_extracted_from_page")
-                                        self.log.info(f"📋 Found cached Amazon data via linking map: EAN {supplier_ean} -> ASIN {asin} in file: {cache_file} (fast search)")
+                                        found_asin = cached_data.get("asin") or cached_data.get(
+                                            "asin_extracted_from_page"
+                                        )
+                                        self.log.info(
+                                            f"📋 Found cached Amazon data via linking map: EAN {supplier_ean} -> ASIN {asin} in file: {cache_file} (fast search)"
+                                        )
                                 except Exception as e:
                                     self.log.debug(f"Error reading cache file {cache_file}: {e}")
-                                        
+
                 # OLD SLOW METHOD COMMENTED OUT - Performance improvement: 90%+ faster
                 # The old method that was causing infinite loops:
                 # for cache_file in os.listdir(amazon_cache_dir):  # SLOW: scans all files
@@ -4647,12 +5832,15 @@ Return ONLY valid JSON, no additional text."""
                 #                     break
                 #             except Exception as e:
                 #                 self.log.debug(f"Error reading cache file {cache_file}: {e}")
-            
+
             if cached_data:
                 # 🚨 FIX: Validate cached data completeness before using it
-                required_fields = ['current_price', 'price', 'original_price']
-                has_price_data = any(field in cached_data and cached_data[field] is not None for field in required_fields)
-                
+                required_fields = ["current_price", "price", "original_price"]
+                has_price_data = any(
+                    field in cached_data and cached_data[field] is not None
+                    for field in required_fields
+                )
+
                 if has_price_data:
                     # Cached data is complete - use it
                     amazon_product_data = cached_data
@@ -4660,142 +5848,220 @@ Return ONLY valid JSON, no additional text."""
                     self.log.info(f"✅ Using complete cached Amazon data for EAN {supplier_ean}")
                 else:
                     # Cached data is incomplete - trigger fresh scraping
-                    self.log.warning(f"⚠️ Cached data for EAN {supplier_ean} missing price fields. Triggering fresh scraping.")
-                    amazon_product_data = await self.extractor.search_by_ean_and_extract_data(supplier_ean, product_data["title"])
+                    self.log.warning(
+                        f"⚠️ Cached data for EAN {supplier_ean} missing price fields. Triggering fresh scraping."
+                    )
+                    amazon_product_data = await self.extractor.search_by_ean_and_extract_data(
+                        supplier_ean, product_data["title"]
+                    )
                     # Don't hardcode method - let extractor set it based on what actually worked
-                    search_method = amazon_product_data.get("_search_method_used") if amazon_product_data else None
+                    search_method = (
+                        amazon_product_data.get("_search_method_used")
+                        if amazon_product_data
+                        else None
+                    )
                     if not search_method:
-                        self.log.warning(f"🚨 MISSING SEARCH METHOD: No _search_method_used found for EAN {supplier_ean}")
+                        self.log.warning(
+                            f"🚨 MISSING SEARCH METHOD: No _search_method_used found for EAN {supplier_ean}"
+                        )
                         self.log.warning(f"   This may indicate a bug in search method assignment")
-                        actual_search_method = "UNKNOWN"  # Explicit unknown instead of dangerous default
+                        actual_search_method = (
+                            "UNKNOWN"  # Explicit unknown instead of dangerous default
+                        )
                     else:
                         actual_search_method = search_method
             else:
                 # No cache found - perform EAN search
-                amazon_product_data = await self.extractor.search_by_ean_and_extract_data(supplier_ean, product_data["title"])
+                amazon_product_data = await self.extractor.search_by_ean_and_extract_data(
+                    supplier_ean, product_data["title"]
+                )
                 # Don't hardcode method - let extractor set it based on what actually worked
-                search_method = amazon_product_data.get("_search_method_used") if amazon_product_data else None
+                search_method = (
+                    amazon_product_data.get("_search_method_used") if amazon_product_data else None
+                )
                 if not search_method:
-                    self.log.warning(f"🚨 MISSING SEARCH METHOD: No _search_method_used found for EAN {supplier_ean}")
+                    self.log.warning(
+                        f"🚨 MISSING SEARCH METHOD: No _search_method_used found for EAN {supplier_ean}"
+                    )
                     self.log.warning(f"   This may indicate a bug in search method assignment")
-                    actual_search_method = "UNKNOWN"  # Explicit unknown instead of dangerous default
+                    actual_search_method = (
+                        "UNKNOWN"  # Explicit unknown instead of dangerous default
+                    )
                 else:
                     actual_search_method = search_method
-            
+
             if amazon_product_data and "error" not in amazon_product_data:
                 # EAN search succeeded (or we used cached data)
-                found_asin = amazon_product_data.get("asin") or amazon_product_data.get("asin_extracted_from_page")
-                
+                found_asin = amazon_product_data.get("asin") or amazon_product_data.get(
+                    "asin_extracted_from_page"
+                )
+
                 if found_asin and actual_search_method != "EAN_cached":
                     # For fresh EAN search results, check if we need to copy to EAN-specific cache file
                     # Keep the actual search method as determined by the extractor
                     pass  # Don't override actual_search_method here
                 elif not found_asin:
                     actual_search_method = "EAN"  # EAN search succeeded but no ASIN found
-                
+
                 # FIX 1: EAN search successful - skip title search completely
-                self.log.info(f"✅ EAN search successful for {supplier_ean}. Using EAN result without title fallback.")
-                
+                self.log.info(
+                    f"✅ EAN search successful for {supplier_ean}. Using EAN result without title fallback."
+                )
+
                 # Add search method info and return immediately to prevent title search
                 amazon_product_data["_search_method_used"] = actual_search_method
                 return amazon_product_data
             else:
-                amazon_product_data = None # Reset if EAN search failed
-                self.log.info(f"❌ EAN search failed for {supplier_ean}. Will fall back to title search.")
-                
+                amazon_product_data = None  # Reset if EAN search failed
+                self.log.info(
+                    f"❌ EAN search failed for {supplier_ean}. Will fall back to title search."
+                )
+
         if not amazon_product_data:
-            if supplier_ean: self.log.info("EAN search failed. Falling back to title search.")
-            else: self.log.info("No EAN. Using title search.")
+            if supplier_ean:
+                self.log.info("EAN search failed. Falling back to title search.")
+            else:
+                self.log.info("No EAN. Using title search.")
             self.results_summary["products_analyzed_title"] += 1
-            amazon_search_results = await self.extractor.search_by_title_using_search_bar(product_data["title"])
-            if not amazon_search_results or "error" in amazon_search_results or not amazon_search_results.get("results"):
+            amazon_search_results = await self.extractor.search_by_title_using_search_bar(
+                product_data["title"]
+            )
+            if (
+                not amazon_search_results
+                or "error" in amazon_search_results
+                or not amazon_search_results.get("results")
+            ):
                 # 🚨 SURGICAL FIX #4: ENHANCED SEARCH FALLBACK
                 # Improve error handling without replacing existing working logic
-                error_detail = amazon_search_results.get("error") if isinstance(amazon_search_results, dict) else "No results returned"
-                self.log.warning(f"No Amazon results for title '{product_data['title']}'. Error: {error_detail}")
-                
+                error_detail = (
+                    amazon_search_results.get("error")
+                    if isinstance(amazon_search_results, dict)
+                    else "No results returned"
+                )
+                self.log.warning(
+                    f"No Amazon results for title '{product_data['title']}'. Error: {error_detail}"
+                )
+
                 # 🚀 ENHANCEMENT: Try simplified title search if original fails
-                if product_data.get('title') and len(product_data['title']) > 10:
+                if product_data.get("title") and len(product_data["title"]) > 10:
                     # Extract first few meaningful words for simplified search
-                    simplified_title = ' '.join(product_data['title'].split()[:4])  # First 4 words
-                    self.log.info(f"🔄 FALLBACK: Trying simplified title search: '{simplified_title}'")
-                    
-                    simplified_results = await self.extractor.search_by_title_using_search_bar(simplified_title)
-                    if simplified_results and "error" not in simplified_results and simplified_results.get("results"):
-                        self.log.info(f"✅ SIMPLIFIED SEARCH SUCCESS: Found {len(simplified_results['results'])} results")
+                    simplified_title = " ".join(product_data["title"].split()[:4])  # First 4 words
+                    self.log.info(
+                        f"🔄 FALLBACK: Trying simplified title search: '{simplified_title}'"
+                    )
+
+                    simplified_results = await self.extractor.search_by_title_using_search_bar(
+                        simplified_title
+                    )
+                    if (
+                        simplified_results
+                        and "error" not in simplified_results
+                        and simplified_results.get("results")
+                    ):
+                        self.log.info(
+                            f"✅ SIMPLIFIED SEARCH SUCCESS: Found {len(simplified_results['results'])} results"
+                        )
                         amazon_search_results = simplified_results
                     else:
-                        self.log.warning(f"💫 SIMPLIFIED SEARCH ALSO FAILED: No results for simplified title '{simplified_title}'")
+                        self.log.warning(
+                            f"💫 SIMPLIFIED SEARCH ALSO FAILED: No results for simplified title '{simplified_title}'"
+                        )
                         return None
                 else:
                     return None
-                
+
             best_result = None
             best_confidence = 0.0
-            
+
             # Use configurable confidence threshold instead of hardcoded value
-            matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-            confidence_threshold = matching_thresholds.get("medium_title_similarity", 0.5)  # More conservative than old 0.4
-            
-            self.log.info(f"🔍 PRODUCT VALIDATION: Evaluating {len(amazon_search_results['results'])} Amazon results for '{product_data['title']}'")
-            
+            matching_thresholds = self.system_config.get("performance", {}).get(
+                "matching_thresholds", {}
+            )
+            confidence_threshold = matching_thresholds.get(
+                "medium_title_similarity", 0.5
+            )  # More conservative than old 0.4
+
+            self.log.info(
+                f"🔍 PRODUCT VALIDATION: Evaluating {len(amazon_search_results['results'])} Amazon results for '{product_data['title']}'"
+            )
+
             for i, result in enumerate(amazon_search_results["results"][:5]):  # Check top 5 results
                 # Use existing _validate_product_match method (now fixed)
                 amazon_product_data = {"title": result.get("title", "")}
                 validation = self._validate_product_match(product_data, amazon_product_data)
-                
+
                 confidence = validation.get("confidence", 0.0)
                 match_quality = validation.get("match_quality", "low")
                 overlap_score = validation.get("title_overlap_score", 0.0)
-                
-                self.log.info(f"📊 Result {i+1}: ASIN {result.get('asin')} - Confidence: {confidence:.3f} ({match_quality}) - Overlap: {overlap_score:.3f} - '{result.get('title', 'No title')[:60]}...'")
-                
+
+                self.log.info(
+                    f"📊 Result {i+1}: ASIN {result.get('asin')} - Confidence: {confidence:.3f} ({match_quality}) - Overlap: {overlap_score:.3f} - '{result.get('title', 'No title')[:60]}...'"
+                )
+
                 if confidence > best_confidence and confidence >= confidence_threshold:
                     best_confidence = confidence
                     best_result = result
-            
+
             if not best_result:
                 # 🚨 SURGICAL FIX #4: ENHANCED NO-MATCH HANDLING
-                self.log.warning(f"🚨 NO CONFIDENT MATCH: All Amazon results below {confidence_threshold:.1%} confidence threshold for '{product_data['title']}'. Skipping to prevent irrational matches.")
-                
+                self.log.warning(
+                    f"🚨 NO CONFIDENT MATCH: All Amazon results below {confidence_threshold:.1%} confidence threshold for '{product_data['title']}'. Skipping to prevent irrational matches."
+                )
+
                 # 🚀 ENHANCEMENT: Log detailed analysis for debugging
                 self.log.info(f"📊 CONFIDENCE ANALYSIS SUMMARY:")
                 self.log.info(f"   🎯 Threshold: {confidence_threshold:.1%}")
                 self.log.info(f"   📈 Best confidence achieved: {best_confidence:.1%}")
                 self.log.info(f"   📉 Results analyzed: {len(amazon_search_results['results'][:5])}")
-                
+
                 # 💫 ADDITIONAL FALLBACK: Try with even more simplified title if confidence is close
                 if best_confidence > (confidence_threshold * 0.8):  # Within 80% of threshold
                     # Extract brand or key product identifier
-                    title_words = product_data['title'].split()
+                    title_words = product_data["title"].split()
                     if len(title_words) >= 2:
                         brand_search = title_words[0]  # Assume first word is brand
-                        self.log.info(f"🎯 BRAND FALLBACK: Trying brand-only search: '{brand_search}'")
-                        
-                        brand_results = await self.extractor.search_by_title_using_search_bar(brand_search)
-                        if brand_results and "error" not in brand_results and brand_results.get("results"):
+                        self.log.info(
+                            f"🎯 BRAND FALLBACK: Trying brand-only search: '{brand_search}'"
+                        )
+
+                        brand_results = await self.extractor.search_by_title_using_search_bar(
+                            brand_search
+                        )
+                        if (
+                            brand_results
+                            and "error" not in brand_results
+                            and brand_results.get("results")
+                        ):
                             # Quick confidence check on brand results
                             for result in brand_results["results"][:3]:  # Check top 3 brand results
                                 amazon_product_data = {"title": result.get("title", "")}
-                                validation = self._validate_product_match(product_data, amazon_product_data)
+                                validation = self._validate_product_match(
+                                    product_data, amazon_product_data
+                                )
                                 if validation.get("confidence", 0.0) >= confidence_threshold:
-                                    self.log.info(f"✅ BRAND SEARCH SUCCESS: Found match with {validation.get('confidence', 0.0):.1%} confidence")
+                                    self.log.info(
+                                        f"✅ BRAND SEARCH SUCCESS: Found match with {validation.get('confidence', 0.0):.1%} confidence"
+                                    )
                                     best_result = result
                                     best_confidence = validation.get("confidence", 0.0)
                                     break
-                
+
                 if not best_result:
                     return None
-            
-            self.log.info(f"✅ BEST MATCH: ASIN {best_result.get('asin')} with {best_confidence:.1%} confidence")
+
+            self.log.info(
+                f"✅ BEST MATCH: ASIN {best_result.get('asin')} with {best_confidence:.1%} confidence"
+            )
             asin = best_result.get("asin")
             if not asin:
-                self.log.warning(f"Could not determine ASIN for '{product_data['title']}'. Skipping.")
+                self.log.warning(
+                    f"Could not determine ASIN for '{product_data['title']}'. Skipping."
+                )
                 return None
-            
+
             # ENHANCEMENT: Check Amazon cache before scraping
             amazon_product_data = self._check_amazon_cache_by_asin(asin, supplier_ean)
-            
+
             if amazon_product_data:
                 # Cache hit - use cached data
                 actual_search_method = "title_cached"
@@ -4805,40 +6071,48 @@ Return ONLY valid JSON, no additional text."""
                 amazon_product_data = await self.extractor.extract_data(asin)
                 if amazon_product_data and "error" not in amazon_product_data:
                     actual_search_method = "title"  # Title search succeeded
-                
+
         if not amazon_product_data or "error" in amazon_product_data:
-            self.log.warning(f"Failed to get valid Amazon data for '{product_data['title']}'. Skipping.")
+            self.log.warning(
+                f"Failed to get valid Amazon data for '{product_data['title']}'. Skipping."
+            )
             self.results_summary["errors"] += 1
             return None
-            
+
         # Add search method info to the returned data for accurate linking map creation
         amazon_product_data["_search_method_used"] = actual_search_method
         return amazon_product_data
 
     def _save_final_report(self, profitable_results: List[Dict[str, Any]], supplier_name: str):
         """Generate CSV financial report using FBA_Financial_calculator."""
-        self.log.info(f"🔍 DEBUG: _save_final_report called with {len(profitable_results) if profitable_results else 0} profitable results")
-        
+        self.log.info(
+            f"🔍 DEBUG: _save_final_report called with {len(profitable_results) if profitable_results else 0} profitable results"
+        )
+
         # Always call FBA_Financial_calculator to generate CSV report regardless of profitable_results
         # The calculator will process linking_map and generate comprehensive financial analysis
         try:
-            self.log.info("📊 Calling FBA_Financial_calculator.run_calculations to generate CSV financial report...")
-            
+            self.log.info(
+                "📊 Calling FBA_Financial_calculator.run_calculations to generate CSV financial report..."
+            )
+
             # Call run_calculations with supplier_name to generate CSV report
             run_calculations(supplier_name)
-            
+
             self.log.info("✅ Financial report CSV generation completed successfully")
-            
+
         except Exception as e:
             self.log.error(f"❌ CRITICAL: Error generating financial report CSV: {e}", exc_info=True)
 
-    def _combine_data(self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    def _combine_data(
+        self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str
+    ) -> Dict[str, Any]:
         """Combine supplier and Amazon data and calculate financial metrics."""
         combined = {
             "supplier_product_info": supplier_data,
             "amazon_product_info": amazon_data,
             "analysis_timestamp": datetime.now().isoformat(),
-            "session_id": session_id
+            "session_id": session_id,
         }
         # Financial calculation is now handled within the main run loop before this function is called
         # This function is primarily for combining data and adding match validation
@@ -4848,33 +6122,39 @@ Return ONLY valid JSON, no additional text."""
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
-    
+
     def _sanitize_filename(self, title: str) -> str:
         """Sanitize product title for use in filename"""
         if not title:
             return "unknown_title"
         # Remove or replace problematic characters
-        sanitized = re.sub(r'[^\w\s-]', '', title)
-        sanitized = re.sub(r'\s+', '_', sanitized)
+        sanitized = re.sub(r"[^\w\s-]", "", title)
+        sanitized = re.sub(r"\s+", "_", sanitized)
         return sanitized[:50]  # Limit length to 50 chars
 
-    def _validate_product_match(self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate_product_match(
+        self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Validate the match between supplier and Amazon products using configurable thresholds."""
-        matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-        
+        matching_thresholds = self.system_config.get("performance", {}).get(
+            "matching_thresholds", {}
+        )
+
         # Get configurable thresholds with fallback to more conservative defaults
         title_similarity_threshold = matching_thresholds.get("title_similarity", 0.25)
-        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5) 
+        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5)
         high_title_similarity = matching_thresholds.get("high_title_similarity", 0.75)
-        
-        title_overlap_score = self._overlap_score(supplier_product.get("title", ""), amazon_product.get("title", ""))
+
+        title_overlap_score = self._overlap_score(
+            supplier_product.get("title", ""), amazon_product.get("title", "")
+        )
 
         match_quality = "low"
         confidence = 0.0
-        
+
         # Use configurable thresholds - much more strict than previous hardcoded values
         if title_overlap_score >= high_title_similarity:
             match_quality = "high"
@@ -4889,9 +6169,15 @@ Return ONLY valid JSON, no additional text."""
             match_quality = "very_low"
             confidence = 0.1
 
-        self.log.debug(f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})")
-        
-        return {"match_quality": match_quality, "confidence": confidence, "title_overlap_score": title_overlap_score}
+        self.log.debug(
+            f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})"
+        )
+
+        return {
+            "match_quality": match_quality,
+            "confidence": confidence,
+            "title_overlap_score": title_overlap_score,
+        }
 
     def _is_product_meeting_criteria(self, combined_data: Dict[str, Any]) -> bool:
         """Check if a product meets all defined business criteria."""
@@ -4900,22 +6186,41 @@ Return ONLY valid JSON, no additional text."""
         amazon_data = combined_data.get("amazon_product_info", {})
         financials = combined_data.get("financials", {})
         # Check profitability (already done, but for completeness)
-        is_profitable = financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        is_profitable = (
+            financials.get("ROI", 0) > MIN_ROI_PERCENT
+            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        )
         # Check Amazon listing quality
         meets_rating = amazon_data.get("rating", 0) >= MIN_RATING
         meets_reviews = amazon_data.get("reviews", 0) >= MIN_REVIEWS
         meets_sales_rank = amazon_data.get("sales_rank", MAX_SALES_RANK + 1) <= MAX_SALES_RANK
         # Check for battery products (using the helper function)
-        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(combined_data["supplier_product_info"].get("title", ""))
+        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(
+            combined_data["supplier_product_info"].get("title", "")
+        )
         # Check for other non-FBA friendly keywords
-        is_non_fba_friendly = any(k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS) or \
-                              any(k in combined_data["supplier_product_info"].get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS)
+        is_non_fba_friendly = any(
+            k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS
+        ) or any(
+            k in combined_data["supplier_product_info"].get("title", "").lower()
+            for k in NON_FBA_FRIENDLY_KEYWORDS
+        )
         # All criteria must be met
-        return is_profitable and meets_rating and meets_reviews and meets_sales_rank and not is_battery and not is_non_fba_friendly
+        return (
+            is_profitable
+            and meets_rating
+            and meets_reviews
+            and meets_sales_rank
+            and not is_battery
+            and not is_non_fba_friendly
+        )
 
-    def _apply_batch_synchronization(self, max_products_per_cycle: int, 
-                                   supplier_extraction_batch_size: int,
-                                   batch_sync_config: Dict[str, Any]) -> Tuple[int, int]:
+    def _apply_batch_synchronization(
+        self,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+        batch_sync_config: Dict[str, Any],
+    ) -> Tuple[int, int]:
         """
         Apply batch synchronization to align all batch sizes consistently.
         Returns updated max_products_per_cycle and supplier_extraction_batch_size.
@@ -4923,55 +6228,69 @@ Return ONLY valid JSON, no additional text."""
         target_batch_size = batch_sync_config.get("target_batch_size", 3)
         synchronize_all = batch_sync_config.get("synchronize_all_batch_sizes", False)
         validation_config = batch_sync_config.get("validation", {})
-        
+
         self.log.info(f"🔄 BATCH SYNCHRONIZATION: Enabled")
         self.log.info(f"   target_batch_size: {target_batch_size}")
         self.log.info(f"   synchronize_all_batch_sizes: {synchronize_all}")
-        
+
         original_values = {
             "max_products_per_cycle": max_products_per_cycle,
             "supplier_extraction_batch_size": supplier_extraction_batch_size,
             "linking_map_batch_size": self.system_config.get("linking_map_batch_size", 1),
-            "financial_report_batch_size": self.config_loader.get_financial_batch_size()
+            "financial_report_batch_size": self.config_loader.get_financial_batch_size(),
         }
-        
+
         # Check for mismatched sizes and warn if configured
         if validation_config.get("warn_on_mismatched_sizes", True):
             unique_sizes = set(original_values.values())
             if len(unique_sizes) > 1:
-                self.log.warning(f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}")
+                self.log.warning(
+                    f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}"
+                )
                 self.log.warning(f"   Unique sizes found: {sorted(unique_sizes)}")
-        
+
         if synchronize_all:
             # Synchronize all batch sizes to target
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
+
             # Also update system config values in memory for consistency
             if "system" in self.system_config:
                 self.system_config["max_products_per_cycle"] = target_batch_size
                 self.system_config["supplier_extraction_batch_size"] = target_batch_size
                 self.system_config["linking_map_batch_size"] = target_batch_size
                 # financial_report_batch_size managed by config_loader
-            
+
             self.log.info(f"✅ BATCH SYNC: All batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-            
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         else:
             # Only synchronize the two main processing batch sizes
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
-            self.log.info(f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-        
+
+            self.log.info(
+                f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}"
+            )
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         return new_max_products_per_cycle, new_supplier_extraction_batch_size
 
-    async def _run_hybrid_processing_mode(self, supplier_url: str, supplier_name: str, 
-                                         category_urls_to_scrape: List[str], 
-                                         max_products_per_category: int, max_products_to_process: int,
-                                         max_analyzed_products: int, max_products_per_cycle: int, 
-                                         supplier_extraction_batch_size: int) -> List[Dict[str, Any]]:
+    async def _run_hybrid_processing_mode(
+        self,
+        supplier_url: str,
+        supplier_name: str,
+        category_urls_to_scrape: List[str],
+        max_products_per_category: int,
+        max_products_to_process: int,
+        max_analyzed_products: int,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+    ) -> List[Dict[str, Any]]:
         """
         Hybrid processing mode that allows switching between supplier extraction and Amazon analysis.
         Supports chunked, sequential, and balanced processing modes.
@@ -4981,30 +6300,39 @@ Return ONLY valid JSON, no additional text."""
         hybrid_config = full_config.get("hybrid_processing", {})
         processing_modes = hybrid_config.get("processing_modes", {})
         switch_after_categories = hybrid_config.get("switch_to_amazon_after_categories")
-        
+
         self.log.info(f"🔄 HYBRID PROCESSING: Mode configuration loaded")
         self.log.info(f"   switch_to_amazon_after_categories: {switch_after_categories}")
-        
+
         if processing_modes.get("chunked", {}).get("enabled", False):
             # Chunked mode: Alternate between supplier extraction and Amazon analysis
             chunk_size = processing_modes.get("chunked", {}).get("chunk_size_categories")
             if not chunk_size:
-                self.log.error("❌ CONFIGURATION ERROR: chunk_size_categories not found in hybrid_processing.processing_modes.chunked")
+                self.log.error(
+                    "❌ CONFIGURATION ERROR: chunk_size_categories not found in hybrid_processing.processing_modes.chunked"
+                )
                 return profitable_results
-            
-            self.log.info(f"🔄 HYBRID MODE: Chunked processing (chunk size: {chunk_size} categories)")
-            
+
+            self.log.info(
+                f"🔄 HYBRID MODE: Chunked processing (chunk size: {chunk_size} categories)"
+            )
 
             # Process categories in chunks
             for chunk_start in range(0, len(category_urls_to_scrape), chunk_size):
                 chunk_end = min(chunk_start + chunk_size, len(category_urls_to_scrape))
                 chunk_categories = category_urls_to_scrape[chunk_start:chunk_end]
-                
-                self.log.info(f"🔄 Processing chunk {chunk_start//chunk_size + 1}: categories {chunk_start+1}-{chunk_end}")
-                
+
+                self.log.info(
+                    f"🔄 Processing chunk {chunk_start//chunk_size + 1}: categories {chunk_start+1}-{chunk_end}"
+                )
+
                 chunk_products = await self._extract_supplier_products(
-                    supplier_url, supplier_name, chunk_categories,
-                    max_products_per_category, max_products_to_process, supplier_extraction_batch_size
+                    supplier_url,
+                    supplier_name,
+                    chunk_categories,
+                    max_products_per_category,
+                    max_products_to_process,
+                    supplier_extraction_batch_size,
                 )
 
                 if chunk_products:
@@ -5012,7 +6340,7 @@ Return ONLY valid JSON, no additional text."""
                     cached_products: List[Dict[str, Any]] = []
                     if actual_cache_file:
                         try:
-                            with open(actual_cache_file, 'r', encoding='utf-8') as fh:
+                            with open(actual_cache_file, "r", encoding="utf-8") as fh:
                                 cached_products = json.load(fh)
                         except Exception as e:
                             self.log.warning(f"⚠️ Could not read supplier cache: {e}")
@@ -5021,87 +6349,108 @@ Return ONLY valid JSON, no additional text."""
                     for idx_offset, category_url in enumerate(chunk_categories):
                         # 🚨 Track category processing start time for summary logging
                         self._category_start_time = datetime.now()
-                        
+
                         urls = self.category_manifests.get(category_url, [])
                         # Set category index for manifest logging
                         category_index = chunk_start + idx_offset + 1
                         self._set_current_category_index(category_index)
-                        
+
                         # 🚨 CRITICAL FIX: Generate atomic manifest BEFORE filtering (authoritative bridge)
                         try:
                             self._save_category_manifest(supplier_name, category_url, urls)
-                            self.log.debug(f"📝 MANIFEST: Successfully saved manifest for category {category_index} before filtering")
+                            self.log.debug(
+                                f"📝 MANIFEST: Successfully saved manifest for category {category_index} before filtering"
+                            )
                         except Exception as e:
-                            self.log.error(f"❌ MANIFEST ERROR: Failed to save manifest for category {category_index}: {e}")
+                            self.log.error(
+                                f"❌ MANIFEST ERROR: Failed to save manifest for category {category_index}: {e}"
+                            )
                             # Continue processing but log the failure
-                            
+
                         # 🚨 LEGACY FILTERING PATH REMOVED - Now using the new pre-extraction filtering from lines 3907-3975
                         # This prevents double URL extraction and conflicting filtering decisions
                         # 🚨 PERMANENT REMOVAL: Legacy filtering approach permanently disabled
                         # DO NOT RE-INTEGRATE: This legacy filtering code has been permanently removed
                         # because it conflicts with the new 2-step pre-extraction filtering.
-                        # 
+                        #
                         # The new filtering correctly handles (per project memory specification):
                         # 1. SKIP_ENTIRELY: Products in linking map (fully processed)
-                        # 2. NEEDS_AMAZON_ONLY: Products in cache but not linking map  
+                        # 2. NEEDS_AMAZON_ONLY: Products in cache but not linking map
                         # 3. NEEDS_FULL_EXTRACTION: Products in neither file
-                        # 
+                        #
                         # Legacy approach was causing:
                         # - Double URL extraction
                         # - Filter bypass due to missing load_linking_map_urls method
                         # - Processing all 59 URLs despite filter saying only 5 needed
-                        # 
+                        #
                         # All filtering is now handled in the pre-extraction phase (lines 3907-3975).
                         # If debugging is needed, check the pre-extraction filtering logs:
                         # - "🔗 DETAILED PRE-EXTRACTION FILTERING: Analyzing X collected URLs"
                         # - "🔗 STEP 1 - LINKING MAP CHECK: X complete (skipped)"
                         # - "💾 STEP 2 - PRODUCT CACHE CHECK: X have supplier data; X need supplier extraction"
-                        
+
                         # Skip legacy filtering entirely - use pre-extraction results
-                        self.log.info(f"⚡ LEGACY FILTER BYPASSED: Using pre-extraction filter results for chunk {chunk_start + 1}")
+                        self.log.info(
+                            f"⚡ LEGACY FILTER BYPASSED: Using pre-extraction filter results for chunk {chunk_start + 1}"
+                        )
                         continue  # Move to next chunk/category
 
-    def _validate_filter_invariant(self, input_urls: List[str], filtered: Dict[str, List[str]], 
-                                  category_index: int = None, slug: str = None) -> None:
+    def _validate_filter_invariant(
+        self,
+        input_urls: List[str],
+        filtered: Dict[str, List[str]],
+        category_index: int = None,
+        slug: str = None,
+    ) -> None:
         """
         🚨 CRITICAL FIX: Validate filter invariant and log results per project specification.
         Ensures that filter logic correctly accounts for all input URLs.
-        
+
         Args:
             input_urls: Original list of URLs to filter
             filtered: Result from filter_urls() containing skip_entirely, needs_amazon_only, needs_full_extraction
             category_index: Category index for logging context
             slug: Category slug for logging context
-        
+
         Raises:
             RuntimeError: If filter invariant is violated (data integrity compromised)
         """
-        skip_count = len(filtered['skip_entirely'])
-        amazon_count = len(filtered['needs_amazon_only'])
-        full_count = len(filtered['needs_full_extraction'])
+        skip_count = len(filtered["skip_entirely"])
+        amazon_count = len(filtered["needs_amazon_only"])
+        full_count = len(filtered["needs_full_extraction"])
         total_input = len(input_urls)
         total_output = skip_count + amazon_count + full_count
-        
+
         # Enhanced logging with filter transparency - removed to avoid duplication
         # Main filter transparency logs appear in hybrid workflow (lines 4472-4474)
         context = f"[C{category_index} {slug}]" if category_index and slug else "[Filter]"
-        
+
         # 🚨 CRITICAL INVARIANT VALIDATION per project memory requirement
         if total_input != total_output:
             self.log.error(f"❌ FILTER INVARIANT VIOLATION: in={total_input} != out={total_output}")
-            self.log.error(f"   skip={skip_count} + amz_only={amazon_count} + full={full_count} = {total_output}")
-            self.log.error(f"   This indicates a bug in the filtering logic - data integrity compromised")
-            
+            self.log.error(
+                f"   skip={skip_count} + amz_only={amazon_count} + full={full_count} = {total_output}"
+            )
+            self.log.error(
+                f"   This indicates a bug in the filtering logic - data integrity compromised"
+            )
+
             # Detailed debugging information
             difference = total_input - total_output
-            self.log.error(f"   Difference: {difference} products {'missing' if difference > 0 else 'extra'}")
-            
+            self.log.error(
+                f"   Difference: {difference} products {'missing' if difference > 0 else 'extra'}"
+            )
+
             # This is a critical data integrity issue - raise exception
-            raise RuntimeError(f"Filter invariant violation in {context}: data integrity compromised")
+            raise RuntimeError(
+                f"Filter invariant violation in {context}: data integrity compromised"
+            )
         else:
             # Project specification format: "🧮 Filter Invariant: in=<N> == skip=<A> + amz_only=<B> + full=<C>"
-            self.log.info(f"🧮 Filter Invariant: in={total_input} == skip={skip_count} + amz_only={amazon_count} + full={full_count}")
-            
+            self.log.info(
+                f"🧮 Filter Invariant: in={total_input} == skip={skip_count} + amz_only={amazon_count} + full={full_count}"
+            )
+
             # Compact logging for backward compatibility
             self.log.info(
                 f"FILTER{context}: in={total_input} "
@@ -5109,15 +6458,22 @@ Return ONLY valid JSON, no additional text."""
                 f"needs_amz={amazon_count} "
                 f"needs_full={full_count}"
             )
-            
-    def _log_category_summary(self, category_index: int, category_url: str, 
-                             discovered_count: int, skip_count: int, 
-                             amazon_count: int, full_count: int, 
-                             start_time: datetime, profitable_count: int = 0) -> None:
+
+    def _log_category_summary(
+        self,
+        category_index: int,
+        category_url: str,
+        discovered_count: int,
+        skip_count: int,
+        amazon_count: int,
+        full_count: int,
+        start_time: datetime,
+        profitable_count: int = 0,
+    ) -> None:
         """
         📊 Log comprehensive category completion summary per project specification.
         Required by project memory: "00d39165-8042-4d53-b3c2-0d1591864be4"
-        
+
         Args:
             category_index: Absolute category index (1-based for user display)
             category_url: Category URL being processed
@@ -5132,7 +6488,7 @@ Return ONLY valid JSON, no additional text."""
             # Generate category slug for consistent logging
             slug = re.sub(r"[^a-z0-9]+", "-", category_url.lower()).strip("-")[:30]
             duration = datetime.now() - start_time
-            
+
             # 🚨 PROJECT MEMORY COMPLIANCE: Structured category summary format
             self.log.info(f"📊 CATEGORY SUMMARY[C{category_index} {slug}]")
             self.log.info(f"  discovered (frozen) : {discovered_count}")
@@ -5141,94 +6497,121 @@ Return ONLY valid JSON, no additional text."""
             self.log.info(f"  full_extraction     : {full_count}")
             self.log.info(f"  profitable_found    : {profitable_count}")
             self.log.info(f"  duration            : {duration}")
-            
+
             # Additional metrics for analysis
             if discovered_count > 0:
                 skip_percentage = (skip_count / discovered_count) * 100
                 processing_percentage = ((amazon_count + full_count) / discovered_count) * 100
-                self.log.info(f"  efficiency          : {skip_percentage:.1f}% skipped, {processing_percentage:.1f}% processed")
-                
+                self.log.info(
+                    f"  efficiency          : {skip_percentage:.1f}% skipped, {processing_percentage:.1f}% processed"
+                )
+
             if amazon_count + full_count > 0:
                 profitability_rate = (profitable_count / (amazon_count + full_count)) * 100
-                self.log.info(f"  profitability_rate  : {profitability_rate:.1f}% ({profitable_count}/{amazon_count + full_count})")
-                
+                self.log.info(
+                    f"  profitability_rate  : {profitability_rate:.1f}% ({profitable_count}/{amazon_count + full_count})"
+                )
+
         except Exception as e:
-            self.log.error(f"❌ CATEGORY SUMMARY ERROR: Failed to log summary for category {category_index}: {e}")
-            
+            self.log.error(
+                f"❌ CATEGORY SUMMARY ERROR: Failed to log summary for category {category_index}: {e}"
+            )
+
     def _validate_resume_point(self, resume_data: Dict[str, Any]) -> tuple[bool, List[str]]:
         """
         🚨 CRITICAL: Validate resume point integrity with hard guards per project specification.
         Required by project memory for safe resumption without corruption.
-        
+
         Args:
             resume_data: State data for resumption validation
-            
+
         Returns:
             Tuple of (is_valid, error_list) where is_valid is bool and error_list contains validation failures
         """
         errors = []
         sp = resume_data.get("system_progression", {})
-        
+
         try:
             # 🚨 CRITICAL: Validate required fields exist
-            required_fields = ["current_phase", "current_category_index", "current_product_index_in_category"]
+            required_fields = [
+                "current_phase",
+                "current_category_index",
+                "current_product_index_in_category",
+            ]
             for field in required_fields:
                 if field not in sp:
                     errors.append(f"Missing required field: {field}")
-            
+
             # 🚨 CRITICAL: Validate field types and bounds
             current_category_index = sp.get("current_category_index", -1)
             current_product_index = sp.get("current_product_index_in_category", -1)
             total_categories = sp.get("total_categories", 0)
             total_products = sp.get("total_products_in_current_category", 0)
-            
+
             # Validate category bounds
             if current_category_index < 0:
-                errors.append(f"Invalid current_category_index: {current_category_index} (must be >= 0)")
+                errors.append(
+                    f"Invalid current_category_index: {current_category_index} (must be >= 0)"
+                )
             elif total_categories > 0 and current_category_index >= total_categories:
-                errors.append(f"Category index out of bounds: {current_category_index} >= {total_categories}")
-            
+                errors.append(
+                    f"Category index out of bounds: {current_category_index} >= {total_categories}"
+                )
+
             # Validate product bounds
             if current_product_index < 0:
-                errors.append(f"Invalid current_product_index_in_category: {current_product_index} (must be >= 0)")
+                errors.append(
+                    f"Invalid current_product_index_in_category: {current_product_index} (must be >= 0)"
+                )
             elif total_products > 0 and current_product_index > total_products:
-                errors.append(f"Product index out of bounds: {current_product_index} > {total_products}")
-            
+                errors.append(
+                    f"Product index out of bounds: {current_product_index} > {total_products}"
+                )
+
             # 🚨 CRITICAL: Validate phase consistency
             current_phase = sp.get("current_phase", "")
             valid_phases = ["supplier", "amazon_analysis", "financial_analysis", "complete"]
             if current_phase not in valid_phases:
                 errors.append(f"Invalid phase: {current_phase} (must be one of {valid_phases})")
-            
+
             # 🚨 CRITICAL: Cross-validate with file system state
             current_category_url = sp.get("current_category_url", "")
             if current_category_url:
                 # Check if category manifests exist for consistency
                 try:
                     slug = re.sub(r"[^a-z0-9]+", "-", current_category_url.lower()).strip("-")[:30]
-                    manifest_path = Path("OUTPUTS") / "manifests" / "poundwholesale.co.uk" / f"{slug}.json"
+                    manifest_path = (
+                        Path("OUTPUTS") / "manifests" / "poundwholesale.co.uk" / f"{slug}.json"
+                    )
                     if not manifest_path.exists():
-                        self.log.warning(f"⚠️ RESUME INTEGRITY: Manifest missing for current category {current_category_url}")
+                        self.log.warning(
+                            f"⚠️ RESUME INTEGRITY: Manifest missing for current category {current_category_url}"
+                        )
                         # This is a warning, not an error - we can continue without the manifest
                 except Exception as manifest_error:
-                    self.log.warning(f"⚠️ RESUME INTEGRITY: Could not check manifest: {manifest_error}")
-            
+                    self.log.warning(
+                        f"⚠️ RESUME INTEGRITY: Could not check manifest: {manifest_error}"
+                    )
+
             # 🚨 CRITICAL: Validate timestamp integrity
             last_updated = sp.get("last_updated", "")
             if last_updated:
                 try:
                     from datetime import datetime, timezone
-                    last_update_time = datetime.fromisoformat(last_updated.replace('Z', '+00:00'))
+
+                    last_update_time = datetime.fromisoformat(last_updated.replace("Z", "+00:00"))
                     time_since_update = datetime.now(timezone.utc) - last_update_time
-                    
+
                     # Warn if resume point is very old (>24 hours)
                     if time_since_update.total_seconds() > 86400:  # 24 hours
                         hours_old = time_since_update.total_seconds() / 3600
-                        self.log.warning(f"⚠️ RESUME INTEGRITY: Resume point is {hours_old:.1f} hours old")
-                        
+                        self.log.warning(
+                            f"⚠️ RESUME INTEGRITY: Resume point is {hours_old:.1f} hours old"
+                        )
+
                 except Exception as time_error:
                     errors.append(f"Invalid timestamp format: {last_updated}")
-            
+
             # 🚨 CRITICAL: Log validation results
             if errors:
                 self.log.error(f"❌ RESUME VALIDATION FAILED: {len(errors)} integrity errors found")
@@ -5237,9 +6620,11 @@ Return ONLY valid JSON, no additional text."""
                 return False, errors
             else:
                 self.log.info(f"✅ RESUME VALIDATION PASSED: Resume point integrity confirmed")
-                self.log.info(f"   Phase: {current_phase}, Category: {current_category_index}/{total_categories}, Product: {current_product_index}/{total_products}")
+                self.log.info(
+                    f"   Phase: {current_phase}, Category: {current_category_index}/{total_categories}, Product: {current_product_index}/{total_products}"
+                )
                 return True, []
-                
+
         except Exception as e:
             error_msg = f"Resume validation exception: {e}"
             errors.append(error_msg)
@@ -5253,19 +6638,26 @@ Return ONLY valid JSON, no additional text."""
         """
         financial_batch_size = self.config_loader.get_financial_batch_size()
         if not financial_batch_size:
-            self.log.error("❌ CONFIGURATION ERROR: financial_report_batch_size not found in system config")
+            self.log.error(
+                "❌ CONFIGURATION ERROR: financial_report_batch_size not found in system config"
+            )
             return False
-        
+
         current_linking_map_count = len(self.linking_map)
-        
+
         # ✅ CORRECTED LOGIC: financial_report_batch_size is TRIGGER MECHANISM (every N linking map entries)
         if current_linking_map_count > 0 and current_linking_map_count % financial_batch_size == 0:
             try:
-                self.log.info(f"🚨 FINANCIAL REPORT TRIGGER: Reached {current_linking_map_count} linking map entries (trigger every {financial_batch_size})")
+                self.log.info(
+                    f"🚨 FINANCIAL REPORT TRIGGER: Reached {current_linking_map_count} linking map entries (trigger every {financial_batch_size})"
+                )
                 from tools.FBA_Financial_calculator import run_calculations
+
                 financial_results = run_calculations(supplier_name)
-                if financial_results and financial_results.get('statistics', {}).get('output_file'):
-                    self.log.info(f"✅ Financial report EXECUTED: {financial_results['statistics']['output_file']}")
+                if financial_results and financial_results.get("statistics", {}).get("output_file"):
+                    self.log.info(
+                        f"✅ Financial report EXECUTED: {financial_results['statistics']['output_file']}"
+                    )
                 else:
                     self.log.warning("⚠️ Financial report executed but no file path returned")
                 return True
@@ -5274,16 +6666,26 @@ Return ONLY valid JSON, no additional text."""
             except Exception as e:
                 self.log.error(f"❌ Error executing financial report: {e}")
         elif current_linking_map_count > 0:
-            next_trigger_count = ((current_linking_map_count // financial_batch_size) + 1) * financial_batch_size
-            self.log.info(f"💡 FINANCIAL REPORT TRIGGER: Next trigger at {next_trigger_count} linking map entries (current: {current_linking_map_count}, trigger frequency: {financial_batch_size})")
-        
+            next_trigger_count = (
+                (current_linking_map_count // financial_batch_size) + 1
+            ) * financial_batch_size
+            self.log.info(
+                f"💡 FINANCIAL REPORT TRIGGER: Next trigger at {next_trigger_count} linking map entries (current: {current_linking_map_count}, trigger frequency: {financial_batch_size})"
+            )
+
         return False
-    
-    async def _run_hybrid_processing_mode(self, supplier_url: str, supplier_name: str, 
-                                         category_urls_to_scrape: List[str], 
-                                         max_products_per_category: int, max_products_to_process: int,
-                                         max_analyzed_products: int, max_products_per_cycle: int, 
-                                         supplier_extraction_batch_size: int) -> List[Dict[str, Any]]:
+
+    async def _run_hybrid_processing_mode(
+        self,
+        supplier_url: str,
+        supplier_name: str,
+        category_urls_to_scrape: List[str],
+        max_products_per_category: int,
+        max_products_to_process: int,
+        max_analyzed_products: int,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+    ) -> List[Dict[str, Any]]:
         """
         Hybrid processing mode that allows switching between supplier extraction and Amazon analysis.
         Supports chunked, sequential, and balanced processing modes.
@@ -5293,65 +6695,85 @@ Return ONLY valid JSON, no additional text."""
         hybrid_config = full_config.get("hybrid_processing", {})
         processing_modes = hybrid_config.get("processing_modes", {})
         switch_after_categories = hybrid_config.get("switch_to_amazon_after_categories")
-        
+
         self.log.info(f"🔄 HYBRID PROCESSING: Mode configuration loaded")
         self.log.info(f"   switch_to_amazon_after_categories: {switch_after_categories}")
-        
+
         if processing_modes.get("chunked", {}).get("enabled", False):
             # Chunked mode: Alternate between supplier extraction and Amazon analysis
             chunk_size = processing_modes.get("chunked", {}).get("chunk_size_categories")
             if not chunk_size:
-                self.log.error("❌ CONFIGURATION ERROR: chunk_size_categories not found in hybrid_processing.processing_modes.chunked")
+                self.log.error(
+                    "❌ CONFIGURATION ERROR: chunk_size_categories not found in hybrid_processing.processing_modes.chunked"
+                )
                 return profitable_results
-            
-            self.log.info(f"🔄 HYBRID MODE: Chunked processing (chunk size: {chunk_size} categories)")
-            
+
+            self.log.info(
+                f"🔄 HYBRID MODE: Chunked processing (chunk size: {chunk_size} categories)"
+            )
+
             # Process categories in chunks
             for chunk_start in range(0, len(category_urls_to_scrape), chunk_size):
                 chunk_end = min(chunk_start + chunk_size, len(category_urls_to_scrape))
                 chunk_categories = category_urls_to_scrape[chunk_start:chunk_end]
-                
-                self.log.info(f"🔄 Processing chunk {chunk_start//chunk_size + 1}: categories {chunk_start+1}-{chunk_end}")
-                
+
+                self.log.info(
+                    f"🔄 Processing chunk {chunk_start//chunk_size + 1}: categories {chunk_start+1}-{chunk_end}"
+                )
+
                 # Extract from this chunk of categories
                 chunk_products = await self._extract_supplier_products(
-                    supplier_url, supplier_name, chunk_categories, 
-                    max_products_per_category, max_products_to_process, supplier_extraction_batch_size
+                    supplier_url,
+                    supplier_name,
+                    chunk_categories,
+                    max_products_per_category,
+                    max_products_to_process,
+                    supplier_extraction_batch_size,
                 )
-                
+
                 if chunk_products:
                     # Immediately analyze these products
                     # Use the same detailed processing logic as main workflow
                     chunk_results = await self._process_chunk_with_main_workflow_logic(
-                        chunk_products, max_products_per_cycle, category_urls=category_urls_to_scrape
+                        chunk_products,
+                        max_products_per_cycle,
+                        category_urls=category_urls_to_scrape,
                     )
                     profitable_results.extend(chunk_results)
-                    
+
                     # Check memory management
                     memory_config = hybrid_config.get("memory_management", {})
                     if memory_config.get("clear_cache_between_phases", False):
                         self.log.info("🧹 Clearing cache between processing phases")
                         # Add cache clearing logic here if needed
-                
+
         elif processing_modes.get("balanced", {}).get("enabled", False):
             # Balanced mode: Extract in batches, analyze each batch
             self.log.info(f"🔄 HYBRID MODE: Balanced processing")
-            
+
             # Extract all products first
             all_products = await self._extract_supplier_products(
-                supplier_url, supplier_name, category_urls_to_scrape, 
-                max_products_per_category, max_products_to_process, supplier_extraction_batch_size
+                supplier_url,
+                supplier_name,
+                category_urls_to_scrape,
+                max_products_per_category,
+                max_products_to_process,
+                supplier_extraction_batch_size,
             )
-            
+
             if all_products:
                 # Process in analysis batches if enabled
-                if processing_modes.get("balanced", {}).get("analysis_after_extraction_batch", True):
+                if processing_modes.get("balanced", {}).get(
+                    "analysis_after_extraction_batch", True
+                ):
                     batch_size = max_products_per_cycle
                     for batch_start in range(0, len(all_products), batch_size):
                         batch_end = min(batch_start + batch_size, len(all_products))
                         batch_products = all_products[batch_start:batch_end]
-                        
-                        self.log.info(f"🔄 Analyzing batch {batch_start//batch_size + 1}: products {batch_start+1}-{batch_end}")
+
+                        self.log.info(
+                            f"🔄 Analyzing batch {batch_start//batch_size + 1}: products {batch_start+1}-{batch_end}"
+                        )
                         # Use the same detailed processing logic as main workflow
                         batch_results = await self._process_chunk_with_main_workflow_logic(
                             batch_products, max_products_per_cycle
@@ -5366,88 +6788,109 @@ Return ONLY valid JSON, no additional text."""
         else:
             # Sequential mode (default): Complete supplier extraction, then Amazon analysis
             self.log.info(f"🔄 HYBRID MODE: Sequential processing (extract all, then analyze all)")
-            
+
             # Standard sequential processing - extract all first
             all_products = await self._extract_supplier_products(
-                supplier_url, supplier_name, category_urls_to_scrape, 
-                max_products_per_category, max_products_to_process, supplier_extraction_batch_size
+                supplier_url,
+                supplier_name,
+                category_urls_to_scrape,
+                max_products_per_category,
+                max_products_to_process,
+                supplier_extraction_batch_size,
             )
-            
+
             if all_products:
                 profitable_results = await self._analyze_products_batch(
                     all_products, supplier_name, max_products_per_cycle
                 )
-        
+
         try:
             # Save linking map with all collected entries
             self._save_linking_map(supplier_name)
             self.log.info("✅ Hybrid mode: Linking map save completed")
-            
-            # Save final report of profitable products  
+
+            # Save final report of profitable products
             self._save_final_report(profitable_results, supplier_name)
             self.log.info("✅ Hybrid mode: Final report save completed")
-            
+
             # Save processing state
             self.state_manager.save_state(preserve_interruption_state=True)
             self.log.info("--- Hybrid Processing Mode Finished ---")
-            
+
         except Exception as save_error:
-            self.log.error(f"❌ CRITICAL: Error during final save operations in hybrid mode: {save_error}", exc_info=True)
-        
+            self.log.error(
+                f"❌ CRITICAL: Error during final save operations in hybrid mode: {save_error}",
+                exc_info=True,
+            )
+
         return profitable_results
 
-    async def _analyze_products_batch(self, products: List[Dict[str, Any]], 
-                                    supplier_name: str, max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _analyze_products_batch(
+        self, products: List[Dict[str, Any]], supplier_name: str, max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Analyze a batch of supplier products for Amazon matching and profitability."""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         self.log.info(f"🔍 Analyzing {len(price_filtered_products)} products in batch mode")
-        
+
         # Process products in cycles
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
-            self.log.info(f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-            
+
+            self.log.info(
+                f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+            )
+
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(f"🔍 Analyzing product {current_index}: '{product_data.get('title')}'")
-                
+
                 # Check if already processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
-                
+
                 # Amazon data extraction and analysis
                 amazon_data = await self._get_amazon_data(product_data)
                 if not amazon_data or "error" in amazon_data:
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # 🚨 FIX: Create no-match linking entry for batch processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Batch processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -5457,77 +6900,108 @@ Return ONLY valid JSON, no additional text."""
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
                     continue
-                
+
                 # Save Amazon cache and create linking map
                 supplier_ean = product_data.get("ean") or product_data.get("barcode")
                 asin = amazon_data.get("asin", "NO_ASIN")
-                
+
                 # Save Amazon data
-                filename_identifier = supplier_ean if supplier_ean else re.sub(r'[<>:"/\\|?*\s]+', '_', product_data.get("title", "NO_TITLE")[:50])
-                amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
-                with open(amazon_cache_path, 'w', encoding='utf-8') as f:
+                filename_identifier = (
+                    supplier_ean
+                    if supplier_ean
+                    else re.sub(r'[<>:"/\\|?*\s]+', "_", product_data.get("title", "NO_TITLE")[:50])
+                )
+                amazon_cache_path = str(
+                    path_manager.get_output_path(
+                        "FBA_ANALYSIS", "amazon_cache", f"amazon_{asin}_{filename_identifier}.json"
+                    )
+                )
+                with open(amazon_cache_path, "w", encoding="utf-8") as f:
                     json.dump(amazon_data, f, indent=2, ensure_ascii=False)
-                
+
                 # Financial analysis
                 try:
                     # Already imported at top of file: from FBA_Financial_calculator import financials as calc_financials
                     supplier_price = float(product_data.get("price", 0))
                     current_price = amazon_data.get("current_price", 0)
-                    
+
                     if supplier_price > 0 and current_price > 0:
                         financials = calc_financials(
                             supplier_price=supplier_price,
                             amazon_price=current_price,
                             amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                             amazon_rating=amazon_data.get("rating", 0),
-                            amazon_review_count=amazon_data.get("reviews", 0)
+                            amazon_review_count=amazon_data.get("reviews", 0),
                         )
-                        
+
                         # Check profitability
-                        if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                            self.log.info(f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}")
-                            
-                            combined_data = self._combine_supplier_amazon_data(product_data, amazon_data, "hybrid_batch")
+                        if (
+                            financials.get("ROI", 0) > MIN_ROI_PERCENT
+                            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                        ):
+                            self.log.info(
+                                f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}"
+                            )
+
+                            combined_data = self._combine_supplier_amazon_data(
+                                product_data, amazon_data, "hybrid_batch"
+                            )
                             combined_data["financials"] = financials
                             profitable_results.append(combined_data)
-                            
-                            self.state_manager.update_success_metrics(True, True, financials.get("NetProfit", 0))
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+
+                            self.state_manager.update_success_metrics(
+                                True, True, financials.get("NetProfit", 0)
+                            )
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_profitable"
+                            )
                         else:
-                            self.log.info(f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}")
+                            self.log.info(
+                                f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}"
+                            )
                             self.state_manager.update_success_metrics(True, False)
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                            
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_not_profitable"
+                            )
+
                 except Exception as e:
                     self.log.error(f"Financial calculation failed: {e}")
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
-        
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_financial_calculation"
+                    )
+
         return profitable_results
 
     def _get_cached_products_path(self, category_url: str):
         """Helper to get the path for a category's product cache file."""
         category_filename = f"{self.supplier_name}_{category_url.split('/')[-1]}_products.json"
-        return str(path_manager.get_cache_path('supplier_cache', category_filename))
+        return str(path_manager.get_cache_path("supplier_cache", category_filename))
 
-    def _combine_data(self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    def _combine_data(
+        self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str
+    ) -> Dict[str, Any]:
         """Combine supplier and Amazon data and calculate financial metrics."""
         combined = {
             "supplier_product_info": supplier_data,
             "amazon_product_info": amazon_data,
             "analysis_timestamp": datetime.now().isoformat(),
-            "session_id": session_id
+            "session_id": session_id,
         }
         # Financial calculation is now handled within the main run loop before this function is called
         # This function is primarily for combining data and adding match validation
@@ -5537,33 +7011,39 @@ Return ONLY valid JSON, no additional text."""
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
-    
+
     def _sanitize_filename(self, title: str) -> str:
         """Sanitize product title for use in filename"""
         if not title:
             return "unknown_title"
         # Remove or replace problematic characters
-        sanitized = re.sub(r'[^\w\s-]', '', title)
-        sanitized = re.sub(r'\s+', '_', sanitized)
+        sanitized = re.sub(r"[^\w\s-]", "", title)
+        sanitized = re.sub(r"\s+", "_", sanitized)
         return sanitized[:50]  # Limit length to 50 chars
 
-    def _validate_product_match(self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate_product_match(
+        self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Validate the match between supplier and Amazon products using configurable thresholds."""
-        matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-        
+        matching_thresholds = self.system_config.get("performance", {}).get(
+            "matching_thresholds", {}
+        )
+
         # Get configurable thresholds with fallback to more conservative defaults
         title_similarity_threshold = matching_thresholds.get("title_similarity", 0.25)
-        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5) 
+        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5)
         high_title_similarity = matching_thresholds.get("high_title_similarity", 0.75)
-        
-        title_overlap_score = self._overlap_score(supplier_product.get("title", ""), amazon_product.get("title", ""))
+
+        title_overlap_score = self._overlap_score(
+            supplier_product.get("title", ""), amazon_product.get("title", "")
+        )
 
         match_quality = "low"
         confidence = 0.0
-        
+
         # Use configurable thresholds - much more strict than previous hardcoded values
         if title_overlap_score >= high_title_similarity:
             match_quality = "high"
@@ -5578,9 +7058,15 @@ Return ONLY valid JSON, no additional text."""
             match_quality = "very_low"
             confidence = 0.1
 
-        self.log.debug(f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})")
-        
-        return {"match_quality": match_quality, "confidence": confidence, "title_overlap_score": title_overlap_score}
+        self.log.debug(
+            f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})"
+        )
+
+        return {
+            "match_quality": match_quality,
+            "confidence": confidence,
+            "title_overlap_score": title_overlap_score,
+        }
 
     def _is_product_meeting_criteria(self, combined_data: Dict[str, Any]) -> bool:
         """Check if a product meets all defined business criteria."""
@@ -5589,22 +7075,41 @@ Return ONLY valid JSON, no additional text."""
         amazon_data = combined_data.get("amazon_product_info", {})
         financials = combined_data.get("financials", {})
         # Check profitability (already done, but for completeness)
-        is_profitable = financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        is_profitable = (
+            financials.get("ROI", 0) > MIN_ROI_PERCENT
+            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        )
         # Check Amazon listing quality
         meets_rating = amazon_data.get("rating", 0) >= MIN_RATING
         meets_reviews = amazon_data.get("reviews", 0) >= MIN_REVIEWS
         meets_sales_rank = amazon_data.get("sales_rank", MAX_SALES_RANK + 1) <= MAX_SALES_RANK
         # Check for battery products (using the helper function)
-        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(combined_data["supplier_product_info"].get("title", ""))
+        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(
+            combined_data["supplier_product_info"].get("title", "")
+        )
         # Check for other non-FBA friendly keywords
-        is_non_fba_friendly = any(k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS) or \
-                              any(k in combined_data["supplier_product_info"].get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS)
+        is_non_fba_friendly = any(
+            k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS
+        ) or any(
+            k in combined_data["supplier_product_info"].get("title", "").lower()
+            for k in NON_FBA_FRIENDLY_KEYWORDS
+        )
         # All criteria must be met
-        return is_profitable and meets_rating and meets_reviews and meets_sales_rank and not is_battery and not is_non_fba_friendly
+        return (
+            is_profitable
+            and meets_rating
+            and meets_reviews
+            and meets_sales_rank
+            and not is_battery
+            and not is_non_fba_friendly
+        )
 
-    def _apply_batch_synchronization(self, max_products_per_cycle: int, 
-                                   supplier_extraction_batch_size: int,
-                                   batch_sync_config: Dict[str, Any]) -> Tuple[int, int]:
+    def _apply_batch_synchronization(
+        self,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+        batch_sync_config: Dict[str, Any],
+    ) -> Tuple[int, int]:
         """
         Apply batch synchronization to align all batch sizes consistently.
         Returns updated max_products_per_cycle and supplier_extraction_batch_size.
@@ -5612,102 +7117,124 @@ Return ONLY valid JSON, no additional text."""
         target_batch_size = batch_sync_config.get("target_batch_size", 3)
         synchronize_all = batch_sync_config.get("synchronize_all_batch_sizes", False)
         validation_config = batch_sync_config.get("validation", {})
-        
+
         self.log.info(f"🔄 BATCH SYNCHRONIZATION: Enabled")
         self.log.info(f"   target_batch_size: {target_batch_size}")
         self.log.info(f"   synchronize_all_batch_sizes: {synchronize_all}")
-        
+
         original_values = {
             "max_products_per_cycle": max_products_per_cycle,
             "supplier_extraction_batch_size": supplier_extraction_batch_size,
             "linking_map_batch_size": self.system_config.get("linking_map_batch_size", 1),
-            "financial_report_batch_size": self.config_loader.get_financial_batch_size()
+            "financial_report_batch_size": self.config_loader.get_financial_batch_size(),
         }
-        
+
         # Check for mismatched sizes and warn if configured
         if validation_config.get("warn_on_mismatched_sizes", True):
             unique_sizes = set(original_values.values())
             if len(unique_sizes) > 1:
-                self.log.warning(f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}")
+                self.log.warning(
+                    f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}"
+                )
                 self.log.warning(f"   Unique sizes found: {sorted(unique_sizes)}")
-        
+
         if synchronize_all:
             # Synchronize all batch sizes to target
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
+
             # Also update system config values in memory for consistency
             if "system" in self.system_config:
                 self.system_config["max_products_per_cycle"] = target_batch_size
                 self.system_config["supplier_extraction_batch_size"] = target_batch_size
                 self.system_config["linking_map_batch_size"] = target_batch_size
                 # financial_report_batch_size managed by config_loader
-            
+
             self.log.info(f"✅ BATCH SYNC: All batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-            
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         else:
             # Only synchronize the two main processing batch sizes
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
-            self.log.info(f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-        
+
+            self.log.info(
+                f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}"
+            )
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         return new_max_products_per_cycle, new_supplier_extraction_batch_size
 
-    async def _analyze_products_batch(self, products: List[Dict[str, Any]], 
-                                    supplier_name: str, max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _analyze_products_batch(
+        self, products: List[Dict[str, Any]], supplier_name: str, max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Analyze a batch of supplier products for Amazon matching and profitability."""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         self.log.info(f"🔍 Analyzing {len(price_filtered_products)} products in batch mode")
-        
+
         # Process products in cycles
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
-            self.log.info(f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-            
+
+            self.log.info(
+                f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+            )
+
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(f"🔍 Analyzing product {current_index}: '{product_data.get('title')}'")
-                
+
                 # Check if already processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
-                
+
                 # Amazon data extraction and analysis
                 amazon_data = await self._get_amazon_data(product_data)
                 if not amazon_data or "error" in amazon_data:
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # 🚨 FIX: Create no-match linking entry for batch processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Batch processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -5717,77 +7244,108 @@ Return ONLY valid JSON, no additional text."""
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
                     continue
-                
+
                 # Save Amazon cache and create linking map
                 supplier_ean = product_data.get("ean") or product_data.get("barcode")
                 asin = amazon_data.get("asin", "NO_ASIN")
-                
+
                 # Save Amazon data
-                filename_identifier = supplier_ean if supplier_ean else re.sub(r'[<>:"/\\|?*\s]+', '_', product_data.get("title", "NO_TITLE")[:50])
-                amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
-                with open(amazon_cache_path, 'w', encoding='utf-8') as f:
+                filename_identifier = (
+                    supplier_ean
+                    if supplier_ean
+                    else re.sub(r'[<>:"/\\|?*\s]+', "_", product_data.get("title", "NO_TITLE")[:50])
+                )
+                amazon_cache_path = str(
+                    path_manager.get_output_path(
+                        "FBA_ANALYSIS", "amazon_cache", f"amazon_{asin}_{filename_identifier}.json"
+                    )
+                )
+                with open(amazon_cache_path, "w", encoding="utf-8") as f:
                     json.dump(amazon_data, f, indent=2, ensure_ascii=False)
-                
+
                 # Financial analysis
                 try:
                     # Already imported at top of file: from FBA_Financial_calculator import financials as calc_financials
                     supplier_price = float(product_data.get("price", 0))
                     current_price = amazon_data.get("current_price", 0)
-                    
+
                     if supplier_price > 0 and current_price > 0:
                         financials = calc_financials(
                             supplier_price=supplier_price,
                             amazon_price=current_price,
                             amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                             amazon_rating=amazon_data.get("rating", 0),
-                            amazon_review_count=amazon_data.get("reviews", 0)
+                            amazon_review_count=amazon_data.get("reviews", 0),
                         )
-                        
+
                         # Check profitability
-                        if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                            self.log.info(f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}")
-                            
-                            combined_data = self._combine_supplier_amazon_data(product_data, amazon_data, "hybrid_batch")
+                        if (
+                            financials.get("ROI", 0) > MIN_ROI_PERCENT
+                            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                        ):
+                            self.log.info(
+                                f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}"
+                            )
+
+                            combined_data = self._combine_supplier_amazon_data(
+                                product_data, amazon_data, "hybrid_batch"
+                            )
                             combined_data["financials"] = financials
                             profitable_results.append(combined_data)
-                            
-                            self.state_manager.update_success_metrics(True, True, financials.get("NetProfit", 0))
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+
+                            self.state_manager.update_success_metrics(
+                                True, True, financials.get("NetProfit", 0)
+                            )
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_profitable"
+                            )
                         else:
-                            self.log.info(f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}")
+                            self.log.info(
+                                f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}"
+                            )
                             self.state_manager.update_success_metrics(True, False)
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                            
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_not_profitable"
+                            )
+
                 except Exception as e:
                     self.log.error(f"Financial calculation failed: {e}")
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
-        
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_financial_calculation"
+                    )
+
         return profitable_results
 
     def _get_cached_products_path(self, category_url: str):
         """Helper to get the path for a category's product cache file."""
         category_filename = f"{self.supplier_name}_{category_url.split('/')[-1]}_products.json"
-        return str(path_manager.get_cache_path('supplier_cache', category_filename))
+        return str(path_manager.get_cache_path("supplier_cache", category_filename))
 
-    def _combine_data(self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    def _combine_data(
+        self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str
+    ) -> Dict[str, Any]:
         """Combine supplier and Amazon data and calculate financial metrics."""
         combined = {
             "supplier_product_info": supplier_data,
             "amazon_product_info": amazon_data,
             "analysis_timestamp": datetime.now().isoformat(),
-            "session_id": session_id
+            "session_id": session_id,
         }
         # Financial calculation is now handled within the main run loop before this function is called
         # This function is primarily for combining data and adding match validation
@@ -5797,33 +7355,39 @@ Return ONLY valid JSON, no additional text."""
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
-    
+
     def _sanitize_filename(self, title: str) -> str:
         """Sanitize product title for use in filename"""
         if not title:
             return "unknown_title"
         # Remove or replace problematic characters
-        sanitized = re.sub(r'[^\w\s-]', '', title)
-        sanitized = re.sub(r'\s+', '_', sanitized)
+        sanitized = re.sub(r"[^\w\s-]", "", title)
+        sanitized = re.sub(r"\s+", "_", sanitized)
         return sanitized[:50]  # Limit length to 50 chars
 
-    def _validate_product_match(self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate_product_match(
+        self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Validate the match between supplier and Amazon products using configurable thresholds."""
-        matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-        
+        matching_thresholds = self.system_config.get("performance", {}).get(
+            "matching_thresholds", {}
+        )
+
         # Get configurable thresholds with fallback to more conservative defaults
         title_similarity_threshold = matching_thresholds.get("title_similarity", 0.25)
-        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5) 
+        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5)
         high_title_similarity = matching_thresholds.get("high_title_similarity", 0.75)
-        
-        title_overlap_score = self._overlap_score(supplier_product.get("title", ""), amazon_product.get("title", ""))
+
+        title_overlap_score = self._overlap_score(
+            supplier_product.get("title", ""), amazon_product.get("title", "")
+        )
 
         match_quality = "low"
         confidence = 0.0
-        
+
         # Use configurable thresholds - much more strict than previous hardcoded values
         if title_overlap_score >= high_title_similarity:
             match_quality = "high"
@@ -5838,9 +7402,15 @@ Return ONLY valid JSON, no additional text."""
             match_quality = "very_low"
             confidence = 0.1
 
-        self.log.debug(f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})")
-        
-        return {"match_quality": match_quality, "confidence": confidence, "title_overlap_score": title_overlap_score}
+        self.log.debug(
+            f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})"
+        )
+
+        return {
+            "match_quality": match_quality,
+            "confidence": confidence,
+            "title_overlap_score": title_overlap_score,
+        }
 
     def _is_product_meeting_criteria(self, combined_data: Dict[str, Any]) -> bool:
         """Check if a product meets all defined business criteria."""
@@ -5849,22 +7419,41 @@ Return ONLY valid JSON, no additional text."""
         amazon_data = combined_data.get("amazon_product_info", {})
         financials = combined_data.get("financials", {})
         # Check profitability (already done, but for completeness)
-        is_profitable = financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        is_profitable = (
+            financials.get("ROI", 0) > MIN_ROI_PERCENT
+            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        )
         # Check Amazon listing quality
         meets_rating = amazon_data.get("rating", 0) >= MIN_RATING
         meets_reviews = amazon_data.get("reviews", 0) >= MIN_REVIEWS
         meets_sales_rank = amazon_data.get("sales_rank", MAX_SALES_RANK + 1) <= MAX_SALES_RANK
         # Check for battery products (using the helper function)
-        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(combined_data["supplier_product_info"].get("title", ""))
+        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(
+            combined_data["supplier_product_info"].get("title", "")
+        )
         # Check for other non-FBA friendly keywords
-        is_non_fba_friendly = any(k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS) or \
-                              any(k in combined_data["supplier_product_info"].get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS)
+        is_non_fba_friendly = any(
+            k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS
+        ) or any(
+            k in combined_data["supplier_product_info"].get("title", "").lower()
+            for k in NON_FBA_FRIENDLY_KEYWORDS
+        )
         # All criteria must be met
-        return is_profitable and meets_rating and meets_reviews and meets_sales_rank and not is_battery and not is_non_fba_friendly
+        return (
+            is_profitable
+            and meets_rating
+            and meets_reviews
+            and meets_sales_rank
+            and not is_battery
+            and not is_non_fba_friendly
+        )
 
-    def _apply_batch_synchronization(self, max_products_per_cycle: int, 
-                                   supplier_extraction_batch_size: int,
-                                   batch_sync_config: Dict[str, Any]) -> Tuple[int, int]:
+    def _apply_batch_synchronization(
+        self,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+        batch_sync_config: Dict[str, Any],
+    ) -> Tuple[int, int]:
         """
         Apply batch synchronization to align all batch sizes consistently.
         Returns updated max_products_per_cycle and supplier_extraction_batch_size.
@@ -5872,102 +7461,124 @@ Return ONLY valid JSON, no additional text."""
         target_batch_size = batch_sync_config.get("target_batch_size", 3)
         synchronize_all = batch_sync_config.get("synchronize_all_batch_sizes", False)
         validation_config = batch_sync_config.get("validation", {})
-        
+
         self.log.info(f"🔄 BATCH SYNCHRONIZATION: Enabled")
         self.log.info(f"   target_batch_size: {target_batch_size}")
         self.log.info(f"   synchronize_all_batch_sizes: {synchronize_all}")
-        
+
         original_values = {
             "max_products_per_cycle": max_products_per_cycle,
             "supplier_extraction_batch_size": supplier_extraction_batch_size,
             "linking_map_batch_size": self.system_config.get("linking_map_batch_size", 1),
-            "financial_report_batch_size": self.config_loader.get_financial_batch_size()
+            "financial_report_batch_size": self.config_loader.get_financial_batch_size(),
         }
-        
+
         # Check for mismatched sizes and warn if configured
         if validation_config.get("warn_on_mismatched_sizes", True):
             unique_sizes = set(original_values.values())
             if len(unique_sizes) > 1:
-                self.log.warning(f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}")
+                self.log.warning(
+                    f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}"
+                )
                 self.log.warning(f"   Unique sizes found: {sorted(unique_sizes)}")
-        
+
         if synchronize_all:
             # Synchronize all batch sizes to target
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
+
             # Also update system config values in memory for consistency
             if "system" in self.system_config:
                 self.system_config["max_products_per_cycle"] = target_batch_size
                 self.system_config["supplier_extraction_batch_size"] = target_batch_size
                 self.system_config["linking_map_batch_size"] = target_batch_size
                 # financial_report_batch_size managed by config_loader
-            
+
             self.log.info(f"✅ BATCH SYNC: All batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-            
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         else:
             # Only synchronize the two main processing batch sizes
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
-            self.log.info(f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-        
+
+            self.log.info(
+                f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}"
+            )
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         return new_max_products_per_cycle, new_supplier_extraction_batch_size
 
-    async def _analyze_products_batch(self, products: List[Dict[str, Any]], 
-                                    supplier_name: str, max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _analyze_products_batch(
+        self, products: List[Dict[str, Any]], supplier_name: str, max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Analyze a batch of supplier products for Amazon matching and profitability."""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         self.log.info(f"🔍 Analyzing {len(price_filtered_products)} products in batch mode")
-        
+
         # Process products in cycles
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
-            self.log.info(f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-            
+
+            self.log.info(
+                f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+            )
+
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(f"🔍 Analyzing product {current_index}: '{product_data.get('title')}'")
-                
+
                 # Check if already processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
-                
+
                 # Amazon data extraction and analysis
                 amazon_data = await self._get_amazon_data(product_data)
                 if not amazon_data or "error" in amazon_data:
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # 🚨 FIX: Create no-match linking entry for batch processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Batch processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -5977,77 +7588,108 @@ Return ONLY valid JSON, no additional text."""
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
                     continue
-                
+
                 # Save Amazon cache and create linking map
                 supplier_ean = product_data.get("ean") or product_data.get("barcode")
                 asin = amazon_data.get("asin", "NO_ASIN")
-                
+
                 # Save Amazon data
-                filename_identifier = supplier_ean if supplier_ean else re.sub(r'[<>:"/\\|?*\s]+', '_', product_data.get("title", "NO_TITLE")[:50])
-                amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
-                with open(amazon_cache_path, 'w', encoding='utf-8') as f:
+                filename_identifier = (
+                    supplier_ean
+                    if supplier_ean
+                    else re.sub(r'[<>:"/\\|?*\s]+', "_", product_data.get("title", "NO_TITLE")[:50])
+                )
+                amazon_cache_path = str(
+                    path_manager.get_output_path(
+                        "FBA_ANALYSIS", "amazon_cache", f"amazon_{asin}_{filename_identifier}.json"
+                    )
+                )
+                with open(amazon_cache_path, "w", encoding="utf-8") as f:
                     json.dump(amazon_data, f, indent=2, ensure_ascii=False)
-                
+
                 # Financial analysis
                 try:
                     # Already imported at top of file: from FBA_Financial_calculator import financials as calc_financials
                     supplier_price = float(product_data.get("price", 0))
                     current_price = amazon_data.get("current_price", 0)
-                    
+
                     if supplier_price > 0 and current_price > 0:
                         financials = calc_financials(
                             supplier_price=supplier_price,
                             amazon_price=current_price,
                             amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                             amazon_rating=amazon_data.get("rating", 0),
-                            amazon_review_count=amazon_data.get("reviews", 0)
+                            amazon_review_count=amazon_data.get("reviews", 0),
                         )
-                        
+
                         # Check profitability
-                        if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                            self.log.info(f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}")
-                            
-                            combined_data = self._combine_supplier_amazon_data(product_data, amazon_data, "hybrid_batch")
+                        if (
+                            financials.get("ROI", 0) > MIN_ROI_PERCENT
+                            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                        ):
+                            self.log.info(
+                                f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}"
+                            )
+
+                            combined_data = self._combine_supplier_amazon_data(
+                                product_data, amazon_data, "hybrid_batch"
+                            )
                             combined_data["financials"] = financials
                             profitable_results.append(combined_data)
-                            
-                            self.state_manager.update_success_metrics(True, True, financials.get("NetProfit", 0))
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+
+                            self.state_manager.update_success_metrics(
+                                True, True, financials.get("NetProfit", 0)
+                            )
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_profitable"
+                            )
                         else:
-                            self.log.info(f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}")
+                            self.log.info(
+                                f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}"
+                            )
                             self.state_manager.update_success_metrics(True, False)
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                            
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_not_profitable"
+                            )
+
                 except Exception as e:
                     self.log.error(f"Financial calculation failed: {e}")
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
-        
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_financial_calculation"
+                    )
+
         return profitable_results
 
     def _get_cached_products_path(self, category_url: str):
         """Helper to get the path for a category's product cache file."""
         category_filename = f"{self.supplier_name}_{category_url.split('/')[-1]}_products.json"
-        return str(path_manager.get_cache_path('supplier_cache', category_filename))
+        return str(path_manager.get_cache_path("supplier_cache", category_filename))
 
-    def _combine_data(self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    def _combine_data(
+        self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str
+    ) -> Dict[str, Any]:
         """Combine supplier and Amazon data and calculate financial metrics."""
         combined = {
             "supplier_product_info": supplier_data,
             "amazon_product_info": amazon_data,
             "analysis_timestamp": datetime.now().isoformat(),
-            "session_id": session_id
+            "session_id": session_id,
         }
         # Financial calculation is now handled within the main run loop before this function is called
         # This function is primarily for combining data and adding match validation
@@ -6057,33 +7699,39 @@ Return ONLY valid JSON, no additional text."""
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
-    
+
     def _sanitize_filename(self, title: str) -> str:
         """Sanitize product title for use in filename"""
         if not title:
             return "unknown_title"
         # Remove or replace problematic characters
-        sanitized = re.sub(r'[^\w\s-]', '', title)
-        sanitized = re.sub(r'\s+', '_', sanitized)
+        sanitized = re.sub(r"[^\w\s-]", "", title)
+        sanitized = re.sub(r"\s+", "_", sanitized)
         return sanitized[:50]  # Limit length to 50 chars
 
-    def _validate_product_match(self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate_product_match(
+        self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Validate the match between supplier and Amazon products using configurable thresholds."""
-        matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-        
+        matching_thresholds = self.system_config.get("performance", {}).get(
+            "matching_thresholds", {}
+        )
+
         # Get configurable thresholds with fallback to more conservative defaults
         title_similarity_threshold = matching_thresholds.get("title_similarity", 0.25)
-        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5) 
+        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5)
         high_title_similarity = matching_thresholds.get("high_title_similarity", 0.75)
-        
-        title_overlap_score = self._overlap_score(supplier_product.get("title", ""), amazon_product.get("title", ""))
+
+        title_overlap_score = self._overlap_score(
+            supplier_product.get("title", ""), amazon_product.get("title", "")
+        )
 
         match_quality = "low"
         confidence = 0.0
-        
+
         # Use configurable thresholds - much more strict than previous hardcoded values
         if title_overlap_score >= high_title_similarity:
             match_quality = "high"
@@ -6098,9 +7746,15 @@ Return ONLY valid JSON, no additional text."""
             match_quality = "very_low"
             confidence = 0.1
 
-        self.log.debug(f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})")
-        
-        return {"match_quality": match_quality, "confidence": confidence, "title_overlap_score": title_overlap_score}
+        self.log.debug(
+            f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})"
+        )
+
+        return {
+            "match_quality": match_quality,
+            "confidence": confidence,
+            "title_overlap_score": title_overlap_score,
+        }
 
     def _is_product_meeting_criteria(self, combined_data: Dict[str, Any]) -> bool:
         """Check if a product meets all defined business criteria."""
@@ -6109,22 +7763,41 @@ Return ONLY valid JSON, no additional text."""
         amazon_data = combined_data.get("amazon_product_info", {})
         financials = combined_data.get("financials", {})
         # Check profitability (already done, but for completeness)
-        is_profitable = financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        is_profitable = (
+            financials.get("ROI", 0) > MIN_ROI_PERCENT
+            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        )
         # Check Amazon listing quality
         meets_rating = amazon_data.get("rating", 0) >= MIN_RATING
         meets_reviews = amazon_data.get("reviews", 0) >= MIN_REVIEWS
         meets_sales_rank = amazon_data.get("sales_rank", MAX_SALES_RANK + 1) <= MAX_SALES_RANK
         # Check for battery products (using the helper function)
-        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(combined_data["supplier_product_info"].get("title", ""))
+        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(
+            combined_data["supplier_product_info"].get("title", "")
+        )
         # Check for other non-FBA friendly keywords
-        is_non_fba_friendly = any(k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS) or \
-                              any(k in combined_data["supplier_product_info"].get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS)
+        is_non_fba_friendly = any(
+            k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS
+        ) or any(
+            k in combined_data["supplier_product_info"].get("title", "").lower()
+            for k in NON_FBA_FRIENDLY_KEYWORDS
+        )
         # All criteria must be met
-        return is_profitable and meets_rating and meets_reviews and meets_sales_rank and not is_battery and not is_non_fba_friendly
+        return (
+            is_profitable
+            and meets_rating
+            and meets_reviews
+            and meets_sales_rank
+            and not is_battery
+            and not is_non_fba_friendly
+        )
 
-    def _apply_batch_synchronization(self, max_products_per_cycle: int, 
-                                   supplier_extraction_batch_size: int,
-                                   batch_sync_config: Dict[str, Any]) -> Tuple[int, int]:
+    def _apply_batch_synchronization(
+        self,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+        batch_sync_config: Dict[str, Any],
+    ) -> Tuple[int, int]:
         """
         Apply batch synchronization to align all batch sizes consistently.
         Returns updated max_products_per_cycle and supplier_extraction_batch_size.
@@ -6132,102 +7805,124 @@ Return ONLY valid JSON, no additional text."""
         target_batch_size = batch_sync_config.get("target_batch_size", 3)
         synchronize_all = batch_sync_config.get("synchronize_all_batch_sizes", False)
         validation_config = batch_sync_config.get("validation", {})
-        
+
         self.log.info(f"🔄 BATCH SYNCHRONIZATION: Enabled")
         self.log.info(f"   target_batch_size: {target_batch_size}")
         self.log.info(f"   synchronize_all_batch_sizes: {synchronize_all}")
-        
+
         original_values = {
             "max_products_per_cycle": max_products_per_cycle,
             "supplier_extraction_batch_size": supplier_extraction_batch_size,
             "linking_map_batch_size": self.system_config.get("linking_map_batch_size", 1),
-            "financial_report_batch_size": self.config_loader.get_financial_batch_size()
+            "financial_report_batch_size": self.config_loader.get_financial_batch_size(),
         }
-        
+
         # Check for mismatched sizes and warn if configured
         if validation_config.get("warn_on_mismatched_sizes", True):
             unique_sizes = set(original_values.values())
             if len(unique_sizes) > 1:
-                self.log.warning(f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}")
+                self.log.warning(
+                    f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}"
+                )
                 self.log.warning(f"   Unique sizes found: {sorted(unique_sizes)}")
-        
+
         if synchronize_all:
             # Synchronize all batch sizes to target
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
+
             # Also update system config values in memory for consistency
             if "system" in self.system_config:
                 self.system_config["max_products_per_cycle"] = target_batch_size
                 self.system_config["supplier_extraction_batch_size"] = target_batch_size
                 self.system_config["linking_map_batch_size"] = target_batch_size
                 # financial_report_batch_size managed by config_loader
-            
+
             self.log.info(f"✅ BATCH SYNC: All batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-            
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         else:
             # Only synchronize the two main processing batch sizes
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
-            self.log.info(f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-        
+
+            self.log.info(
+                f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}"
+            )
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         return new_max_products_per_cycle, new_supplier_extraction_batch_size
 
-    async def _analyze_products_batch(self, products: List[Dict[str, Any]], 
-                                    supplier_name: str, max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _analyze_products_batch(
+        self, products: List[Dict[str, Any]], supplier_name: str, max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Analyze a batch of supplier products for Amazon matching and profitability."""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         self.log.info(f"🔍 Analyzing {len(price_filtered_products)} products in batch mode")
-        
+
         # Process products in cycles
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
-            self.log.info(f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-            
+
+            self.log.info(
+                f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+            )
+
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(f"🔍 Analyzing product {current_index}: '{product_data.get('title')}'")
-                
+
                 # Check if already processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
-                
+
                 # Amazon data extraction and analysis
                 amazon_data = await self._get_amazon_data(product_data)
                 if not amazon_data or "error" in amazon_data:
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # 🚨 FIX: Create no-match linking entry for batch processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Batch processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -6237,77 +7932,108 @@ Return ONLY valid JSON, no additional text."""
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
                     continue
-                
+
                 # Save Amazon cache and create linking map
                 supplier_ean = product_data.get("ean") or product_data.get("barcode")
                 asin = amazon_data.get("asin", "NO_ASIN")
-                
+
                 # Save Amazon data
-                filename_identifier = supplier_ean if supplier_ean else re.sub(r'[<>:"/\\|?*\s]+', '_', product_data.get("title", "NO_TITLE")[:50])
-                amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
-                with open(amazon_cache_path, 'w', encoding='utf-8') as f:
+                filename_identifier = (
+                    supplier_ean
+                    if supplier_ean
+                    else re.sub(r'[<>:"/\\|?*\s]+', "_", product_data.get("title", "NO_TITLE")[:50])
+                )
+                amazon_cache_path = str(
+                    path_manager.get_output_path(
+                        "FBA_ANALYSIS", "amazon_cache", f"amazon_{asin}_{filename_identifier}.json"
+                    )
+                )
+                with open(amazon_cache_path, "w", encoding="utf-8") as f:
                     json.dump(amazon_data, f, indent=2, ensure_ascii=False)
-                
+
                 # Financial analysis
                 try:
                     # Already imported at top of file: from FBA_Financial_calculator import financials as calc_financials
                     supplier_price = float(product_data.get("price", 0))
                     current_price = amazon_data.get("current_price", 0)
-                    
+
                     if supplier_price > 0 and current_price > 0:
                         financials = calc_financials(
                             supplier_price=supplier_price,
                             amazon_price=current_price,
                             amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                             amazon_rating=amazon_data.get("rating", 0),
-                            amazon_review_count=amazon_data.get("reviews", 0)
+                            amazon_review_count=amazon_data.get("reviews", 0),
                         )
-                        
+
                         # Check profitability
-                        if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                            self.log.info(f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}")
-                            
-                            combined_data = self._combine_supplier_amazon_data(product_data, amazon_data, "hybrid_batch")
+                        if (
+                            financials.get("ROI", 0) > MIN_ROI_PERCENT
+                            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                        ):
+                            self.log.info(
+                                f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}"
+                            )
+
+                            combined_data = self._combine_supplier_amazon_data(
+                                product_data, amazon_data, "hybrid_batch"
+                            )
                             combined_data["financials"] = financials
                             profitable_results.append(combined_data)
-                            
-                            self.state_manager.update_success_metrics(True, True, financials.get("NetProfit", 0))
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+
+                            self.state_manager.update_success_metrics(
+                                True, True, financials.get("NetProfit", 0)
+                            )
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_profitable"
+                            )
                         else:
-                            self.log.info(f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}")
+                            self.log.info(
+                                f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}"
+                            )
                             self.state_manager.update_success_metrics(True, False)
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                            
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_not_profitable"
+                            )
+
                 except Exception as e:
                     self.log.error(f"Financial calculation failed: {e}")
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
-        
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_financial_calculation"
+                    )
+
         return profitable_results
 
     def _get_cached_products_path(self, category_url: str):
         """Helper to get the path for a category's product cache file."""
         category_filename = f"{self.supplier_name}_{category_url.split('/')[-1]}_products.json"
-        return str(path_manager.get_cache_path('supplier_cache', category_filename))
+        return str(path_manager.get_cache_path("supplier_cache", category_filename))
 
-    def _combine_data(self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    def _combine_data(
+        self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str
+    ) -> Dict[str, Any]:
         """Combine supplier and Amazon data and calculate financial metrics."""
         combined = {
             "supplier_product_info": supplier_data,
             "amazon_product_info": amazon_data,
             "analysis_timestamp": datetime.now().isoformat(),
-            "session_id": session_id
+            "session_id": session_id,
         }
         # Financial calculation is now handled within the main run loop before this function is called
         # This function is primarily for combining data and adding match validation
@@ -6317,33 +8043,39 @@ Return ONLY valid JSON, no additional text."""
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
-    
+
     def _sanitize_filename(self, title: str) -> str:
         """Sanitize product title for use in filename"""
         if not title:
             return "unknown_title"
         # Remove or replace problematic characters
-        sanitized = re.sub(r'[^\w\s-]', '', title)
-        sanitized = re.sub(r'\s+', '_', sanitized)
+        sanitized = re.sub(r"[^\w\s-]", "", title)
+        sanitized = re.sub(r"\s+", "_", sanitized)
         return sanitized[:50]  # Limit length to 50 chars
 
-    def _validate_product_match(self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate_product_match(
+        self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Validate the match between supplier and Amazon products using configurable thresholds."""
-        matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-        
+        matching_thresholds = self.system_config.get("performance", {}).get(
+            "matching_thresholds", {}
+        )
+
         # Get configurable thresholds with fallback to more conservative defaults
         title_similarity_threshold = matching_thresholds.get("title_similarity", 0.25)
-        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5) 
+        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5)
         high_title_similarity = matching_thresholds.get("high_title_similarity", 0.75)
-        
-        title_overlap_score = self._overlap_score(supplier_product.get("title", ""), amazon_product.get("title", ""))
+
+        title_overlap_score = self._overlap_score(
+            supplier_product.get("title", ""), amazon_product.get("title", "")
+        )
 
         match_quality = "low"
         confidence = 0.0
-        
+
         # Use configurable thresholds - much more strict than previous hardcoded values
         if title_overlap_score >= high_title_similarity:
             match_quality = "high"
@@ -6358,9 +8090,15 @@ Return ONLY valid JSON, no additional text."""
             match_quality = "very_low"
             confidence = 0.1
 
-        self.log.debug(f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})")
-        
-        return {"match_quality": match_quality, "confidence": confidence, "title_overlap_score": title_overlap_score}
+        self.log.debug(
+            f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})"
+        )
+
+        return {
+            "match_quality": match_quality,
+            "confidence": confidence,
+            "title_overlap_score": title_overlap_score,
+        }
 
     def _is_product_meeting_criteria(self, combined_data: Dict[str, Any]) -> bool:
         """Check if a product meets all defined business criteria."""
@@ -6369,22 +8107,41 @@ Return ONLY valid JSON, no additional text."""
         amazon_data = combined_data.get("amazon_product_info", {})
         financials = combined_data.get("financials", {})
         # Check profitability (already done, but for completeness)
-        is_profitable = financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        is_profitable = (
+            financials.get("ROI", 0) > MIN_ROI_PERCENT
+            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        )
         # Check Amazon listing quality
         meets_rating = amazon_data.get("rating", 0) >= MIN_RATING
         meets_reviews = amazon_data.get("reviews", 0) >= MIN_REVIEWS
         meets_sales_rank = amazon_data.get("sales_rank", MAX_SALES_RANK + 1) <= MAX_SALES_RANK
         # Check for battery products (using the helper function)
-        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(combined_data["supplier_product_info"].get("title", ""))
+        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(
+            combined_data["supplier_product_info"].get("title", "")
+        )
         # Check for other non-FBA friendly keywords
-        is_non_fba_friendly = any(k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS) or \
-                              any(k in combined_data["supplier_product_info"].get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS)
+        is_non_fba_friendly = any(
+            k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS
+        ) or any(
+            k in combined_data["supplier_product_info"].get("title", "").lower()
+            for k in NON_FBA_FRIENDLY_KEYWORDS
+        )
         # All criteria must be met
-        return is_profitable and meets_rating and meets_reviews and meets_sales_rank and not is_battery and not is_non_fba_friendly
+        return (
+            is_profitable
+            and meets_rating
+            and meets_reviews
+            and meets_sales_rank
+            and not is_battery
+            and not is_non_fba_friendly
+        )
 
-    def _apply_batch_synchronization(self, max_products_per_cycle: int, 
-                                   supplier_extraction_batch_size: int,
-                                   batch_sync_config: Dict[str, Any]) -> Tuple[int, int]:
+    def _apply_batch_synchronization(
+        self,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+        batch_sync_config: Dict[str, Any],
+    ) -> Tuple[int, int]:
         """
         Apply batch synchronization to align all batch sizes consistently.
         Returns updated max_products_per_cycle and supplier_extraction_batch_size.
@@ -6392,102 +8149,124 @@ Return ONLY valid JSON, no additional text."""
         target_batch_size = batch_sync_config.get("target_batch_size", 3)
         synchronize_all = batch_sync_config.get("synchronize_all_batch_sizes", False)
         validation_config = batch_sync_config.get("validation", {})
-        
+
         self.log.info(f"🔄 BATCH SYNCHRONIZATION: Enabled")
         self.log.info(f"   target_batch_size: {target_batch_size}")
         self.log.info(f"   synchronize_all_batch_sizes: {synchronize_all}")
-        
+
         original_values = {
             "max_products_per_cycle": max_products_per_cycle,
             "supplier_extraction_batch_size": supplier_extraction_batch_size,
             "linking_map_batch_size": self.system_config.get("linking_map_batch_size", 1),
-            "financial_report_batch_size": self.config_loader.get_financial_batch_size()
+            "financial_report_batch_size": self.config_loader.get_financial_batch_size(),
         }
-        
+
         # Check for mismatched sizes and warn if configured
         if validation_config.get("warn_on_mismatched_sizes", True):
             unique_sizes = set(original_values.values())
             if len(unique_sizes) > 1:
-                self.log.warning(f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}")
+                self.log.warning(
+                    f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}"
+                )
                 self.log.warning(f"   Unique sizes found: {sorted(unique_sizes)}")
-        
+
         if synchronize_all:
             # Synchronize all batch sizes to target
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
+
             # Also update system config values in memory for consistency
             if "system" in self.system_config:
                 self.system_config["max_products_per_cycle"] = target_batch_size
                 self.system_config["supplier_extraction_batch_size"] = target_batch_size
                 self.system_config["linking_map_batch_size"] = target_batch_size
                 # financial_report_batch_size managed by config_loader
-            
+
             self.log.info(f"✅ BATCH SYNC: All batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-            
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         else:
             # Only synchronize the two main processing batch sizes
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
-            self.log.info(f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-        
+
+            self.log.info(
+                f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}"
+            )
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         return new_max_products_per_cycle, new_supplier_extraction_batch_size
 
-    async def _analyze_products_batch(self, products: List[Dict[str, Any]], 
-                                    supplier_name: str, max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _analyze_products_batch(
+        self, products: List[Dict[str, Any]], supplier_name: str, max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Analyze a batch of supplier products for Amazon matching and profitability."""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         self.log.info(f"🔍 Analyzing {len(price_filtered_products)} products in batch mode")
-        
+
         # Process products in cycles
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
-            self.log.info(f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-            
+
+            self.log.info(
+                f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+            )
+
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(f"🔍 Analyzing product {current_index}: '{product_data.get('title')}'")
-                
+
                 # Check if already processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
-                
+
                 # Amazon data extraction and analysis
                 amazon_data = await self._get_amazon_data(product_data)
                 if not amazon_data or "error" in amazon_data:
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # 🚨 FIX: Create no-match linking entry for batch processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Batch processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -6497,77 +8276,108 @@ Return ONLY valid JSON, no additional text."""
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
                     continue
-                
+
                 # Save Amazon cache and create linking map
                 supplier_ean = product_data.get("ean") or product_data.get("barcode")
                 asin = amazon_data.get("asin", "NO_ASIN")
-                
+
                 # Save Amazon data
-                filename_identifier = supplier_ean if supplier_ean else re.sub(r'[<>:"/\\|?*\s]+', '_', product_data.get("title", "NO_TITLE")[:50])
-                amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
-                with open(amazon_cache_path, 'w', encoding='utf-8') as f:
+                filename_identifier = (
+                    supplier_ean
+                    if supplier_ean
+                    else re.sub(r'[<>:"/\\|?*\s]+', "_", product_data.get("title", "NO_TITLE")[:50])
+                )
+                amazon_cache_path = str(
+                    path_manager.get_output_path(
+                        "FBA_ANALYSIS", "amazon_cache", f"amazon_{asin}_{filename_identifier}.json"
+                    )
+                )
+                with open(amazon_cache_path, "w", encoding="utf-8") as f:
                     json.dump(amazon_data, f, indent=2, ensure_ascii=False)
-                
+
                 # Financial analysis
                 try:
                     # Already imported at top of file: from FBA_Financial_calculator import financials as calc_financials
                     supplier_price = float(product_data.get("price", 0))
                     current_price = amazon_data.get("current_price", 0)
-                    
+
                     if supplier_price > 0 and current_price > 0:
                         financials = calc_financials(
                             supplier_price=supplier_price,
                             amazon_price=current_price,
                             amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                             amazon_rating=amazon_data.get("rating", 0),
-                            amazon_review_count=amazon_data.get("reviews", 0)
+                            amazon_review_count=amazon_data.get("reviews", 0),
                         )
-                        
+
                         # Check profitability
-                        if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                            self.log.info(f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}")
-                            
-                            combined_data = self._combine_supplier_amazon_data(product_data, amazon_data, "hybrid_batch")
+                        if (
+                            financials.get("ROI", 0) > MIN_ROI_PERCENT
+                            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                        ):
+                            self.log.info(
+                                f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}"
+                            )
+
+                            combined_data = self._combine_supplier_amazon_data(
+                                product_data, amazon_data, "hybrid_batch"
+                            )
                             combined_data["financials"] = financials
                             profitable_results.append(combined_data)
-                            
-                            self.state_manager.update_success_metrics(True, True, financials.get("NetProfit", 0))
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+
+                            self.state_manager.update_success_metrics(
+                                True, True, financials.get("NetProfit", 0)
+                            )
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_profitable"
+                            )
                         else:
-                            self.log.info(f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}")
+                            self.log.info(
+                                f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}"
+                            )
                             self.state_manager.update_success_metrics(True, False)
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                            
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_not_profitable"
+                            )
+
                 except Exception as e:
                     self.log.error(f"Financial calculation failed: {e}")
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
-        
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_financial_calculation"
+                    )
+
         return profitable_results
 
     def _get_cached_products_path(self, category_url: str):
         """Helper to get the path for a category's product cache file."""
         category_filename = f"{self.supplier_name}_{category_url.split('/')[-1]}_products.json"
-        return str(path_manager.get_cache_path('supplier_cache', category_filename))
+        return str(path_manager.get_cache_path("supplier_cache", category_filename))
 
-    def _combine_data(self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    def _combine_data(
+        self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str
+    ) -> Dict[str, Any]:
         """Combine supplier and Amazon data and calculate financial metrics."""
         combined = {
             "supplier_product_info": supplier_data,
             "amazon_product_info": amazon_data,
             "analysis_timestamp": datetime.now().isoformat(),
-            "session_id": session_id
+            "session_id": session_id,
         }
         # Financial calculation is now handled within the main run loop before this function is called
         # This function is primarily for combining data and adding match validation
@@ -6577,33 +8387,39 @@ Return ONLY valid JSON, no additional text."""
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
-    
+
     def _sanitize_filename(self, title: str) -> str:
         """Sanitize product title for use in filename"""
         if not title:
             return "unknown_title"
         # Remove or replace problematic characters
-        sanitized = re.sub(r'[^\w\s-]', '', title)
-        sanitized = re.sub(r'\s+', '_', sanitized)
+        sanitized = re.sub(r"[^\w\s-]", "", title)
+        sanitized = re.sub(r"\s+", "_", sanitized)
         return sanitized[:50]  # Limit length to 50 chars
 
-    def _validate_product_match(self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate_product_match(
+        self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Validate the match between supplier and Amazon products using configurable thresholds."""
-        matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-        
+        matching_thresholds = self.system_config.get("performance", {}).get(
+            "matching_thresholds", {}
+        )
+
         # Get configurable thresholds with fallback to more conservative defaults
         title_similarity_threshold = matching_thresholds.get("title_similarity", 0.25)
-        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5) 
+        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5)
         high_title_similarity = matching_thresholds.get("high_title_similarity", 0.75)
-        
-        title_overlap_score = self._overlap_score(supplier_product.get("title", ""), amazon_product.get("title", ""))
+
+        title_overlap_score = self._overlap_score(
+            supplier_product.get("title", ""), amazon_product.get("title", "")
+        )
 
         match_quality = "low"
         confidence = 0.0
-        
+
         # Use configurable thresholds - much more strict than previous hardcoded values
         if title_overlap_score >= high_title_similarity:
             match_quality = "high"
@@ -6618,9 +8434,15 @@ Return ONLY valid JSON, no additional text."""
             match_quality = "very_low"
             confidence = 0.1
 
-        self.log.debug(f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})")
-        
-        return {"match_quality": match_quality, "confidence": confidence, "title_overlap_score": title_overlap_score}
+        self.log.debug(
+            f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})"
+        )
+
+        return {
+            "match_quality": match_quality,
+            "confidence": confidence,
+            "title_overlap_score": title_overlap_score,
+        }
 
     def _is_product_meeting_criteria(self, combined_data: Dict[str, Any]) -> bool:
         """Check if a product meets all defined business criteria."""
@@ -6629,22 +8451,41 @@ Return ONLY valid JSON, no additional text."""
         amazon_data = combined_data.get("amazon_product_info", {})
         financials = combined_data.get("financials", {})
         # Check profitability (already done, but for completeness)
-        is_profitable = financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        is_profitable = (
+            financials.get("ROI", 0) > MIN_ROI_PERCENT
+            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        )
         # Check Amazon listing quality
         meets_rating = amazon_data.get("rating", 0) >= MIN_RATING
         meets_reviews = amazon_data.get("reviews", 0) >= MIN_REVIEWS
         meets_sales_rank = amazon_data.get("sales_rank", MAX_SALES_RANK + 1) <= MAX_SALES_RANK
         # Check for battery products (using the helper function)
-        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(combined_data["supplier_product_info"].get("title", ""))
+        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(
+            combined_data["supplier_product_info"].get("title", "")
+        )
         # Check for other non-FBA friendly keywords
-        is_non_fba_friendly = any(k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS) or \
-                              any(k in combined_data["supplier_product_info"].get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS)
+        is_non_fba_friendly = any(
+            k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS
+        ) or any(
+            k in combined_data["supplier_product_info"].get("title", "").lower()
+            for k in NON_FBA_FRIENDLY_KEYWORDS
+        )
         # All criteria must be met
-        return is_profitable and meets_rating and meets_reviews and meets_sales_rank and not is_battery and not is_non_fba_friendly
+        return (
+            is_profitable
+            and meets_rating
+            and meets_reviews
+            and meets_sales_rank
+            and not is_battery
+            and not is_non_fba_friendly
+        )
 
-    def _apply_batch_synchronization(self, max_products_per_cycle: int, 
-                                   supplier_extraction_batch_size: int,
-                                   batch_sync_config: Dict[str, Any]) -> Tuple[int, int]:
+    def _apply_batch_synchronization(
+        self,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+        batch_sync_config: Dict[str, Any],
+    ) -> Tuple[int, int]:
         """
         Apply batch synchronization to align all batch sizes consistently.
         Returns updated max_products_per_cycle and supplier_extraction_batch_size.
@@ -6652,102 +8493,124 @@ Return ONLY valid JSON, no additional text."""
         target_batch_size = batch_sync_config.get("target_batch_size", 3)
         synchronize_all = batch_sync_config.get("synchronize_all_batch_sizes", False)
         validation_config = batch_sync_config.get("validation", {})
-        
+
         self.log.info(f"🔄 BATCH SYNCHRONIZATION: Enabled")
         self.log.info(f"   target_batch_size: {target_batch_size}")
         self.log.info(f"   synchronize_all_batch_sizes: {synchronize_all}")
-        
+
         original_values = {
             "max_products_per_cycle": max_products_per_cycle,
             "supplier_extraction_batch_size": supplier_extraction_batch_size,
             "linking_map_batch_size": self.system_config.get("linking_map_batch_size", 1),
-            "financial_report_batch_size": self.config_loader.get_financial_batch_size()
+            "financial_report_batch_size": self.config_loader.get_financial_batch_size(),
         }
-        
+
         # Check for mismatched sizes and warn if configured
         if validation_config.get("warn_on_mismatched_sizes", True):
             unique_sizes = set(original_values.values())
             if len(unique_sizes) > 1:
-                self.log.warning(f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}")
+                self.log.warning(
+                    f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}"
+                )
                 self.log.warning(f"   Unique sizes found: {sorted(unique_sizes)}")
-        
+
         if synchronize_all:
             # Synchronize all batch sizes to target
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
+
             # Also update system config values in memory for consistency
             if "system" in self.system_config:
                 self.system_config["max_products_per_cycle"] = target_batch_size
                 self.system_config["supplier_extraction_batch_size"] = target_batch_size
                 self.system_config["linking_map_batch_size"] = target_batch_size
                 # financial_report_batch_size managed by config_loader
-            
+
             self.log.info(f"✅ BATCH SYNC: All batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-            
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         else:
             # Only synchronize the two main processing batch sizes
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
-            self.log.info(f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-        
+
+            self.log.info(
+                f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}"
+            )
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         return new_max_products_per_cycle, new_supplier_extraction_batch_size
 
-    async def _analyze_products_batch(self, products: List[Dict[str, Any]], 
-                                    supplier_name: str, max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _analyze_products_batch(
+        self, products: List[Dict[str, Any]], supplier_name: str, max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Analyze a batch of supplier products for Amazon matching and profitability."""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         self.log.info(f"🔍 Analyzing {len(price_filtered_products)} products in batch mode")
-        
+
         # Process products in cycles
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
-            self.log.info(f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-            
+
+            self.log.info(
+                f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+            )
+
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(f"🔍 Analyzing product {current_index}: '{product_data.get('title')}'")
-                
+
                 # Check if already processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
-                
+
                 # Amazon data extraction and analysis
                 amazon_data = await self._get_amazon_data(product_data)
                 if not amazon_data or "error" in amazon_data:
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # 🚨 FIX: Create no-match linking entry for batch processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Batch processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -6757,77 +8620,108 @@ Return ONLY valid JSON, no additional text."""
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
                     continue
-                
+
                 # Save Amazon cache and create linking map
                 supplier_ean = product_data.get("ean") or product_data.get("barcode")
                 asin = amazon_data.get("asin", "NO_ASIN")
-                
+
                 # Save Amazon data
-                filename_identifier = supplier_ean if supplier_ean else re.sub(r'[<>:"/\\|?*\s]+', '_', product_data.get("title", "NO_TITLE")[:50])
-                amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
-                with open(amazon_cache_path, 'w', encoding='utf-8') as f:
+                filename_identifier = (
+                    supplier_ean
+                    if supplier_ean
+                    else re.sub(r'[<>:"/\\|?*\s]+', "_", product_data.get("title", "NO_TITLE")[:50])
+                )
+                amazon_cache_path = str(
+                    path_manager.get_output_path(
+                        "FBA_ANALYSIS", "amazon_cache", f"amazon_{asin}_{filename_identifier}.json"
+                    )
+                )
+                with open(amazon_cache_path, "w", encoding="utf-8") as f:
                     json.dump(amazon_data, f, indent=2, ensure_ascii=False)
-                
+
                 # Financial analysis
                 try:
                     # Already imported at top of file: from FBA_Financial_calculator import financials as calc_financials
                     supplier_price = float(product_data.get("price", 0))
                     current_price = amazon_data.get("current_price", 0)
-                    
+
                     if supplier_price > 0 and current_price > 0:
                         financials = calc_financials(
                             supplier_price=supplier_price,
                             amazon_price=current_price,
                             amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                             amazon_rating=amazon_data.get("rating", 0),
-                            amazon_review_count=amazon_data.get("reviews", 0)
+                            amazon_review_count=amazon_data.get("reviews", 0),
                         )
-                        
+
                         # Check profitability
-                        if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                            self.log.info(f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}")
-                            
-                            combined_data = self._combine_supplier_amazon_data(product_data, amazon_data, "hybrid_batch")
+                        if (
+                            financials.get("ROI", 0) > MIN_ROI_PERCENT
+                            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                        ):
+                            self.log.info(
+                                f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}"
+                            )
+
+                            combined_data = self._combine_supplier_amazon_data(
+                                product_data, amazon_data, "hybrid_batch"
+                            )
                             combined_data["financials"] = financials
                             profitable_results.append(combined_data)
-                            
-                            self.state_manager.update_success_metrics(True, True, financials.get("NetProfit", 0))
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+
+                            self.state_manager.update_success_metrics(
+                                True, True, financials.get("NetProfit", 0)
+                            )
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_profitable"
+                            )
                         else:
-                            self.log.info(f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}")
+                            self.log.info(
+                                f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}"
+                            )
                             self.state_manager.update_success_metrics(True, False)
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                            
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_not_profitable"
+                            )
+
                 except Exception as e:
                     self.log.error(f"Financial calculation failed: {e}")
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
-        
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_financial_calculation"
+                    )
+
         return profitable_results
 
     def _get_cached_products_path(self, category_url: str):
         """Helper to get the path for a category's product cache file."""
         category_filename = f"{self.supplier_name}_{category_url.split('/')[-1]}_products.json"
-        return str(path_manager.get_cache_path('supplier_cache', category_filename))
+        return str(path_manager.get_cache_path("supplier_cache", category_filename))
 
-    def _combine_data(self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    def _combine_data(
+        self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str
+    ) -> Dict[str, Any]:
         """Combine supplier and Amazon data and calculate financial metrics."""
         combined = {
             "supplier_product_info": supplier_data,
             "amazon_product_info": amazon_data,
             "analysis_timestamp": datetime.now().isoformat(),
-            "session_id": session_id
+            "session_id": session_id,
         }
         # Financial calculation is now handled within the main run loop before this function is called
         # This function is primarily for combining data and adding match validation
@@ -6837,33 +8731,39 @@ Return ONLY valid JSON, no additional text."""
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
-    
+
     def _sanitize_filename(self, title: str) -> str:
         """Sanitize product title for use in filename"""
         if not title:
             return "unknown_title"
         # Remove or replace problematic characters
-        sanitized = re.sub(r'[^\w\s-]', '', title)
-        sanitized = re.sub(r'\s+', '_', sanitized)
+        sanitized = re.sub(r"[^\w\s-]", "", title)
+        sanitized = re.sub(r"\s+", "_", sanitized)
         return sanitized[:50]  # Limit length to 50 chars
 
-    def _validate_product_match(self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate_product_match(
+        self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Validate the match between supplier and Amazon products using configurable thresholds."""
-        matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-        
+        matching_thresholds = self.system_config.get("performance", {}).get(
+            "matching_thresholds", {}
+        )
+
         # Get configurable thresholds with fallback to more conservative defaults
         title_similarity_threshold = matching_thresholds.get("title_similarity", 0.25)
-        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5) 
+        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5)
         high_title_similarity = matching_thresholds.get("high_title_similarity", 0.75)
-        
-        title_overlap_score = self._overlap_score(supplier_product.get("title", ""), amazon_product.get("title", ""))
+
+        title_overlap_score = self._overlap_score(
+            supplier_product.get("title", ""), amazon_product.get("title", "")
+        )
 
         match_quality = "low"
         confidence = 0.0
-        
+
         # Use configurable thresholds - much more strict than previous hardcoded values
         if title_overlap_score >= high_title_similarity:
             match_quality = "high"
@@ -6878,9 +8778,15 @@ Return ONLY valid JSON, no additional text."""
             match_quality = "very_low"
             confidence = 0.1
 
-        self.log.debug(f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})")
-        
-        return {"match_quality": match_quality, "confidence": confidence, "title_overlap_score": title_overlap_score}
+        self.log.debug(
+            f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})"
+        )
+
+        return {
+            "match_quality": match_quality,
+            "confidence": confidence,
+            "title_overlap_score": title_overlap_score,
+        }
 
     def _is_product_meeting_criteria(self, combined_data: Dict[str, Any]) -> bool:
         """Check if a product meets all defined business criteria."""
@@ -6889,22 +8795,41 @@ Return ONLY valid JSON, no additional text."""
         amazon_data = combined_data.get("amazon_product_info", {})
         financials = combined_data.get("financials", {})
         # Check profitability (already done, but for completeness)
-        is_profitable = financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        is_profitable = (
+            financials.get("ROI", 0) > MIN_ROI_PERCENT
+            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        )
         # Check Amazon listing quality
         meets_rating = amazon_data.get("rating", 0) >= MIN_RATING
         meets_reviews = amazon_data.get("reviews", 0) >= MIN_REVIEWS
         meets_sales_rank = amazon_data.get("sales_rank", MAX_SALES_RANK + 1) <= MAX_SALES_RANK
         # Check for battery products (using the helper function)
-        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(combined_data["supplier_product_info"].get("title", ""))
+        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(
+            combined_data["supplier_product_info"].get("title", "")
+        )
         # Check for other non-FBA friendly keywords
-        is_non_fba_friendly = any(k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS) or \
-                              any(k in combined_data["supplier_product_info"].get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS)
+        is_non_fba_friendly = any(
+            k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS
+        ) or any(
+            k in combined_data["supplier_product_info"].get("title", "").lower()
+            for k in NON_FBA_FRIENDLY_KEYWORDS
+        )
         # All criteria must be met
-        return is_profitable and meets_rating and meets_reviews and meets_sales_rank and not is_battery and not is_non_fba_friendly
+        return (
+            is_profitable
+            and meets_rating
+            and meets_reviews
+            and meets_sales_rank
+            and not is_battery
+            and not is_non_fba_friendly
+        )
 
-    def _apply_batch_synchronization(self, max_products_per_cycle: int, 
-                                   supplier_extraction_batch_size: int,
-                                   batch_sync_config: Dict[str, Any]) -> Tuple[int, int]:
+    def _apply_batch_synchronization(
+        self,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+        batch_sync_config: Dict[str, Any],
+    ) -> Tuple[int, int]:
         """
         Apply batch synchronization to align all batch sizes consistently.
         Returns updated max_products_per_cycle and supplier_extraction_batch_size.
@@ -6912,102 +8837,124 @@ Return ONLY valid JSON, no additional text."""
         target_batch_size = batch_sync_config.get("target_batch_size", 3)
         synchronize_all = batch_sync_config.get("synchronize_all_batch_sizes", False)
         validation_config = batch_sync_config.get("validation", {})
-        
+
         self.log.info(f"🔄 BATCH SYNCHRONIZATION: Enabled")
         self.log.info(f"   target_batch_size: {target_batch_size}")
         self.log.info(f"   synchronize_all_batch_sizes: {synchronize_all}")
-        
+
         original_values = {
             "max_products_per_cycle": max_products_per_cycle,
             "supplier_extraction_batch_size": supplier_extraction_batch_size,
             "linking_map_batch_size": self.system_config.get("linking_map_batch_size", 1),
-            "financial_report_batch_size": self.config_loader.get_financial_batch_size()
+            "financial_report_batch_size": self.config_loader.get_financial_batch_size(),
         }
-        
+
         # Check for mismatched sizes and warn if configured
         if validation_config.get("warn_on_mismatched_sizes", True):
             unique_sizes = set(original_values.values())
             if len(unique_sizes) > 1:
-                self.log.warning(f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}")
+                self.log.warning(
+                    f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}"
+                )
                 self.log.warning(f"   Unique sizes found: {sorted(unique_sizes)}")
-        
+
         if synchronize_all:
             # Synchronize all batch sizes to target
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
+
             # Also update system config values in memory for consistency
             if "system" in self.system_config:
                 self.system_config["max_products_per_cycle"] = target_batch_size
                 self.system_config["supplier_extraction_batch_size"] = target_batch_size
                 self.system_config["linking_map_batch_size"] = target_batch_size
                 # financial_report_batch_size managed by config_loader
-            
+
             self.log.info(f"✅ BATCH SYNC: All batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-            
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         else:
             # Only synchronize the two main processing batch sizes
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
-            self.log.info(f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-        
+
+            self.log.info(
+                f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}"
+            )
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         return new_max_products_per_cycle, new_supplier_extraction_batch_size
 
-    async def _analyze_products_batch(self, products: List[Dict[str, Any]], 
-                                    supplier_name: str, max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _analyze_products_batch(
+        self, products: List[Dict[str, Any]], supplier_name: str, max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Analyze a batch of supplier products for Amazon matching and profitability."""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         self.log.info(f"🔍 Analyzing {len(price_filtered_products)} products in batch mode")
-        
+
         # Process products in cycles
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
-            self.log.info(f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-            
+
+            self.log.info(
+                f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+            )
+
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(f"🔍 Analyzing product {current_index}: '{product_data.get('title')}'")
-                
+
                 # Check if already processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
-                
+
                 # Amazon data extraction and analysis
                 amazon_data = await self._get_amazon_data(product_data)
                 if not amazon_data or "error" in amazon_data:
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # 🚨 FIX: Create no-match linking entry for batch processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Batch processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -7017,77 +8964,108 @@ Return ONLY valid JSON, no additional text."""
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
                     continue
-                
+
                 # Save Amazon cache and create linking map
                 supplier_ean = product_data.get("ean") or product_data.get("barcode")
                 asin = amazon_data.get("asin", "NO_ASIN")
-                
+
                 # Save Amazon data
-                filename_identifier = supplier_ean if supplier_ean else re.sub(r'[<>:"/\\|?*\s]+', '_', product_data.get("title", "NO_TITLE")[:50])
-                amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
-                with open(amazon_cache_path, 'w', encoding='utf-8') as f:
+                filename_identifier = (
+                    supplier_ean
+                    if supplier_ean
+                    else re.sub(r'[<>:"/\\|?*\s]+', "_", product_data.get("title", "NO_TITLE")[:50])
+                )
+                amazon_cache_path = str(
+                    path_manager.get_output_path(
+                        "FBA_ANALYSIS", "amazon_cache", f"amazon_{asin}_{filename_identifier}.json"
+                    )
+                )
+                with open(amazon_cache_path, "w", encoding="utf-8") as f:
                     json.dump(amazon_data, f, indent=2, ensure_ascii=False)
-                
+
                 # Financial analysis
                 try:
                     # Already imported at top of file: from FBA_Financial_calculator import financials as calc_financials
                     supplier_price = float(product_data.get("price", 0))
                     current_price = amazon_data.get("current_price", 0)
-                    
+
                     if supplier_price > 0 and current_price > 0:
                         financials = calc_financials(
                             supplier_price=supplier_price,
                             amazon_price=current_price,
                             amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                             amazon_rating=amazon_data.get("rating", 0),
-                            amazon_review_count=amazon_data.get("reviews", 0)
+                            amazon_review_count=amazon_data.get("reviews", 0),
                         )
-                        
+
                         # Check profitability
-                        if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                            self.log.info(f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}")
-                            
-                            combined_data = self._combine_supplier_amazon_data(product_data, amazon_data, "hybrid_batch")
+                        if (
+                            financials.get("ROI", 0) > MIN_ROI_PERCENT
+                            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                        ):
+                            self.log.info(
+                                f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}"
+                            )
+
+                            combined_data = self._combine_supplier_amazon_data(
+                                product_data, amazon_data, "hybrid_batch"
+                            )
                             combined_data["financials"] = financials
                             profitable_results.append(combined_data)
-                            
-                            self.state_manager.update_success_metrics(True, True, financials.get("NetProfit", 0))
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+
+                            self.state_manager.update_success_metrics(
+                                True, True, financials.get("NetProfit", 0)
+                            )
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_profitable"
+                            )
                         else:
-                            self.log.info(f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}")
+                            self.log.info(
+                                f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}"
+                            )
                             self.state_manager.update_success_metrics(True, False)
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                            
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_not_profitable"
+                            )
+
                 except Exception as e:
                     self.log.error(f"Financial calculation failed: {e}")
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
-        
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_financial_calculation"
+                    )
+
         return profitable_results
 
     def _get_cached_products_path(self, category_url: str):
         """Helper to get the path for a category's product cache file."""
         category_filename = f"{self.supplier_name}_{category_url.split('/')[-1]}_products.json"
-        return str(path_manager.get_cache_path('supplier_cache', category_filename))
+        return str(path_manager.get_cache_path("supplier_cache", category_filename))
 
-    def _combine_data(self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    def _combine_data(
+        self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str
+    ) -> Dict[str, Any]:
         """Combine supplier and Amazon data and calculate financial metrics."""
         combined = {
             "supplier_product_info": supplier_data,
             "amazon_product_info": amazon_data,
             "analysis_timestamp": datetime.now().isoformat(),
-            "session_id": session_id
+            "session_id": session_id,
         }
         # Financial calculation is now handled within the main run loop before this function is called
         # This function is primarily for combining data and adding match validation
@@ -7097,33 +9075,39 @@ Return ONLY valid JSON, no additional text."""
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
-    
+
     def _sanitize_filename(self, title: str) -> str:
         """Sanitize product title for use in filename"""
         if not title:
             return "unknown_title"
         # Remove or replace problematic characters
-        sanitized = re.sub(r'[^\w\s-]', '', title)
-        sanitized = re.sub(r'\s+', '_', sanitized)
+        sanitized = re.sub(r"[^\w\s-]", "", title)
+        sanitized = re.sub(r"\s+", "_", sanitized)
         return sanitized[:50]  # Limit length to 50 chars
 
-    def _validate_product_match(self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate_product_match(
+        self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Validate the match between supplier and Amazon products using configurable thresholds."""
-        matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-        
+        matching_thresholds = self.system_config.get("performance", {}).get(
+            "matching_thresholds", {}
+        )
+
         # Get configurable thresholds with fallback to more conservative defaults
         title_similarity_threshold = matching_thresholds.get("title_similarity", 0.25)
-        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5) 
+        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5)
         high_title_similarity = matching_thresholds.get("high_title_similarity", 0.75)
-        
-        title_overlap_score = self._overlap_score(supplier_product.get("title", ""), amazon_product.get("title", ""))
+
+        title_overlap_score = self._overlap_score(
+            supplier_product.get("title", ""), amazon_product.get("title", "")
+        )
 
         match_quality = "low"
         confidence = 0.0
-        
+
         # Use configurable thresholds - much more strict than previous hardcoded values
         if title_overlap_score >= high_title_similarity:
             match_quality = "high"
@@ -7138,9 +9122,15 @@ Return ONLY valid JSON, no additional text."""
             match_quality = "very_low"
             confidence = 0.1
 
-        self.log.debug(f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})")
-        
-        return {"match_quality": match_quality, "confidence": confidence, "title_overlap_score": title_overlap_score}
+        self.log.debug(
+            f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})"
+        )
+
+        return {
+            "match_quality": match_quality,
+            "confidence": confidence,
+            "title_overlap_score": title_overlap_score,
+        }
 
     def _is_product_meeting_criteria(self, combined_data: Dict[str, Any]) -> bool:
         """Check if a product meets all defined business criteria."""
@@ -7149,22 +9139,41 @@ Return ONLY valid JSON, no additional text."""
         amazon_data = combined_data.get("amazon_product_info", {})
         financials = combined_data.get("financials", {})
         # Check profitability (already done, but for completeness)
-        is_profitable = financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        is_profitable = (
+            financials.get("ROI", 0) > MIN_ROI_PERCENT
+            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        )
         # Check Amazon listing quality
         meets_rating = amazon_data.get("rating", 0) >= MIN_RATING
         meets_reviews = amazon_data.get("reviews", 0) >= MIN_REVIEWS
         meets_sales_rank = amazon_data.get("sales_rank", MAX_SALES_RANK + 1) <= MAX_SALES_RANK
         # Check for battery products (using the helper function)
-        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(combined_data["supplier_product_info"].get("title", ""))
+        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(
+            combined_data["supplier_product_info"].get("title", "")
+        )
         # Check for other non-FBA friendly keywords
-        is_non_fba_friendly = any(k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS) or \
-                              any(k in combined_data["supplier_product_info"].get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS)
+        is_non_fba_friendly = any(
+            k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS
+        ) or any(
+            k in combined_data["supplier_product_info"].get("title", "").lower()
+            for k in NON_FBA_FRIENDLY_KEYWORDS
+        )
         # All criteria must be met
-        return is_profitable and meets_rating and meets_reviews and meets_sales_rank and not is_battery and not is_non_fba_friendly
+        return (
+            is_profitable
+            and meets_rating
+            and meets_reviews
+            and meets_sales_rank
+            and not is_battery
+            and not is_non_fba_friendly
+        )
 
-    def _apply_batch_synchronization(self, max_products_per_cycle: int, 
-                                   supplier_extraction_batch_size: int,
-                                   batch_sync_config: Dict[str, Any]) -> Tuple[int, int]:
+    def _apply_batch_synchronization(
+        self,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+        batch_sync_config: Dict[str, Any],
+    ) -> Tuple[int, int]:
         """
         Apply batch synchronization to align all batch sizes consistently.
         Returns updated max_products_per_cycle and supplier_extraction_batch_size.
@@ -7172,102 +9181,124 @@ Return ONLY valid JSON, no additional text."""
         target_batch_size = batch_sync_config.get("target_batch_size", 3)
         synchronize_all = batch_sync_config.get("synchronize_all_batch_sizes", False)
         validation_config = batch_sync_config.get("validation", {})
-        
+
         self.log.info(f"🔄 BATCH SYNCHRONIZATION: Enabled")
         self.log.info(f"   target_batch_size: {target_batch_size}")
         self.log.info(f"   synchronize_all_batch_sizes: {synchronize_all}")
-        
+
         original_values = {
             "max_products_per_cycle": max_products_per_cycle,
             "supplier_extraction_batch_size": supplier_extraction_batch_size,
             "linking_map_batch_size": self.system_config.get("linking_map_batch_size", 1),
-            "financial_report_batch_size": self.config_loader.get_financial_batch_size()
+            "financial_report_batch_size": self.config_loader.get_financial_batch_size(),
         }
-        
+
         # Check for mismatched sizes and warn if configured
         if validation_config.get("warn_on_mismatched_sizes", True):
             unique_sizes = set(original_values.values())
             if len(unique_sizes) > 1:
-                self.log.warning(f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}")
+                self.log.warning(
+                    f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}"
+                )
                 self.log.warning(f"   Unique sizes found: {sorted(unique_sizes)}")
-        
+
         if synchronize_all:
             # Synchronize all batch sizes to target
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
+
             # Also update system config values in memory for consistency
             if "system" in self.system_config:
                 self.system_config["max_products_per_cycle"] = target_batch_size
                 self.system_config["supplier_extraction_batch_size"] = target_batch_size
                 self.system_config["linking_map_batch_size"] = target_batch_size
                 # financial_report_batch_size managed by config_loader
-            
+
             self.log.info(f"✅ BATCH SYNC: All batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-            
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         else:
             # Only synchronize the two main processing batch sizes
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
-            self.log.info(f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-        
+
+            self.log.info(
+                f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}"
+            )
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         return new_max_products_per_cycle, new_supplier_extraction_batch_size
 
-    async def _analyze_products_batch(self, products: List[Dict[str, Any]], 
-                                    supplier_name: str, max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _analyze_products_batch(
+        self, products: List[Dict[str, Any]], supplier_name: str, max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Analyze a batch of supplier products for Amazon matching and profitability."""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         self.log.info(f"🔍 Analyzing {len(price_filtered_products)} products in batch mode")
-        
+
         # Process products in cycles
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
-            self.log.info(f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-            
+
+            self.log.info(
+                f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+            )
+
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(f"🔍 Analyzing product {current_index}: '{product_data.get('title')}'")
-                
+
                 # Check if already processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
-                
+
                 # Amazon data extraction and analysis
                 amazon_data = await self._get_amazon_data(product_data)
                 if not amazon_data or "error" in amazon_data:
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # 🚨 FIX: Create no-match linking entry for batch processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Batch processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -7277,77 +9308,108 @@ Return ONLY valid JSON, no additional text."""
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
                     continue
-                
+
                 # Save Amazon cache and create linking map
                 supplier_ean = product_data.get("ean") or product_data.get("barcode")
                 asin = amazon_data.get("asin", "NO_ASIN")
-                
+
                 # Save Amazon data
-                filename_identifier = supplier_ean if supplier_ean else re.sub(r'[<>:"/\\|?*\s]+', '_', product_data.get("title", "NO_TITLE")[:50])
-                amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
-                with open(amazon_cache_path, 'w', encoding='utf-8') as f:
+                filename_identifier = (
+                    supplier_ean
+                    if supplier_ean
+                    else re.sub(r'[<>:"/\\|?*\s]+', "_", product_data.get("title", "NO_TITLE")[:50])
+                )
+                amazon_cache_path = str(
+                    path_manager.get_output_path(
+                        "FBA_ANALYSIS", "amazon_cache", f"amazon_{asin}_{filename_identifier}.json"
+                    )
+                )
+                with open(amazon_cache_path, "w", encoding="utf-8") as f:
                     json.dump(amazon_data, f, indent=2, ensure_ascii=False)
-                
+
                 # Financial analysis
                 try:
                     # Already imported at top of file: from FBA_Financial_calculator import financials as calc_financials
                     supplier_price = float(product_data.get("price", 0))
                     current_price = amazon_data.get("current_price", 0)
-                    
+
                     if supplier_price > 0 and current_price > 0:
                         financials = calc_financials(
                             supplier_price=supplier_price,
                             amazon_price=current_price,
                             amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                             amazon_rating=amazon_data.get("rating", 0),
-                            amazon_review_count=amazon_data.get("reviews", 0)
+                            amazon_review_count=amazon_data.get("reviews", 0),
                         )
-                        
+
                         # Check profitability
-                        if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                            self.log.info(f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}")
-                            
-                            combined_data = self._combine_supplier_amazon_data(product_data, amazon_data, "hybrid_batch")
+                        if (
+                            financials.get("ROI", 0) > MIN_ROI_PERCENT
+                            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                        ):
+                            self.log.info(
+                                f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}"
+                            )
+
+                            combined_data = self._combine_supplier_amazon_data(
+                                product_data, amazon_data, "hybrid_batch"
+                            )
                             combined_data["financials"] = financials
                             profitable_results.append(combined_data)
-                            
-                            self.state_manager.update_success_metrics(True, True, financials.get("NetProfit", 0))
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+
+                            self.state_manager.update_success_metrics(
+                                True, True, financials.get("NetProfit", 0)
+                            )
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_profitable"
+                            )
                         else:
-                            self.log.info(f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}")
+                            self.log.info(
+                                f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}"
+                            )
                             self.state_manager.update_success_metrics(True, False)
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                            
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_not_profitable"
+                            )
+
                 except Exception as e:
                     self.log.error(f"Financial calculation failed: {e}")
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
-        
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_financial_calculation"
+                    )
+
         return profitable_results
 
     def _get_cached_products_path(self, category_url: str):
         """Helper to get the path for a category's product cache file."""
         category_filename = f"{self.supplier_name}_{category_url.split('/')[-1]}_products.json"
-        return str(path_manager.get_cache_path('supplier_cache', category_filename))
+        return str(path_manager.get_cache_path("supplier_cache", category_filename))
 
-    def _combine_data(self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str) -> Dict[str, Any]:
+    def _combine_data(
+        self, supplier_data: Dict[str, Any], amazon_data: Dict[str, Any], session_id: str
+    ) -> Dict[str, Any]:
         """Combine supplier and Amazon data and calculate financial metrics."""
         combined = {
             "supplier_product_info": supplier_data,
             "amazon_product_info": amazon_data,
             "analysis_timestamp": datetime.now().isoformat(),
-            "session_id": session_id
+            "session_id": session_id,
         }
         # Financial calculation is now handled within the main run loop before this function is called
         # This function is primarily for combining data and adding match validation
@@ -7357,33 +9419,39 @@ Return ONLY valid JSON, no additional text."""
 
     def _overlap_score(self, title_a: str, title_b: str) -> float:
         """Calculate word overlap score between two titles"""
-        a = set(re.sub(r'[^\w\s]', ' ', title_a.lower()).split())
-        b = set(re.sub(r'[^\w\s]', ' ', title_b.lower()).split())
+        a = set(re.sub(r"[^\w\s]", " ", title_a.lower()).split())
+        b = set(re.sub(r"[^\w\s]", " ", title_b.lower()).split())
         return len(a & b) / max(1, len(a))
-    
+
     def _sanitize_filename(self, title: str) -> str:
         """Sanitize product title for use in filename"""
         if not title:
             return "unknown_title"
         # Remove or replace problematic characters
-        sanitized = re.sub(r'[^\w\s-]', '', title)
-        sanitized = re.sub(r'\s+', '_', sanitized)
+        sanitized = re.sub(r"[^\w\s-]", "", title)
+        sanitized = re.sub(r"\s+", "_", sanitized)
         return sanitized[:50]  # Limit length to 50 chars
 
-    def _validate_product_match(self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]) -> Dict[str, Any]:
+    def _validate_product_match(
+        self, supplier_product: Dict[str, Any], amazon_product: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Validate the match between supplier and Amazon products using configurable thresholds."""
-        matching_thresholds = self.system_config.get("performance", {}).get("matching_thresholds", {})
-        
+        matching_thresholds = self.system_config.get("performance", {}).get(
+            "matching_thresholds", {}
+        )
+
         # Get configurable thresholds with fallback to more conservative defaults
         title_similarity_threshold = matching_thresholds.get("title_similarity", 0.25)
-        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5) 
+        medium_title_similarity = matching_thresholds.get("medium_title_similarity", 0.5)
         high_title_similarity = matching_thresholds.get("high_title_similarity", 0.75)
-        
-        title_overlap_score = self._overlap_score(supplier_product.get("title", ""), amazon_product.get("title", ""))
+
+        title_overlap_score = self._overlap_score(
+            supplier_product.get("title", ""), amazon_product.get("title", "")
+        )
 
         match_quality = "low"
         confidence = 0.0
-        
+
         # Use configurable thresholds - much more strict than previous hardcoded values
         if title_overlap_score >= high_title_similarity:
             match_quality = "high"
@@ -7398,9 +9466,15 @@ Return ONLY valid JSON, no additional text."""
             match_quality = "very_low"
             confidence = 0.1
 
-        self.log.debug(f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})")
-        
-        return {"match_quality": match_quality, "confidence": confidence, "title_overlap_score": title_overlap_score}
+        self.log.debug(
+            f"🔍 MATCH VALIDATION: '{supplier_product.get('title', 'Unknown')}' vs '{amazon_product.get('title', 'Unknown')}' = {title_overlap_score:.2f} ({match_quality}, {confidence:.1%})"
+        )
+
+        return {
+            "match_quality": match_quality,
+            "confidence": confidence,
+            "title_overlap_score": title_overlap_score,
+        }
 
     def _is_product_meeting_criteria(self, combined_data: Dict[str, Any]) -> bool:
         """Check if a product meets all defined business criteria."""
@@ -7409,22 +9483,41 @@ Return ONLY valid JSON, no additional text."""
         amazon_data = combined_data.get("amazon_product_info", {})
         financials = combined_data.get("financials", {})
         # Check profitability (already done, but for completeness)
-        is_profitable = financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        is_profitable = (
+            financials.get("ROI", 0) > MIN_ROI_PERCENT
+            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+        )
         # Check Amazon listing quality
         meets_rating = amazon_data.get("rating", 0) >= MIN_RATING
         meets_reviews = amazon_data.get("reviews", 0) >= MIN_REVIEWS
         meets_sales_rank = amazon_data.get("sales_rank", MAX_SALES_RANK + 1) <= MAX_SALES_RANK
         # Check for battery products (using the helper function)
-        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(combined_data["supplier_product_info"].get("title", ""))
+        is_battery = is_battery_title(amazon_data.get("title", "")) or is_battery_title(
+            combined_data["supplier_product_info"].get("title", "")
+        )
         # Check for other non-FBA friendly keywords
-        is_non_fba_friendly = any(k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS) or \
-                              any(k in combined_data["supplier_product_info"].get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS)
+        is_non_fba_friendly = any(
+            k in amazon_data.get("title", "").lower() for k in NON_FBA_FRIENDLY_KEYWORDS
+        ) or any(
+            k in combined_data["supplier_product_info"].get("title", "").lower()
+            for k in NON_FBA_FRIENDLY_KEYWORDS
+        )
         # All criteria must be met
-        return is_profitable and meets_rating and meets_reviews and meets_sales_rank and not is_battery and not is_non_fba_friendly
+        return (
+            is_profitable
+            and meets_rating
+            and meets_reviews
+            and meets_sales_rank
+            and not is_battery
+            and not is_non_fba_friendly
+        )
 
-    def _apply_batch_synchronization(self, max_products_per_cycle: int, 
-                                   supplier_extraction_batch_size: int,
-                                   batch_sync_config: Dict[str, Any]) -> Tuple[int, int]:
+    def _apply_batch_synchronization(
+        self,
+        max_products_per_cycle: int,
+        supplier_extraction_batch_size: int,
+        batch_sync_config: Dict[str, Any],
+    ) -> Tuple[int, int]:
         """
         Apply batch synchronization to align all batch sizes consistently.
         Returns updated max_products_per_cycle and supplier_extraction_batch_size.
@@ -7432,102 +9525,124 @@ Return ONLY valid JSON, no additional text."""
         target_batch_size = batch_sync_config.get("target_batch_size", 3)
         synchronize_all = batch_sync_config.get("synchronize_all_batch_sizes", False)
         validation_config = batch_sync_config.get("validation", {})
-        
+
         self.log.info(f"🔄 BATCH SYNCHRONIZATION: Enabled")
         self.log.info(f"   target_batch_size: {target_batch_size}")
         self.log.info(f"   synchronize_all_batch_sizes: {synchronize_all}")
-        
+
         original_values = {
             "max_products_per_cycle": max_products_per_cycle,
             "supplier_extraction_batch_size": supplier_extraction_batch_size,
             "linking_map_batch_size": self.system_config.get("linking_map_batch_size", 1),
-            "financial_report_batch_size": self.config_loader.get_financial_batch_size()
+            "financial_report_batch_size": self.config_loader.get_financial_batch_size(),
         }
-        
+
         # Check for mismatched sizes and warn if configured
         if validation_config.get("warn_on_mismatched_sizes", True):
             unique_sizes = set(original_values.values())
             if len(unique_sizes) > 1:
-                self.log.warning(f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}")
+                self.log.warning(
+                    f"⚠️ BATCH SYNC WARNING: Mismatched batch sizes detected: {original_values}"
+                )
                 self.log.warning(f"   Unique sizes found: {sorted(unique_sizes)}")
-        
+
         if synchronize_all:
             # Synchronize all batch sizes to target
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
+
             # Also update system config values in memory for consistency
             if "system" in self.system_config:
                 self.system_config["max_products_per_cycle"] = target_batch_size
                 self.system_config["supplier_extraction_batch_size"] = target_batch_size
                 self.system_config["linking_map_batch_size"] = target_batch_size
                 # financial_report_batch_size managed by config_loader
-            
+
             self.log.info(f"✅ BATCH SYNC: All batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-            
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         else:
             # Only synchronize the two main processing batch sizes
             new_max_products_per_cycle = target_batch_size
             new_supplier_extraction_batch_size = target_batch_size
-            
-            self.log.info(f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}")
-            self.log.info(f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}")
-        
+
+            self.log.info(
+                f"✅ BATCH SYNC: Main processing batch sizes synchronized to {target_batch_size}"
+            )
+            self.log.info(
+                f"   Updated values: max_products_per_cycle={new_max_products_per_cycle}, supplier_extraction_batch_size={new_supplier_extraction_batch_size}"
+            )
+
         return new_max_products_per_cycle, new_supplier_extraction_batch_size
 
-    async def _analyze_products_batch(self, products: List[Dict[str, Any]], 
-                                    supplier_name: str, max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _analyze_products_batch(
+        self, products: List[Dict[str, Any]], supplier_name: str, max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Analyze a batch of supplier products for Amazon matching and profitability."""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         self.log.info(f"🔍 Analyzing {len(price_filtered_products)} products in batch mode")
-        
+
         # Process products in cycles
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
-            self.log.info(f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)")
-            
+
+            self.log.info(
+                f"🔄 Processing analysis batch {batch_num + 1}/{total_batches} ({len(batch_products)} products)"
+            )
+
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(f"🔍 Analyzing product {current_index}: '{product_data.get('title')}'")
-                
+
                 # Check if already processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
-                
+
                 # Amazon data extraction and analysis
                 amazon_data = await self._get_amazon_data(product_data)
                 if not amazon_data or "error" in amazon_data:
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # 🚨 FIX: Create no-match linking entry for batch processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Batch processing - Amazon search failed: {error_info}"
-                    
+
                     # Create no-match linking entry
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
@@ -7537,131 +9652,173 @@ Return ONLY valid JSON, no additional text."""
                         "supplier_price": product_data.get("price"),
                         "amazon_price": None,
                         "match_method": "none",  # NEW: Indicates no match found
-                        "confidence": 0,    # NEW: No confidence for failed matches
+                        "confidence": 0,  # NEW: No confidence for failed matches
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason  # NEW: Audit trail explaining why no match
+                        "no_match_reason": no_match_reason,  # NEW: Audit trail explaining why no match
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for batch product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
                     continue
-                
+
                 # Save Amazon cache and create linking map
                 supplier_ean = product_data.get("ean") or product_data.get("barcode")
                 asin = amazon_data.get("asin", "NO_ASIN")
-                
+
                 # Save Amazon data
-                filename_identifier = supplier_ean if supplier_ean else re.sub(r'[<>:"/\\|?*\s]+', '_', product_data.get("title", "NO_TITLE")[:50])
-                amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{asin}_{filename_identifier}.json"))
-                with open(amazon_cache_path, 'w', encoding='utf-8') as f:
+                filename_identifier = (
+                    supplier_ean
+                    if supplier_ean
+                    else re.sub(r'[<>:"/\\|?*\s]+', "_", product_data.get("title", "NO_TITLE")[:50])
+                )
+                amazon_cache_path = str(
+                    path_manager.get_output_path(
+                        "FBA_ANALYSIS", "amazon_cache", f"amazon_{asin}_{filename_identifier}.json"
+                    )
+                )
+                with open(amazon_cache_path, "w", encoding="utf-8") as f:
                     json.dump(amazon_data, f, indent=2, ensure_ascii=False)
-                
+
                 # Financial analysis
                 try:
                     # Already imported at top of file: from FBA_Financial_calculator import financials as calc_financials
                     supplier_price = float(product_data.get("price", 0))
                     current_price = amazon_data.get("current_price", 0)
-                    
+
                     if supplier_price > 0 and current_price > 0:
                         financials = calc_financials(
                             supplier_price=supplier_price,
                             amazon_price=current_price,
                             amazon_sales_rank=amazon_data.get("sales_rank", 999999),
                             amazon_rating=amazon_data.get("rating", 0),
-                            amazon_review_count=amazon_data.get("reviews", 0)
+                            amazon_review_count=amazon_data.get("reviews", 0),
                         )
-                        
+
                         # Check profitability
-                        if financials.get("ROI", 0) > MIN_ROI_PERCENT and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT:
-                            self.log.info(f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}")
-                            
-                            combined_data = self._combine_supplier_amazon_data(product_data, amazon_data, "hybrid_batch")
+                        if (
+                            financials.get("ROI", 0) > MIN_ROI_PERCENT
+                            and financials.get("NetProfit", 0) > MIN_PROFIT_PER_UNIT
+                        ):
+                            self.log.info(
+                                f"✅ PROFITABLE: ROI {financials['ROI']:.1f}%, Profit £{financials['NetProfit']:.2f}"
+                            )
+
+                            combined_data = self._combine_supplier_amazon_data(
+                                product_data, amazon_data, "hybrid_batch"
+                            )
                             combined_data["financials"] = financials
                             profitable_results.append(combined_data)
-                            
-                            self.state_manager.update_success_metrics(True, True, financials.get("NetProfit", 0))
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+
+                            self.state_manager.update_success_metrics(
+                                True, True, financials.get("NetProfit", 0)
+                            )
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_profitable"
+                            )
                         else:
-                            self.log.info(f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}")
+                            self.log.info(
+                                f"Not profitable: ROI {financials.get('ROI', 0):.1f}%, Profit £{financials.get('NetProfit', 0):.2f}"
+                            )
                             self.state_manager.update_success_metrics(True, False)
-                            self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                            
+                            self.state_manager.mark_product_processed(
+                                product_data.get("url"), "completed_not_profitable"
+                            )
+
                 except Exception as e:
                     self.log.error(f"Financial calculation failed: {e}")
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
-        
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_financial_calculation"
+                    )
+
         return profitable_results
 
     def _get_cached_products_path(self, category_url: str):
         """Helper to get the path for a category's product cache file."""
         category_filename = f"{self.supplier_name}_{category_url.split('/')[-1]}_products.json"
-        return str(path_manager.get_cache_path('supplier_cache', category_filename))
+        return str(path_manager.get_cache_path("supplier_cache", category_filename))
 
     # Removed duplicate _load_linking_map method - using the one at line 1354
 
-
-
-    async def _process_chunk_with_main_workflow_logic(self, products: List[Dict[str, Any]], max_products_per_cycle: int, *, category_urls) -> List[Dict[str, Any]]:
+    async def _process_chunk_with_main_workflow_logic(
+        self, products: List[Dict[str, Any]], max_products_per_cycle: int, *, category_urls
+    ) -> List[Dict[str, Any]]:
         """Process products using the same detailed logic as main workflow (not simplified batch processing)"""
         profitable_results = []
-        
+
         # Filter and prepare products for analysis (same as main workflow)
         valid_products = [
-            p for p in products
-            if p.get("title") and isinstance(p.get("price"), (float, int)) and p.get("price", 0) > 0 and p.get("url")
+            p
+            for p in products
+            if p.get("title")
+            and isinstance(p.get("price"), (float, int))
+            and p.get("price", 0) > 0
+            and p.get("url")
         ]
-        
+
         price_filtered_products = [
-            p for p in valid_products
-            if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
+            p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
-        
+
         # 🚨 SURGICAL FIX #2: ELIMINATE DUPLICATE PROCESSING
         # Deduplicate products by URL to prevent same product being processed multiple times
         seen_urls = set()
         deduplicated_products = []
         for product in price_filtered_products:
-            product_url = product.get('url')
+            product_url = product.get("url")
             if product_url and product_url not in seen_urls:
                 seen_urls.add(product_url)
                 deduplicated_products.append(product)
             elif product_url:
                 self.log.debug(f"🔄 DEDUP: Skipping duplicate URL: {product_url}")
-        
+
         price_filtered_products = deduplicated_products
-        self.log.info(f"🔍 Processing {len(price_filtered_products)} products with main workflow logic (after deduplication)")
-        
+        self.log.info(
+            f"🔍 Processing {len(price_filtered_products)} products with main workflow logic (after deduplication)"
+        )
+
         # Use the same logic as the main workflow
         batch_size = max_products_per_cycle
         total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
-        
+
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
             end_idx = min(start_idx + batch_size, len(price_filtered_products))
             batch_products = price_filtered_products[start_idx:end_idx]
-            
+
             # Process each product in the current batch using main workflow logic
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
-                self.log.info(f"--- Processing supplier product {current_index}/{len(price_filtered_products)}: '{product_data.get('title')}' ---")
-                
+                self.log.info(
+                    f"--- Processing supplier product {current_index}/{len(price_filtered_products)}: '{product_data.get('title')}' ---"
+                )
+
                 # 🚨 SURGICAL FIX: Update state manager with product index tracking (gap processing)
-                if hasattr(self, 'state_manager') and self.state_manager:
-                    if hasattr(self.state_manager, 'update_product_extraction_progress'):
-                        self.state_manager.update_product_extraction_progress(current_index, len(price_filtered_products))
+                if hasattr(self, "state_manager") and self.state_manager:
+                    if hasattr(self.state_manager, "update_product_extraction_progress"):
+                        self.state_manager.update_product_extraction_progress(
+                            current_index, len(price_filtered_products)
+                        )
                     else:
                         # Fallback: directly update the product index in supplier_extraction_progress
-                        if hasattr(self.state_manager, 'state_data'):
-                            progress_data = self.state_manager.state_data.setdefault('supplier_extraction_progress', {})
-                            progress_data['current_product_index_in_category'] = current_index
-                            progress_data['total_products_in_current_category'] = len(price_filtered_products)
-                
+                        if hasattr(self.state_manager, "state_data"):
+                            progress_data = self.state_manager.state_data.setdefault(
+                                "supplier_extraction_progress", {}
+                            )
+                            progress_data["current_product_index_in_category"] = current_index
+                            progress_data["total_products_in_current_category"] = len(
+                                price_filtered_products
+                            )
+
                 # 🔄 UPDATE PROCESSING STATE: Update detailed progress tracking for hybrid mode
-                if hasattr(self, 'state_manager') and self.state_manager:
+                if hasattr(self, "state_manager") and self.state_manager:
                     # Calculate current category and subcategory indexes
                     # For hybrid mode, we process by chunks, so category index = batch_num + 1
                     self.state_manager.update_supplier_extraction_progress(
@@ -7671,48 +9828,86 @@ Return ONLY valid JSON, no additional text."""
                         total_subcategories=len(batch_products),
                         batch_number=batch_num + 1,
                         total_batches=total_batches,
-                        category_url=product_data.get('source_url', 'unknown'),
-                        extraction_phase="amazon_analysis"
+                        category_url=product_data.get("source_url", "unknown"),
+                        extraction_phase="amazon_analysis",
                     )
                     # Also update the main processing index
-                    self.state_manager.update_processing_index(current_index, len(price_filtered_products))
-                
+                    self.state_manager.update_processing_index(
+                        current_index, len(price_filtered_products)
+                    )
+
                 # Check if product has been previously processed
                 if self.state_manager.is_product_processed(product_data.get("url")):
-                    self.log.info(f"Product already processed: {product_data.get('url')}. Skipping.")
+                    self.log.info(
+                        f"Product already processed: {product_data.get('url')}. Skipping."
+                    )
                     continue
 
                 # Extract Amazon data using the same logic as main workflow
                 amazon_data = await self._get_amazon_data(product_data)
-                
+
                 if amazon_data:
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
-                    amazon_asin = amazon_data.get("asin") or amazon_data.get("asin_extracted_from_page")
-                    
-                    # Save Amazon data to cache file  
+                    amazon_asin = amazon_data.get("asin") or amazon_data.get(
+                        "asin_extracted_from_page"
+                    )
+
+                    # Save Amazon data to cache file
                     # 🚨 FIX: Sanitize supplier_ean to handle multiple EANs or invalid characters
                     if supplier_ean:
                         # Take first EAN if multiple exist, sanitize invalid filename characters
-                        filename_identifier = str(supplier_ean).split('/')[0].split('\\')[0].replace(" ", "_").replace(":", "_").replace("?", "_").replace("*", "_").replace("<", "_").replace(">", "_").replace("|", "_").replace('"', "_")
+                        filename_identifier = (
+                            str(supplier_ean)
+                            .split("/")[0]
+                            .split("\\")[0]
+                            .replace(" ", "_")
+                            .replace(":", "_")
+                            .replace("?", "_")
+                            .replace("*", "_")
+                            .replace("<", "_")
+                            .replace(">", "_")
+                            .replace("|", "_")
+                            .replace('"', "_")
+                        )
                     else:
-                        filename_identifier = product_data.get("title", "NO_TITLE")[:50].replace(" ", "_").replace("/", "_").replace("\\", "_").replace(":", "_").replace("?", "_").replace("*", "_").replace("<", "_").replace(">", "_").replace("|", "_").replace('"', "_")
-                    amazon_cache_path = str(path_manager.get_output_path('FBA_ANALYSIS', 'amazon_cache', f"amazon_{amazon_asin}_{filename_identifier}.json"))
+                        filename_identifier = (
+                            product_data.get("title", "NO_TITLE")[:50]
+                            .replace(" ", "_")
+                            .replace("/", "_")
+                            .replace("\\", "_")
+                            .replace(":", "_")
+                            .replace("?", "_")
+                            .replace("*", "_")
+                            .replace("<", "_")
+                            .replace(">", "_")
+                            .replace("|", "_")
+                            .replace('"', "_")
+                        )
+                    amazon_cache_path = str(
+                        path_manager.get_output_path(
+                            "FBA_ANALYSIS",
+                            "amazon_cache",
+                            f"amazon_{amazon_asin}_{filename_identifier}.json",
+                        )
+                    )
                     success = self.save_guardian.save_json_atomic(amazon_cache_path, amazon_data)
                     if success:
                         self.log.info(f"💾 Saved Amazon data to {amazon_cache_path}")
                     else:
                         self.log.error(f"❌ Failed to save Amazon data to {amazon_cache_path}")
-                    
+
                     # Create linking map entry
-                    
+
                     if amazon_asin:  # Only require ASIN, EAN can be None for title matches
                         # DEBUG: Check linking_map type before assignment
-                        self.log.debug(f"🔍 DEBUG: linking_map type: {type(self.linking_map)}, size: {len(self.linking_map)} entries")
-                        
+                        self.log.debug(
+                            f"🔍 DEBUG: linking_map type: {type(self.linking_map)}, size: {len(self.linking_map)} entries"
+                        )
+
                         # Create detailed linking map entry (matching working pre-minor-fix format)
                         # Get the actual search method used from Amazon data
                         actual_search_method = amazon_data.get("_search_method_used", "unknown")
-                        
+
                         linking_entry = {
                             "supplier_ean": supplier_ean,
                             "amazon_asin": amazon_asin,
@@ -7721,37 +9916,57 @@ Return ONLY valid JSON, no additional text."""
                             "supplier_price": product_data.get("price"),
                             "amazon_price": amazon_data.get("current_price"),
                             "match_method": actual_search_method,
-                            "confidence": "high" if actual_search_method == "EAN" else "medium" if actual_search_method == "title" else "low",
+                            "confidence": "high"
+                            if actual_search_method == "EAN"
+                            else "medium"
+                            if actual_search_method == "title"
+                            else "low",
                             "created_at": datetime.now().isoformat(),
-                            "supplier_url": product_data.get("url")
+                            "supplier_url": product_data.get("url"),
                         }
                         # 🚀 HASH OPTIMIZATION: Use optimized method to add entry and update indexes
                         self._add_linking_map_entry_optimized(linking_entry)
-                        
+
                         # 🚨 CRITICAL FIX: Check financial report trigger after each linking map entry
                         financial_batch_size = self.config_loader.get_financial_batch_size()
                         current_linking_map_count = len(self.linking_map)
-                        
-                        if current_linking_map_count > 0 and current_linking_map_count % financial_batch_size == 0:
+
+                        if (
+                            current_linking_map_count > 0
+                            and current_linking_map_count % financial_batch_size == 0
+                        ):
                             try:
-                                self.log.info(f"🚨 FINANCIAL REPORT TRIGGER: Reached {current_linking_map_count} linking map entries (trigger every {financial_batch_size})")
+                                self.log.info(
+                                    f"🚨 FINANCIAL REPORT TRIGGER: Reached {current_linking_map_count} linking map entries (trigger every {financial_batch_size})"
+                                )
                                 from tools.FBA_Financial_calculator import run_calculations
+
                                 financial_results = run_calculations(self.supplier_name)
-                                if financial_results and financial_results.get('statistics', {}).get('output_file'):
-                                    self.log.info(f"✅ Financial report EXECUTED: {financial_results['statistics']['output_file']}")
+                                if financial_results and financial_results.get(
+                                    "statistics", {}
+                                ).get("output_file"):
+                                    self.log.info(
+                                        f"✅ Financial report EXECUTED: {financial_results['statistics']['output_file']}"
+                                    )
                                 else:
-                                    self.log.warning("⚠️ Financial report executed but no file path returned")
+                                    self.log.warning(
+                                        "⚠️ Financial report executed but no file path returned"
+                                    )
                             except ImportError as ie:
                                 self.log.error(f"❌ Could not import FBA_Financial_calculator: {ie}")
                             except Exception as e:
                                 self.log.error(f"❌ Error executing financial report: {e}")
                         elif current_linking_map_count > 0:
-                            next_trigger_count = ((current_linking_map_count // financial_batch_size) + 1) * financial_batch_size
-                            self.log.info(f"💡 FINANCIAL REPORT TRIGGER: Next trigger at {next_trigger_count} linking map entries (current: {current_linking_map_count}, trigger frequency: {financial_batch_size})")
-                    
+                            next_trigger_count = (
+                                (current_linking_map_count // financial_batch_size) + 1
+                            ) * financial_batch_size
+                            self.log.info(
+                                f"💡 FINANCIAL REPORT TRIGGER: Next trigger at {next_trigger_count} linking map entries (current: {current_linking_map_count}, trigger frequency: {financial_batch_size})"
+                            )
+
                     # Combine supplier and Amazon data
                     combined_data = {**product_data, **amazon_data}
-                    
+
                     # Run financial analysis using same logic as main workflow
                     try:
                         # Extract supplier price with validation
@@ -7759,53 +9974,72 @@ Return ONLY valid JSON, no additional text."""
                         if isinstance(supplier_price_inc_vat, str):
                             # Clean price string and convert to float
                             import re
-                            price_clean = re.sub(r'[^0-9.]', '', supplier_price_inc_vat)
+
+                            price_clean = re.sub(r"[^0-9.]", "", supplier_price_inc_vat)
                             supplier_price_inc_vat = float(price_clean) if price_clean else 0
                         elif supplier_price_inc_vat is None:
                             supplier_price_inc_vat = 0
-                            
+
                         # Calculate financial metrics for this specific product
-                        financials = calc_financials(combined_data, combined_data, supplier_price_inc_vat)
-                        
+                        financials = calc_financials(
+                            combined_data, combined_data, supplier_price_inc_vat
+                        )
+
                         if not financials:
-                            self.log.warning(f"Financial calculation returned empty for '{combined_data.get('title')}'")
-                            financial_result = {"error": "Financial calculation returned empty", "is_profitable": False}
+                            self.log.warning(
+                                f"Financial calculation returned empty for '{combined_data.get('title')}'"
+                            )
+                            financial_result = {
+                                "error": "Financial calculation returned empty",
+                                "is_profitable": False,
+                            }
                         else:
                             # Extract profitability from financials result
                             is_profitable = financials.get("is_profitable", False)
-                            financial_result = {
-                                **financials,
-                                "is_profitable": is_profitable
-                            }
-                            
+                            financial_result = {**financials, "is_profitable": is_profitable}
+
                     except Exception as calc_error:
                         self.log.error(f"Financial calculation error: {calc_error}")
                         financial_result = {"error": str(calc_error), "is_profitable": False}
-                    
+
                     if financial_result and financial_result.get("is_profitable"):
                         profitable_results.append(financial_result)
                         self.log.info(f"✅ Profitable product found: {product_data.get('title')}")
-                        self.state_manager.mark_product_processed(product_data.get("url"), "completed_profitable")
+                        self.state_manager.mark_product_processed(
+                            product_data.get("url"), "completed_profitable"
+                        )
                     elif financial_result and financial_result.get("error"):
-                        self.log.info(f"❌ Financial analysis failed: {financial_result.get('error')}")
-                        self.state_manager.mark_product_processed(product_data.get("url"), "failed_financial_calculation")
+                        self.log.info(
+                            f"❌ Financial analysis failed: {financial_result.get('error')}"
+                        )
+                        self.state_manager.mark_product_processed(
+                            product_data.get("url"), "failed_financial_calculation"
+                        )
                     else:
                         self.log.info(f"❌ Not profitable product: {product_data.get('title')}")
-                        self.state_manager.mark_product_processed(product_data.get("url"), "completed_not_profitable")
-                
+                        self.state_manager.mark_product_processed(
+                            product_data.get("url"), "completed_not_profitable"
+                        )
+
                 else:
                     # Handle no Amazon data or error cases
-                    self.log.warning(f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry.")
-                    
+                    self.log.warning(
+                        f"Could not retrieve Amazon data for '{product_data.get('title')}'. Creating no-match linking entry."
+                    )
+
                     # Create no-match linking entry for chunk processing
                     supplier_ean = product_data.get("ean") or product_data.get("barcode")
                     if supplier_ean == "None" or supplier_ean is None:
                         supplier_ean = None
-                        
+
                     # Determine the reason for no match
-                    error_info = amazon_data.get("error") if isinstance(amazon_data, dict) else "No Amazon data returned"
+                    error_info = (
+                        amazon_data.get("error")
+                        if isinstance(amazon_data, dict)
+                        else "No Amazon data returned"
+                    )
                     no_match_reason = f"Chunk processing - Amazon search failed: {error_info}"
-                    
+
                     no_match_entry = {
                         "supplier_ean": supplier_ean,
                         "amazon_asin": None,
@@ -7817,104 +10051,126 @@ Return ONLY valid JSON, no additional text."""
                         "confidence": 0,
                         "created_at": datetime.now().isoformat(),
                         "supplier_url": product_data.get("url"),
-                        "no_match_reason": no_match_reason
+                        "no_match_reason": no_match_reason,
                     }
-                    
+
                     # Add no-match entry to linking map using optimized method
                     self._add_linking_map_entry_optimized(no_match_entry)
-                    self.log.info(f"✅ Added NO-MATCH linking entry for chunk product: {supplier_ean or 'NO_EAN'} → NO MATCH")
-                    
-                    self.state_manager.mark_product_processed(product_data.get("url"), "failed_amazon_extraction")
-                
+                    self.log.info(
+                        f"✅ Added NO-MATCH linking entry for chunk product: {supplier_ean or 'NO_EAN'} → NO MATCH"
+                    )
+
+                    self.state_manager.mark_product_processed(
+                        product_data.get("url"), "failed_amazon_extraction"
+                    )
+
                 # Save state periodically using configurable batch size
                 linking_map_batch = self.system_config.get("linking_map_batch_size", 1)
                 if current_index % linking_map_batch == 0:
                     self.state_manager.save_state(preserve_interruption_state=True)
                     self._save_linking_map(self.supplier_name)
-                    self.log.info(f"📊 Periodic save at product {current_index} (linking_map_batch_size: {linking_map_batch})")
-        
+                    self.log.info(
+                        f"📊 Periodic save at product {current_index} (linking_map_batch_size: {linking_map_batch})"
+                    )
+
         try:
             # Final save of linking map with all entries
             self._save_linking_map(self.supplier_name)
             self.log.info("✅ Chunk processing: Final linking map save completed")
-            
+
             # Final save of financial results
             if profitable_results:
                 # Note: _save_final_report expects supplier_name as second parameter
                 self._save_final_report(profitable_results, self.supplier_name)
                 self.log.info("✅ Chunk processing: Final report save completed")
-            
+
             self.log.info("--- Chunk Processing with Main Workflow Logic Finished ---")
-            
+
         except Exception as save_error:
-            self.log.error(f"❌ CRITICAL: Error during final save operations in chunk processing: {save_error}", exc_info=True)
-        
+            self.log.error(
+                f"❌ CRITICAL: Error during final save operations in chunk processing: {save_error}",
+                exc_info=True,
+            )
+
         return profitable_results
-    
+
     def _check_authentication_fallback_needed(self) -> bool:
         """
         🔧 AUTHENTICATION FALLBACK: Check if re-authentication is needed based on various triggers
         """
         # Trigger 1: Too many products without prices
-        if self.products_without_price_count >= self.auth_fallback_config["price_missing_threshold"]:
-            self.log.warning(f"🔐 AUTH TRIGGER: {self.products_without_price_count} products without price (threshold: {self.auth_fallback_config['price_missing_threshold']})")
+        if (
+            self.products_without_price_count
+            >= self.auth_fallback_config["price_missing_threshold"]
+        ):
+            self.log.warning(
+                f"🔐 AUTH TRIGGER: {self.products_without_price_count} products without price (threshold: {self.auth_fallback_config['price_missing_threshold']})"
+            )
             return True
-            
+
         # Trigger 2: Product count-based re-authentication
         if self.products_processed_since_auth >= self.auth_fallback_config["products_per_auth"]:
-            self.log.warning(f"🔐 AUTH TRIGGER: {self.products_processed_since_auth} products processed since last auth (threshold: {self.auth_fallback_config['products_per_auth']})")
+            self.log.warning(
+                f"🔐 AUTH TRIGGER: {self.products_processed_since_auth} products processed since last auth (threshold: {self.auth_fallback_config['products_per_auth']})"
+            )
             return True
-            
+
         # Trigger 3: Time-based re-authentication
         if self.last_authentication_time:
             from datetime import datetime, timedelta
-            hours_since_auth = (datetime.now() - self.last_authentication_time).total_seconds() / 3600
+
+            hours_since_auth = (
+                datetime.now() - self.last_authentication_time
+            ).total_seconds() / 3600
             if hours_since_auth >= self.auth_fallback_config["hours_per_auth"]:
-                self.log.warning(f"🔐 AUTH TRIGGER: {hours_since_auth:.1f} hours since last auth (threshold: {self.auth_fallback_config['hours_per_auth']})")
+                self.log.warning(
+                    f"🔐 AUTH TRIGGER: {hours_since_auth:.1f} hours since last auth (threshold: {self.auth_fallback_config['hours_per_auth']})"
+                )
                 return True
-                
+
         return False
-    
+
     async def _perform_authentication_fallback(self) -> bool:
         """
         🔧 AUTHENTICATION FALLBACK: Perform re-authentication using SupplierAuthenticationService
         """
         try:
             self.log.info("🔐 Performing authentication fallback...")
-            
+
             # Import and use the authentication service
             from tools.supplier_authentication_service import SupplierAuthenticationService
-            
+
             # Get credentials from config
             supplier_config_path = os.path.join(
                 os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
-                "config", "supplier_configs", f"{self.supplier_name.replace('.', '-')}.json"
+                "config",
+                "supplier_configs",
+                f"{self.supplier_name.replace('.', '-')}.json",
             )
-            
+
             # Create authentication service
             auth_service = SupplierAuthenticationService(
                 supplier_name=self.supplier_name,
                 supplier_url=f"https://{self.supplier_name}",
-                config_path=supplier_config_path
+                config_path=supplier_config_path,
             )
-            
+
             # Get a page from browser manager
             page = None
-            if hasattr(self, 'browser_manager') and self.browser_manager:
+            if hasattr(self, "browser_manager") and self.browser_manager:
                 try:
                     page = await self.browser_manager.get_page()
                 except:
                     self.log.warning("Could not get page from browser manager for authentication")
-            
+
             if page:
                 # Use hardcoded credentials (as shown in the auth service)
-                credentials = {
-                    "email": "info@theblacksmithmarket.com",
-                    "password": "0Dqixm9c&"
-                }
-                
-                success, method = await auth_service.ensure_authenticated_session(page, credentials, force_reauth=True)
-                
+                credentials = {"email": "info@theblacksmithmarket.com", "password": "0Dqixm9c&"}
+
+                success, method = await auth_service.ensure_authenticated_session(
+                    page, credentials, force_reauth=True
+                )
+
                 if success:
                     self.log.info(f"✅ Authentication fallback successful using {method}")
                     # Reset counters and update timestamp
@@ -7928,33 +10184,37 @@ Return ONLY valid JSON, no additional text."""
             else:
                 self.log.error("❌ Could not get browser page for authentication")
                 return False
-                
+
         except Exception as e:
             self.log.error(f"❌ Authentication fallback error: {e}")
             return False
-    
+
     def _record_product_price_status(self, product_data: dict, has_price: bool):
         """
         🔧 AUTHENTICATION FALLBACK: Record whether product has price for authentication monitoring
         """
         # Update product processing counter
         self.products_processed_since_auth += 1
-        
+
         # Track price missing for authentication fallback
         if not has_price:
             self.products_without_price_count += 1
-            self.log.info(f"🔍 PRICE MISSING: Product without price ({self.products_without_price_count}/{self.auth_fallback_config['price_missing_threshold']})")
+            self.log.info(
+                f"🔍 PRICE MISSING: Product without price ({self.products_without_price_count}/{self.auth_fallback_config['price_missing_threshold']})"
+            )
         else:
             # Reset counter on successful price extraction
             if self.products_without_price_count > 0:
-                self.log.info(f"✅ PRICE FOUND: Resetting price missing counter (was {self.products_without_price_count})")
+                self.log.info(
+                    f"✅ PRICE FOUND: Resetting price missing counter (was {self.products_without_price_count})"
+                )
                 self.products_without_price_count = 0
-    
+
     def _get_supplier_cache_path_fix(self) -> str:
         """Get the path to supplier cache file"""
-        supplier_name_clean = self.supplier_name.replace('.', '-')
+        supplier_name_clean = self.supplier_name.replace(".", "-")
         return os.path.join(self.supplier_cache_dir, f"{supplier_name_clean}_products_cache.json")
-    
+
     def _find_actual_supplier_cache_file(self, supplier_name: str) -> tuple[str, int]:
         """
         🚨 CRITICAL FIX: Find actual supplier cache file including fallback files
@@ -7963,43 +10223,48 @@ Return ONLY valid JSON, no additional text."""
         # Pattern 1: Expected filename (matches save method)
         expected_filename = f"{supplier_name.replace('.', '-')}_products_cache.json"
         expected_path = os.path.join(self.supplier_cache_dir, expected_filename)
-        
+
         # Pattern 2: Alternative sanitized filename (legacy compatibility)
         sanitized_filename = f"{supplier_name.replace('.', '_')}_products_cache.json"
         sanitized_path = os.path.join(self.supplier_cache_dir, sanitized_filename)
-        
+
         # Check expected patterns first
         for pattern_name, file_path in [("expected", expected_path), ("sanitized", sanitized_path)]:
             if os.path.exists(file_path):
                 try:
-                    with open(file_path, 'r', encoding='utf-8') as f:
+                    with open(file_path, "r", encoding="utf-8") as f:
                         products = json.load(f)
                     count = len(products)
-                    self.log.info(f"✅ CACHE FOUND: {pattern_name} pattern - {count} products in {os.path.basename(file_path)}")
+                    self.log.info(
+                        f"✅ CACHE FOUND: {pattern_name} pattern - {count} products in {os.path.basename(file_path)}"
+                    )
                     return file_path, count
                 except Exception as e:
                     self.log.warning(f"⚠️ Could not read {pattern_name} cache file: {e}")
-        
+
         # Pattern 3: Search for fallback files (cache_fallback_*.json)
         try:
             import glob
+
             fallback_pattern = os.path.join(self.supplier_cache_dir, "cache_fallback_*.json")
             fallback_files = glob.glob(fallback_pattern)
-            
+
             if fallback_files:
                 # Use the most recent fallback file
                 latest_fallback = max(fallback_files, key=os.path.getmtime)
                 try:
-                    with open(latest_fallback, 'r', encoding='utf-8') as f:
+                    with open(latest_fallback, "r", encoding="utf-8") as f:
                         products = json.load(f)
                     count = len(products)
-                    self.log.info(f"✅ CACHE FOUND: fallback pattern - {count} products in {os.path.basename(latest_fallback)}")
+                    self.log.info(
+                        f"✅ CACHE FOUND: fallback pattern - {count} products in {os.path.basename(latest_fallback)}"
+                    )
                     return latest_fallback, count
                 except Exception as e:
                     self.log.warning(f"⚠️ Could not read fallback cache file: {e}")
         except Exception as e:
             self.log.warning(f"⚠️ Could not search for fallback files: {e}")
-        
+
         self.log.info(f"📝 NO CACHE FOUND: No supplier cache file found for {supplier_name}")
         return "", 0
 
@@ -8008,35 +10273,43 @@ Return ONLY valid JSON, no additional text."""
         """Check if supplier scraping should continue from previous index"""
         try:
             # Check processing state for extraction progress
-            if hasattr(self.state_manager, 'state_data') and self.state_manager.state_data:
+            if hasattr(self.state_manager, "state_data") and self.state_manager.state_data:
                 # 🚨 CRITICAL FIX: Use system_progression as canonical source
-                sp = self.state_manager.state_data.get('system_progression', {})
+                sp = self.state_manager.state_data.get("system_progression", {})
                 extraction_progress = sp  # Use system_progression data
-                products_extracted = sp.get('current_product_index_in_category', 0)
-                
+                products_extracted = sp.get("current_product_index_in_category", 0)
+
                 # Get the target from runtime settings
-                metadata = self.state_manager.state_data.get('metadata', {})
-                runtime_settings = metadata.get('runtime_settings', {})
-                target_products = runtime_settings.get('max_products_per_category', 8)
-                
-                self.log.info(f"🔍 SUPPLIER SCRAPING CHECK: extracted {products_extracted}/{target_products} products")
-                
+                metadata = self.state_manager.state_data.get("metadata", {})
+                runtime_settings = metadata.get("runtime_settings", {})
+                target_products = runtime_settings.get("max_products_per_category", 8)
+
+                self.log.info(
+                    f"🔍 SUPPLIER SCRAPING CHECK: extracted {products_extracted}/{target_products} products"
+                )
+
                 # Continue scraping if we haven't reached the target
                 if products_extracted < target_products:
-                    self.log.info(f"🔄 SUPPLIER SCRAPING NEEDED: {products_extracted} < {target_products}")
+                    self.log.info(
+                        f"🔄 SUPPLIER SCRAPING NEEDED: {products_extracted} < {target_products}"
+                    )
                     return True
                 else:
-                    self.log.info(f"✅ SUPPLIER SCRAPING COMPLETE: {products_extracted} >= {target_products}")
+                    self.log.info(
+                        f"✅ SUPPLIER SCRAPING COMPLETE: {products_extracted} >= {target_products}"
+                    )
                     return False
             else:
                 self.log.info("🔄 NO PROCESSING STATE: Proceeding with supplier scraping")
                 return True
-                
+
         except Exception as e:
-            self.log.warning(f"⚠️ Error checking supplier scraping status: {e}, proceeding with scraping")
+            self.log.warning(
+                f"⚠️ Error checking supplier scraping status: {e}, proceeding with scraping"
+            )
             return True
 
-    # 🚨 CRITICAL FIX 2: 276-Chunk Skip Logic  
+    # 🚨 CRITICAL FIX 2: 276-Chunk Skip Logic
     def _should_skip_chunk_processing(self) -> bool:
         """Check if chunk processing should be skipped due to already processed products"""
         try:
@@ -8045,13 +10318,13 @@ Return ONLY valid JSON, no additional text."""
             if not os.path.exists(cache_path):
                 self.log.info("🔄 NO SUPPLIER CACHE: Cannot skip chunk processing")
                 return False
-            
+
             # Check if we have processed products through Amazon (linking map exists)
             linking_map = self._load_linking_map(self.supplier_name)
             if not linking_map:
                 self.log.info("🔄 NO LINKING MAP: Cannot skip chunk processing")
                 return False
-            
+
             # Check if financial reports already exist
             financial_reports_dir = Path(self.output_dir) / "FBA_ANALYSIS" / "financial_reports"
             if financial_reports_dir.exists():
@@ -8060,58 +10333,64 @@ Return ONLY valid JSON, no additional text."""
                     latest_report = max(report_files, key=lambda x: x.stat().st_mtime)
                     # Check if report is recent (within last hour)
                     import time
+
                     if (time.time() - latest_report.stat().st_mtime) < 3600:
-                        self.log.info(f"✅ RECENT FINANCIAL REPORT EXISTS: {latest_report.name} - skipping chunk reprocessing")
+                        self.log.info(
+                            f"✅ RECENT FINANCIAL REPORT EXISTS: {latest_report.name} - skipping chunk reprocessing"
+                        )
                         return True
-            
+
             self.log.info("🔄 CONDITIONS NOT MET: Proceeding with chunk processing")
             return False
-            
+
         except Exception as e:
-            self.log.warning(f"⚠️ Error checking chunk skip conditions: {e}, proceeding with processing")
+            self.log.warning(
+                f"⚠️ Error checking chunk skip conditions: {e}, proceeding with processing"
+            )
             return False
-    
+
     def _load_existing_profitable_results(self) -> List[Dict[str, Any]]:
         """Load existing profitable results from recent financial reports"""
         try:
             financial_reports_dir = Path(self.output_dir) / "FBA_ANALYSIS" / "financial_reports"
             if not financial_reports_dir.exists():
                 return []
-            
+
             report_files = list(financial_reports_dir.glob("fba_financial_report_*.csv"))
             if not report_files:
                 return []
-            
+
             latest_report = max(report_files, key=lambda x: x.stat().st_mtime)
             self.log.info(f"📊 Loading existing profitable results from: {latest_report.name}")
-            
+
             # Read CSV and convert to results format
             import pandas as pd
+
             df = pd.read_csv(latest_report)
             profitable_results = []
-            
+
             for _, row in df.iterrows():
-                if row.get('profit_gbp', 0) > 0:  # Only profitable products
+                if row.get("profit_gbp", 0) > 0:  # Only profitable products
                     result = {
-                        'supplier_product': {
-                            'title': row.get('supplier_title', ''),
-                            'price': row.get('supplier_price_gbp', 0),
-                            'ean': row.get('ean', ''),
-                            'url': row.get('supplier_url', '')
+                        "supplier_product": {
+                            "title": row.get("supplier_title", ""),
+                            "price": row.get("supplier_price_gbp", 0),
+                            "ean": row.get("ean", ""),
+                            "url": row.get("supplier_url", ""),
                         },
-                        'amazon_product': {
-                            'asin': row.get('asin', ''),
-                            'title': row.get('amazon_title', ''),
-                            'price': row.get('amazon_price_gbp', 0)
+                        "amazon_product": {
+                            "asin": row.get("asin", ""),
+                            "title": row.get("amazon_title", ""),
+                            "price": row.get("amazon_price_gbp", 0),
                         },
-                        'profit_gbp': row.get('profit_gbp', 0),
-                        'roi_percentage': row.get('roi_percentage', 0)
+                        "profit_gbp": row.get("profit_gbp", 0),
+                        "roi_percentage": row.get("roi_percentage", 0),
                     }
                     profitable_results.append(result)
-            
+
             self.log.info(f"✅ Loaded {len(profitable_results)} existing profitable results")
             return profitable_results
-            
+
         except Exception as e:
             self.log.warning(f"⚠️ Error loading existing profitable results: {e}")
             return []
@@ -8124,47 +10403,61 @@ Return ONLY valid JSON, no additional text."""
         """
         try:
             self.log.info(f"🔐 LOGIN SCRIPT TRIGGER: Checking authentication before {context}")
-            
+
             # Import the same authentication service used at system startup
             from tools.supplier_authentication_service import SupplierAuthenticationService
-            
-            if hasattr(self, 'browser_manager') and self.browser_manager:
+
+            if hasattr(self, "browser_manager") and self.browser_manager:
                 # Initialize authentication service using same pattern as run_custom_poundwholesale.py
                 auth_service = SupplierAuthenticationService(self.browser_manager)
-                
+
                 # Get a page from browser manager to check authentication
                 page = await self.browser_manager.get_page(
-                    self.workflow_config.get('supplier_url', 'https://www.poundwholesale.co.uk')
+                    self.workflow_config.get("supplier_url", "https://www.poundwholesale.co.uk")
                 )
-                
+
                 if page:
                     # Get supplier credentials from system config (hybrid processing enabled)
                     supplier_name = self.supplier_name or "poundwholesale.co.uk"
-                    credentials_config = self.system_config.get("credentials", {}).get(supplier_name, {})
+                    credentials_config = self.system_config.get("credentials", {}).get(
+                        supplier_name, {}
+                    )
                     credentials = {
                         "email": credentials_config.get("username", "info@theblacksmithmarket.com"),
-                        "password": credentials_config.get("password", "0Dqixm9c&")
+                        "password": credentials_config.get("password", "0Dqixm9c&"),
                     }
-                    
+
                     # Use the same authentication method as startup script
-                    authenticated = await auth_service.ensure_authenticated_session(page, credentials)
-                    
+                    authenticated = await auth_service.ensure_authenticated_session(
+                        page, credentials
+                    )
+
                     if authenticated:
-                        self.log.info(f"✅ LOGIN SCRIPT SUCCESS: Authentication verified for {context}")
+                        self.log.info(
+                            f"✅ LOGIN SCRIPT SUCCESS: Authentication verified for {context}"
+                        )
                         return True
                     else:
-                        self.log.warning(f"⚠️ LOGIN SCRIPT FAILED: Authentication failed for {context}")
+                        self.log.warning(
+                            f"⚠️ LOGIN SCRIPT FAILED: Authentication failed for {context}"
+                        )
                         return False
                 else:
-                    self.log.warning(f"⚠️ LOGIN SCRIPT ERROR: Could not get page for authentication check in {context}")
+                    self.log.warning(
+                        f"⚠️ LOGIN SCRIPT ERROR: Could not get page for authentication check in {context}"
+                    )
                     return True  # Continue processing even if can't check
-                    
+
             else:
-                self.log.warning(f"⚠️ LOGIN SCRIPT UNAVAILABLE: No browser manager for authentication in {context}")
+                self.log.warning(
+                    f"⚠️ LOGIN SCRIPT UNAVAILABLE: No browser manager for authentication in {context}"
+                )
                 return True  # Continue processing if no browser manager
-                
+
         except Exception as e:
-            self.log.warning(f"⚠️ LOGIN SCRIPT TRIGGER ERROR: {e} in {context}, continuing processing")
+            self.log.warning(
+                f"⚠️ LOGIN SCRIPT TRIGGER ERROR: {e} in {context}, continuing processing"
+            )
             return True  # Continue processing on error to avoid blocking workflow
 
     # 🚨 CRITICAL FIX 3: Authentication Fallback Integration (Deprecated - replaced by _trigger_authentication_check)
@@ -8173,22 +10466,23 @@ Return ONLY valid JSON, no additional text."""
         try:
             # Import the authentication service
             from tools.supplier_authentication_service import SupplierAuthenticationService
-            
-            if hasattr(self, 'browser_manager') and self.browser_manager:
+
+            if hasattr(self, "browser_manager") and self.browser_manager:
                 auth_service = SupplierAuthenticationService(self.browser_manager)
-                
+
                 # Check if authenticated
                 is_authenticated = await auth_service.is_authenticated()
-                
+
                 if not is_authenticated:
                     self.log.warning("⚠️ AUTHENTICATION LOST: Triggering login fallback")
-                    
+
                     # Trigger standalone login script
                     try:
                         from tools.standalone_playwright_login import StandalonePlaywrightLogin
+
                         login_handler = StandalonePlaywrightLogin(self.browser_manager)
                         login_result = await login_handler.perform_login(self.supplier_name)
-                        
+
                         if login_result:
                             self.log.info("✅ Authentication fallback successful")
                             return True
@@ -8204,7 +10498,7 @@ Return ONLY valid JSON, no additional text."""
             else:
                 self.log.warning("⚠️ No browser manager available for authentication check")
                 return True  # Assume authenticated if can't check
-                
+
         except Exception as e:
             self.log.warning(f"⚠️ Error checking authentication: {e}, proceeding")
             return True  # Assume authenticated on error
@@ -8216,7 +10510,8 @@ Return ONLY valid JSON, no additional text."""
             cache_path = self._get_supplier_cache_path_fix()
             if os.path.exists(cache_path):
                 import json
-                with open(cache_path, 'r', encoding='utf-8') as f:
+
+                with open(cache_path, "r", encoding="utf-8") as f:
                     cached_products = json.load(f)
                 self.log.info(f"✅ Loaded {len(cached_products)} cached supplier products")
                 return cached_products
@@ -8225,92 +10520,102 @@ Return ONLY valid JSON, no additional text."""
             self.log.warning(f"⚠️ Error loading cached products: {e}")
             return []
 
-    async def _process_existing_products_with_amazon_extraction(self, products: List[Dict[str, Any]], max_products_per_cycle: int) -> List[Dict[str, Any]]:
+    async def _process_existing_products_with_amazon_extraction(
+        self, products: List[Dict[str, Any]], max_products_per_cycle: int
+    ) -> List[Dict[str, Any]]:
         """Process existing cached products with Amazon extraction only"""
         self.log.info(f"🔄 Processing {len(products)} existing products with Amazon extraction")
         return await self._process_chunk_with_main_workflow_logic(products, max_products_per_cycle)
 
-    def _filter_unprocessed_products_with_hash_lookup(self, all_products: List[Dict[str, Any]], supplier_name: str) -> List[Dict[str, Any]]:
+    def _filter_unprocessed_products_with_hash_lookup(
+        self, all_products: List[Dict[str, Any]], supplier_name: str
+    ) -> List[Dict[str, Any]]:
         """
         🚨 CRITICAL FIX #1 & #3: Filter products using hash-based O(1) lookup against linking map AND product cache
-        
+
         This method implements:
-        - Hash-based lookup for O(1) performance instead of O(n) linear searches  
+        - Hash-based lookup for O(1) performance instead of O(n) linear searches
         - Linking map filtering to only return unprocessed products
-        - 🚀 ENHANCEMENT: Product cache filtering to skip products already extracted  
+        - 🚀 ENHANCEMENT: Product cache filtering to skip products already extracted
         - Comprehensive logging for debugging gap processing
-        
+
         Args:
             all_products: All cached supplier products (e.g., 2,335 products)
             supplier_name: Name of supplier for linking map path
-            
+
         Returns:
             List of unprocessed products (e.g., 50-100 products that haven't been processed)
         """
         import json
         import os
         from typing import Set
-        
+
         # 🔍 Step 1: Load linking map to identify already processed products
         linking_map_path = self._get_linking_map_path_for_supplier(supplier_name)
         processed_eans: Set[str] = set()
         processed_urls: Set[str] = set()
-        
+
         if os.path.exists(linking_map_path):
             try:
-                with open(linking_map_path, 'r', encoding='utf-8') as f:
+                with open(linking_map_path, "r", encoding="utf-8") as f:
                     linking_map_data = json.load(f)
-                
+
                 # 🚨 CRITICAL FIX: Build both EAN and URL sets for comprehensive filtering
                 processed_eans = {
-                    entry.get('supplier_ean') 
-                    for entry in linking_map_data 
-                    if entry.get('supplier_ean')
+                    entry.get("supplier_ean")
+                    for entry in linking_map_data
+                    if entry.get("supplier_ean")
                 }
                 # 🚨 FIX 4: Normalize URLs for consistent filtering
                 processed_urls = {
-                    self._normalize_url_for_filtering(entry.get('supplier_url')) 
-                    for entry in linking_map_data 
-                    if entry.get('supplier_url')
+                    self._normalize_url_for_filtering(entry.get("supplier_url"))
+                    for entry in linking_map_data
+                    if entry.get("supplier_url")
                 }
-                
-                self.log.info(f"🔍 HASH LOOKUP: Loaded {len(processed_eans)} processed EANs and {len(processed_urls)} processed URLs from linking map")
+
+                self.log.info(
+                    f"🔍 HASH LOOKUP: Loaded {len(processed_eans)} processed EANs and {len(processed_urls)} processed URLs from linking map"
+                )
                 self.log.info(f"🔍 LINKING MAP: {linking_map_path}")
-                
+
             except Exception as e:
                 self.log.warning(f"⚠️ Could not load linking map for filtering: {e}")
                 self.log.info(f"🔍 FALLBACK: Processing all products (no linking map available)")
                 return all_products
         else:
-            self.log.info(f"🔍 NO LINKING MAP: {linking_map_path} does not exist, processing all products")
+            self.log.info(
+                f"🔍 NO LINKING MAP: {linking_map_path} does not exist, processing all products"
+            )
             return all_products
 
         # 🚀 ENHANCEMENT: Build product cache hash indexes for duplicate prevention
-        if not hasattr(self, 'product_cache_ean_index') or not hasattr(self, 'product_cache_url_index'):
+        if not hasattr(self, "product_cache_ean_index") or not hasattr(
+            self, "product_cache_url_index"
+        ):
             self.log.info(f"🔍 Building product cache hash indexes for duplicate prevention...")
-            
+
             # Load product cache
             cached_products = self._load_supplier_cache(supplier_name)
-            
+
             if cached_products:
                 # Build hash indexes for O(1) lookup
                 cache_hash_index = self._build_product_hash_index(cached_products)
-                
+
                 # Separate EAN and URL indexes
                 self.product_cache_ean_index = {}
                 self.product_cache_url_index = {}
-                
+
                 for product in cached_products:
-                    product_ean = product.get('ean', '')
-                    product_url = product.get('url', '')
-                    
+                    product_ean = product.get("ean", "")
+                    product_url = product.get("url", "")
+
                     if product_ean:
                         self.product_cache_ean_index[product_ean] = True
                     if product_url:
                         # 🚨 FIX 4: Normalize URL for consistent cache lookup
                         normalized_product_url = self._normalize_url_for_filtering(product_url)
                         self.product_cache_url_index[normalized_product_url] = True
-                
+
                 self.log.info(f"✅ Product cache indexes built:")
                 self.log.info(f"   📊 URL Index: {len(self.product_cache_url_index)} entries")
                 self.log.info(f"   📊 EAN Index: {len(self.product_cache_ean_index)} entries")
@@ -8319,12 +10624,16 @@ Return ONLY valid JSON, no additional text."""
                 self.product_cache_ean_index = {}
                 self.product_cache_url_index = {}
                 self.log.info(f"📊 No product cache found - cache optimization disabled")
-        
+
         # 🔍 Step 2: Filter products using O(1) hash lookup for both EAN and URL
 
         # 🚨 CRITICAL FIX: Add pre-extraction visibility logs
-        self.log.info(f"🔗 PRE-EXTRACTION PRODUCT FILTERING: Starting with {len(all_products)} products from cache")
-        self.log.info(f"🔗 Filtering against linking map and product cache to identify unprocessed products")
+        self.log.info(
+            f"🔗 PRE-EXTRACTION PRODUCT FILTERING: Starting with {len(all_products)} products from cache"
+        )
+        self.log.info(
+            f"🔗 Filtering against linking map and product cache to identify unprocessed products"
+        )
 
         unprocessed_products = []
         processed_count = 0
@@ -8333,66 +10642,81 @@ Return ONLY valid JSON, no additional text."""
         skipped_by_cache_ean = 0
         skipped_by_cache_url = 0
         included_missing_ean = 0
-        
+
         for product in all_products:
-            product_ean = product.get('ean', '')
-            product_url = product.get('url', '')
-            
+            product_ean = product.get("ean", "")
+            product_url = product.get("url", "")
+
             # 🚨 CRITICAL FIX: Skip if product is processed by EITHER EAN OR URL in linking map
             skip_product = False
-            
+
             # Check linking map EAN-based skipping
             if product_ean and product_ean in processed_eans:
                 skipped_by_linking_map_ean += 1
                 processed_count += 1
                 skip_product = True
-                self.log.debug(f"🔄 Linking map hit (EAN): {product.get('title', 'Unknown')} - skipping extraction")
-            
+                self.log.debug(
+                    f"🔄 Linking map hit (EAN): {product.get('title', 'Unknown')} - skipping extraction"
+                )
+
             # Check linking map URL-based skipping (for products without EAN or as additional check)
             # 🚨 FIX 4: Normalize URL for consistent comparison
             elif product_url and self._normalize_url_for_filtering(product_url) in processed_urls:
                 skipped_by_linking_map_url += 1
-                processed_count += 1  
+                processed_count += 1
                 skip_product = True
-                self.log.debug(f"🔄 Linking map hit (URL): {product.get('title', 'Unknown')} - skipping extraction")
-            
+                self.log.debug(
+                    f"🔄 Linking map hit (URL): {product.get('title', 'Unknown')} - skipping extraction"
+                )
+
             # 🚨 CORRECTED: Products with cached supplier data but NOT in linking map need Amazon analysis
             # Cache hits should NOT be skipped - they indicate supplier data is available for Amazon lookup
             # 🚨 FIX 4: Normalize URL for consistent cache comparison
-            if (product_ean and product_ean in self.product_cache_ean_index) or \
-               (product_url and self._normalize_url_for_filtering(product_url) in self.product_cache_url_index):
+            if (product_ean and product_ean in self.product_cache_ean_index) or (
+                product_url
+                and self._normalize_url_for_filtering(product_url) in self.product_cache_url_index
+            ):
                 # Has cached supplier data - can proceed directly to Amazon analysis
                 # Verbose logging removed per user request - product found in cache
                 pass
 
             if skip_product:
                 continue
-                
+
             # Track products without EAN for visibility
             if not product_ean:
                 included_missing_ean += 1
-            
+
             # Product not found in either set - include for processing
             unprocessed_products.append(product)
-        
+
         # 🚨 CRITICAL FIX: Enhanced filtering visibility with 2-step breakdown
         total_skipped_linking_map = skipped_by_linking_map_ean + skipped_by_linking_map_url
 
         # Count products with cached supplier data (not skipped, just optimized)
-        cached_supplier_data = sum(1 for product in unprocessed_products
-                                 if (product.get('ean') and product.get('ean') in self.product_cache_ean_index) or
-                                    (product.get('url') and product.get('url') in self.product_cache_url_index))
+        cached_supplier_data = sum(
+            1
+            for product in unprocessed_products
+            if (product.get("ean") and product.get("ean") in self.product_cache_ean_index)
+            or (product.get("url") and product.get("url") in self.product_cache_url_index)
+        )
 
         # Calculate products that need full extraction (not cached, not skipped)
         needs_full_extraction = len(unprocessed_products) - cached_supplier_data
 
         # 🚨 ENHANCED VISIBILITY: Show the complete 2-step filtering breakdown
-        self.log.info(f"🔗 LINKING MAP FILTER (Step 1): {total_skipped_linking_map} products already processed")
+        self.log.info(
+            f"🔗 LINKING MAP FILTER (Step 1): {total_skipped_linking_map} products already processed"
+        )
         self.log.info(f"   📊 EAN-based skips: {skipped_by_linking_map_ean}")
         self.log.info(f"   📊 URL-based skips: {skipped_by_linking_map_url}")
 
-        self.log.info(f"💾 PRODUCT CACHE FILTER (Step 2): {cached_supplier_data} products have supplier data cached")
-        self.log.info(f"📊 FULL EXTRACTION NEEDED: {needs_full_extraction} products need fresh extraction")
+        self.log.info(
+            f"💾 PRODUCT CACHE FILTER (Step 2): {cached_supplier_data} products have supplier data cached"
+        )
+        self.log.info(
+            f"📊 FULL EXTRACTION NEEDED: {needs_full_extraction} products need fresh extraction"
+        )
 
         # Verify filter invariant
         expected_total = total_skipped_linking_map + len(unprocessed_products)
@@ -8400,113 +10724,135 @@ Return ONLY valid JSON, no additional text."""
             self.log.error(f"🚨 FILTER INVARIANT VIOLATION: {expected_total} != {len(all_products)}")
             self.log.error(f"   This indicates a bug in the filtering logic")
 
-        self.log.info(f"🧮 FILTER INVARIANT: in={len(all_products)} == skip={total_skipped_linking_map} + remaining={len(unprocessed_products)}")
+        self.log.info(
+            f"🧮 FILTER INVARIANT: in={len(all_products)} == skip={total_skipped_linking_map} + remaining={len(unprocessed_products)}"
+        )
 
         self.log.info(f"🔍 CORRECTED FILTER RESULTS:")
         self.log.info(f"   📊 Input products: {len(all_products)}")
         self.log.info(f"   ✅ Linking map skipped (fully processed): {total_skipped_linking_map}")
-        self.log.info(f"   🚀 Cached supplier data available: {cached_supplier_data} (will use for Amazon analysis)")
+        self.log.info(
+            f"   🚀 Cached supplier data available: {cached_supplier_data} (will use for Amazon analysis)"
+        )
         self.log.info(f"   📋 Need Amazon analysis: {len(unprocessed_products)}")
-        self.log.info(f"   📈 Efficiency: {total_skipped_linking_map}/{len(all_products)} = {(total_skipped_linking_map/len(all_products)*100) if len(all_products) > 0 else 0:.1f}% reduction")
-        
+        self.log.info(
+            f"   📈 Efficiency: {total_skipped_linking_map}/{len(all_products)} = {(total_skipped_linking_map/len(all_products)*100) if len(all_products) > 0 else 0:.1f}% reduction"
+        )
+
         return unprocessed_products
-    
+
     def _load_supplier_cache(self, supplier_name: str) -> List[Dict[str, Any]]:
         """
         Load cached supplier products for hash indexing and duplicate prevention
-        
+
         Args:
             supplier_name: Name of supplier to load cache for
-            
+
         Returns:
             List of cached products, or empty list if no cache found
         """
         import json
-        
+
         supplier_cache_file, _ = self._find_actual_supplier_cache_file(supplier_name)
         if not supplier_cache_file:
             self.log.debug(f"📊 No supplier cache file found for {supplier_name}")
             return []
-        
+
         try:
-            with open(supplier_cache_file, 'r', encoding='utf-8') as f:
+            with open(supplier_cache_file, "r", encoding="utf-8") as f:
                 cached_products = json.load(f)
-                self.log.debug(f"📊 Loaded {len(cached_products)} products from supplier cache: {supplier_cache_file}")
+                self.log.debug(
+                    f"📊 Loaded {len(cached_products)} products from supplier cache: {supplier_cache_file}"
+                )
                 return cached_products
         except Exception as e:
             self.log.warning(f"⚠️ Error loading supplier cache {supplier_cache_file}: {e}")
             return []
-    
+
     def _build_product_hash_index(self, products: List[Dict[str, Any]]) -> Dict[str, bool]:
         """
         Build hash index for O(1) product lookups
-        
+
         Args:
             products: List of products to index
-            
+
         Returns:
             Dict mapping product identifiers to True (for fast existence checking)
         """
         hash_index = {}
-        
+
         for product in products:
             # Index by EAN if available
-            product_ean = product.get('ean', '')
+            product_ean = product.get("ean", "")
             if product_ean:
                 hash_index[product_ean] = True
-            
+
             # Index by URL if available
-            product_url = product.get('url', '')
+            product_url = product.get("url", "")
             if product_url:
                 hash_index[product_url] = True
-        
+
         return hash_index
-    
+
     def _get_linking_map_path_for_supplier(self, supplier_name: str) -> str:
         """Get the linking map file path for a given supplier using centralized path management"""
         # Use path_manager for standardized path construction - ensures canonical dotted path
         return str(get_linking_map_path(supplier_name=supplier_name))
-    
+
     def _perform_smart_memory_management(self, current_product_index: int, batch_products: list):
         """
         🚨 CRITICAL FIX #4: Smart Memory Management with Sliding Window Approach
-        
+
         Implements periodic memory clearing with preservation of recent context for debugging continuity.
         Prevents memory accumulation while maintaining processing efficiency.
-        
+
         Args:
             current_product_index: Current product being processed
             batch_products: Current batch of products being processed
         """
         import gc
-        
+
         # Memory management configuration
         memory_config = self.system_config.get("memory_management", {})
-        clear_frequency = memory_config.get("clear_frequency_products", 500)  # Clear every 500 products
-        sliding_window_size = memory_config.get("sliding_window_size", 100)   # Keep last 100 for continuity
+        clear_frequency = memory_config.get(
+            "clear_frequency_products", 500
+        )  # Clear every 500 products
+        sliding_window_size = memory_config.get(
+            "sliding_window_size", 100
+        )  # Keep last 100 for continuity
         enabled = memory_config.get("enabled", True)
-        
+
         if not enabled:
             return
-        
+
         # Check if it's time for memory clearing
         if current_product_index % clear_frequency == 0:
-            self.log.info(f"🧹 SMART MEMORY MANAGEMENT: Starting memory clearing at product {current_product_index}")
-            
+            self.log.info(
+                f"🧹 SMART MEMORY MANAGEMENT: Starting memory clearing at product {current_product_index}"
+            )
+
             # Step 1: Clear large data structures if they exist
             cleared_items = 0
-            
+
             # Clear any accumulated results lists (while preserving recent items)
-            if hasattr(self, 'profitable_results') and len(self.profitable_results) > sliding_window_size:
+            if (
+                hasattr(self, "profitable_results")
+                and len(self.profitable_results) > sliding_window_size
+            ):
                 original_count = len(self.profitable_results)
                 # Keep only the last N items for continuity
                 self.profitable_results = self.profitable_results[-sliding_window_size:]
                 cleared_count = original_count - len(self.profitable_results)
                 cleared_items += cleared_count
-                self.log.info(f"🧹 MEMORY: Cleared {cleared_count} old profitable results, kept {len(self.profitable_results)} recent items")
-            
+                self.log.info(
+                    f"🧹 MEMORY: Cleared {cleared_count} old profitable results, kept {len(self.profitable_results)} recent items"
+                )
+
             # Clear product accumulation lists if they exist and are large
-            if hasattr(self, '_current_all_products') and len(self._current_all_products) > sliding_window_size * 2:
+            if (
+                hasattr(self, "_current_all_products")
+                and len(self._current_all_products) > sliding_window_size * 2
+            ):
                 # For product lists, we need to be more careful - only clear if we have persistent cache
                 cache_file_exists = False
                 try:
@@ -8514,29 +10860,39 @@ Return ONLY valid JSON, no additional text."""
                     cache_file_exists = cache_file and os.path.exists(cache_file)
                 except:
                     pass
-                
+
                 if cache_file_exists:
                     original_count = len(self._current_all_products)
                     # Keep recent products for continuity
                     self._current_all_products = self._current_all_products[-sliding_window_size:]
                     cleared_count = original_count - len(self._current_all_products)
                     cleared_items += cleared_count
-                    self.log.info(f"🧹 MEMORY: Cleared {cleared_count} old cached products, kept {len(self._current_all_products)} recent items")
-                    self.log.info(f"🧹 MEMORY: Product cache file available for recovery: {cache_file}")
-            
+                    self.log.info(
+                        f"🧹 MEMORY: Cleared {cleared_count} old cached products, kept {len(self._current_all_products)} recent items"
+                    )
+                    self.log.info(
+                        f"🧹 MEMORY: Product cache file available for recovery: {cache_file}"
+                    )
+
             # Step 2: Clear any large temporary variables
-            if hasattr(self, '_temp_amazon_data'):
-                delattr(self, '_temp_amazon_data')
+            if hasattr(self, "_temp_amazon_data"):
+                delattr(self, "_temp_amazon_data")
                 cleared_items += 1
-                
-            if hasattr(self, '_temp_search_results'):
-                delattr(self, '_temp_search_results')
+
+            if hasattr(self, "_temp_search_results"):
+                delattr(self, "_temp_search_results")
                 cleared_items += 1
-            
+
             # Step 3: Force garbage collection
             collected = gc.collect()
-            
+
             # Step 4: Log memory management results
-            self.log.info(f"🧹 SMART MEMORY CLEARED: {cleared_items} data structures, {collected} objects collected")
-            self.log.info(f"🧹 MEMORY CONFIG: clear_frequency={clear_frequency}, sliding_window={sliding_window_size}")
-            self.log.info(f"🧹 MEMORY CONTINUITY: Recent context preserved for debugging and state recovery")
+            self.log.info(
+                f"🧹 SMART MEMORY CLEARED: {cleared_items} data structures, {collected} objects collected"
+            )
+            self.log.info(
+                f"🧹 MEMORY CONFIG: clear_frequency={clear_frequency}, sliding_window={sliding_window_size}"
+            )
+            self.log.info(
+                f"🧹 MEMORY CONTINUITY: Recent context preserved for debugging and state recovery"
+            )

--- a/utils/fixed_enhanced_state_manager.py
+++ b/utils/fixed_enhanced_state_manager.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional, Union, Tuple
 import hashlib
 import logging
+import time
 from collections import defaultdict
 
 # Use relative imports and paths
@@ -39,6 +40,7 @@ except ImportError:
     except ImportError:
         # For standalone testing - use relative paths
         import sys
+
         current_dir = Path(__file__).parent.parent
         sys.path.append(str(current_dir))
         from utils.path_manager import get_processing_state_path, path_manager
@@ -49,7 +51,7 @@ log = logging.getLogger(__name__)
 class FixedEnhancedStateManager:
     """
     Fixed Enhanced State Manager - Solves critical processing state issues
-    
+
     Key Fixes:
     1. Separates resumption_index from progress_index to prevent confusion
     2. Only performs reverse gap detection on startup, not every save
@@ -57,29 +59,31 @@ class FixedEnhancedStateManager:
     4. Fixes metric placement in processing state
     5. Preserves interruption state correctly
     """
-    
+
     SCHEMA_VERSION = "1.1_FIXED"
-    
+
     def __init__(self, supplier_name: str, base_path: Optional[str] = None):
         self.supplier_name = supplier_name
-        
+
         # Use relative base path if not provided
         if base_path is None:
             self.base_path = Path(__file__).parent.parent  # Go up to project root
         else:
             self.base_path = Path(base_path)
-            
+
         self.state_file_path = get_processing_state_path(supplier_name)
         self.state_data = self._initialize_state()
         self._startup_completed = False  # Track if startup analysis is done
+        self._last_save_time = 0.0
         # Load system config for toggles (best-effort)
         self.system_config: Dict[str, Any] = {}
         try:
             from config.system_config_loader import SystemConfigLoader
+
             self.system_config = SystemConfigLoader().get_system_config()
         except Exception:
             self.system_config = {}
-        
+
     def _initialize_state(self) -> Dict[str, Any]:
         """Initialize state structure with all required fields and FIXED architecture"""
         return {
@@ -87,13 +91,11 @@ class FixedEnhancedStateManager:
             "created_at": datetime.now(timezone.utc).isoformat(),
             "last_updated": datetime.now(timezone.utc).isoformat(),
             "supplier_name": self.supplier_name,
-            
             # 🚨 CRITICAL FIX 1: Separate resumption from progress tracking
             "last_processed_index": 0,  # Legacy field for backward compatibility
-            "resumption_index": 0,      # Where to resume after interruption 
-            "progress_index": 0,        # Current progress in active session
+            "resumption_index": 0,  # Where to resume after interruption
+            "progress_index": 0,  # Current progress in active session
             "session_products_processed": 0,  # Products processed in current session
-            
             "total_products": 0,
             "processing_status": "initialized",
             "is_fresh_start": True,  # 🚨 FIX 1: Add missing fresh start field (corrected by _detect_actual_fresh_start)
@@ -102,25 +104,21 @@ class FixedEnhancedStateManager:
             "successful_products": 0,
             "profitable_products": 0,
             "total_profit_found": 0.0,
-            
             "processing_statistics": {
                 "start_time": None,
                 "end_time": None,
                 "total_runtime_seconds": 0,
                 "average_time_per_product": 0,
-                "products_per_hour": 0
+                "products_per_hour": 0,
             },
-            
             "metadata": {
                 "version": "3.7+_FIXED",
                 "config_hash": "",
                 "runtime_settings": {},
                 "system_info": {},
-                "fix_applied": "processing_state_comprehensive_fix_20250730"
+                "fix_applied": "processing_state_comprehensive_fix_20250730",
             },
-            
             # 🚨 REMOVED: processed_products section - hash search uses linking map + cached products only
-            
             # 🚨 CRITICAL FIX 2: Fixed supplier extraction progress structure
             "supplier_extraction_progress": {
                 "current_category_index": 0,
@@ -136,9 +134,8 @@ class FixedEnhancedStateManager:
                 "extraction_phase": "not_started",
                 "last_completed_category": "",
                 "categories_completed": [],
-                "products_extracted_total": 0
+                "products_extracted_total": 0,
             },
-            
             # 🚨 CRITICAL FIX 3: Enhanced gap processing with better tracking
             "gap_processing": {
                 "phase": "not_started",
@@ -150,9 +147,8 @@ class FixedEnhancedStateManager:
                 "gap_last_processed_url": "",
                 "category_completion_status": {},
                 "reverse_gap_detected": False,  # 🚨 NEW: Track reverse gap state
-                "startup_analysis_completed": False  # 🚨 NEW: Track startup completion
+                "startup_analysis_completed": False,  # 🚨 NEW: Track startup completion
             },
-
             # ✅ NEW: Separated progression metrics for precise resumption
             "system_progression": {
                 "current_phase": "supplier",
@@ -162,38 +158,35 @@ class FixedEnhancedStateManager:
                 "current_product_index_in_category": 0,
                 "total_products_in_current_category": 0,
                 "supplier_extraction_resumption_index": 0,
-                "amazon_analysis_resumption_index": 0
+                "amazon_analysis_resumption_index": 0,
             },
-
             # ✅ NEW: User-facing metrics (not used for resumption logic)
             "user_display_metrics": {
                 "total_products": 0,
                 "successful_products": 0,
                 "progress_count": 0,
-                "session_products_processed": 0
-            }
+                "session_products_processed": 0,
+            },
         }
 
     def _detect_actual_fresh_start(self):
         """Enhanced fresh start detection with processed product validation"""
-        
+
         # Original flag-based logic
         flag_fresh_start = self.state_data.get("is_fresh_start", True)
-        
+
         # NEW: Validate against actual processed data
         successful_products = self.state_data.get("successful_products", 0)
         global_counters = self.state_data.get("global_counters", {})
         total_processed = global_counters.get("total_products_processed", 0)
         system_progression = self.state_data.get("system_progression", {})
         current_category = system_progression.get("current_category_index")
-        
+
         # True fresh start criteria: No processed products AND no category progress
         actual_fresh_start = (
-            successful_products == 0 and
-            total_processed == 0 and
-            current_category is None
+            successful_products == 0 and total_processed == 0 and current_category is None
         )
-        
+
         # Detect and log contradictions
         if flag_fresh_start != actual_fresh_start:
             log.warning(
@@ -202,12 +195,12 @@ class FixedEnhancedStateManager:
                 f"products={successful_products} processed={total_processed} "
                 f"category={current_category}"
             )
-            
+
             # Use actual state rather than flag
             self.state_data["is_fresh_start"] = actual_fresh_start
-        
+
         return actual_fresh_start
-    
+
     def load_state(self) -> bool:
         """
         Load existing state from file, with backward compatibility
@@ -216,11 +209,11 @@ class FixedEnhancedStateManager:
         if not self.state_file_path.exists():
             log.info(f"No existing state file found for {self.supplier_name}, starting fresh")
             return False
-        
+
         try:
-            with open(self.state_file_path, 'r', encoding='utf-8') as f:
+            with open(self.state_file_path, "r", encoding="utf-8") as f:
                 loaded_data = json.load(f)
-            
+
             # Handle backward compatibility
             if isinstance(loaded_data, dict) and "schema_version" not in loaded_data:
                 log.info("Converting legacy state format to fixed enhanced format")
@@ -228,14 +221,16 @@ class FixedEnhancedStateManager:
             else:
                 # Merge loaded data with initialized structure
                 self._merge_state_data(loaded_data)
-            
-            log.info(f"Loaded state for {self.supplier_name} - resumption from index {self.state_data['resumption_index']}")
+
+            log.info(
+                f"Loaded state for {self.supplier_name} - resumption from index {self.state_data['resumption_index']}"
+            )
             return True
-            
+
         except Exception as e:
             log.warning(f"Failed to load state file: {e}, starting fresh")
             return False
-    
+
     def _migrate_legacy_state(self, legacy_data: Dict[str, Any]):
         """Migrate legacy state format to fixed enhanced format"""
         # 🚨 CRITICAL FIX: Properly migrate legacy index to resumption_index
@@ -244,18 +239,21 @@ class FixedEnhancedStateManager:
         self.state_data["resumption_index"] = legacy_index
         self.state_data["progress_index"] = 0  # Always start fresh progress
         self.state_data["processing_status"] = "migrated_from_legacy"
-        
+
         # Migrate other legacy fields if they exist
         if "supplier_extraction_progress" in legacy_data:
             legacy_progress = legacy_data["supplier_extraction_progress"]
             # Fix the misplaced metric
             if "total_subcategories_in_batch" in legacy_progress:
-                self.state_data["supplier_extraction_progress"]["pages_scraped_in_session"] = legacy_progress["total_subcategories_in_batch"]
-            
+                self.state_data["supplier_extraction_progress"][
+                    "pages_scraped_in_session"
+                ] = legacy_progress["total_subcategories_in_batch"]
+
         log.info(f"Successfully migrated legacy state format - resumption index: {legacy_index}")
-    
+
     def _merge_state_data(self, loaded_data: Dict[str, Any]):
         """Merge loaded data with initialized structure"""
+
         def deep_merge(base: Dict, overlay: Dict) -> Dict:
             result = base.copy()
             for key, value in overlay.items():
@@ -264,10 +262,10 @@ class FixedEnhancedStateManager:
                 else:
                     result[key] = value
             return result
-        
+
         self.state_data = deep_merge(self.state_data, loaded_data)
         self.state_data["last_updated"] = datetime.now(timezone.utc).isoformat()
-        
+
         # 🚨 CRITICAL FIX: Ensure new fields exist even in merged data
         if "resumption_index" not in self.state_data:
             self.state_data["resumption_index"] = self.state_data.get("last_processed_index", 0)
@@ -275,7 +273,7 @@ class FixedEnhancedStateManager:
             self.state_data["progress_index"] = 0
         if "session_products_processed" not in self.state_data:
             self.state_data["session_products_processed"] = 0
-    
+
     def perform_startup_analysis(self) -> Dict[str, Any]:
         """
         🚨 CRITICAL FIX: Perform reverse gap detection and category analysis ONLY on startup
@@ -284,12 +282,12 @@ class FixedEnhancedStateManager:
         if self._startup_completed:
             log.info("Startup analysis already completed for this session")
             return self.state_data.get("gap_processing", {}).get("category_completion_status", {})
-        
+
         log.info("🔍 STARTUP ANALYSIS: Beginning comprehensive state analysis...")
-        
+
         # Calculate file-grounded totals
         file_grounded_data = self._calculate_file_grounded_totals()
-        
+
         # Toggle: allow disabling reverse gap heuristic entirely via config
         use_reverse_gap_heuristic = (
             self.system_config.get("pipeline_toggles", {})
@@ -307,25 +305,31 @@ class FixedEnhancedStateManager:
             log.info(f"RESUME DECISION: START_AT_INDEX={start_at} (reason: system_progression)")
         # 🚨 REVERSE GAP POLICY FIX: Only perform reverse gap detection on startup
         elif file_grounded_data["linking_map_count"] > file_grounded_data["total_products"]:
-            log.info(f"🔄 REVERSE GAP DETECTED: Linking map ({file_grounded_data['linking_map_count']}) > Cache ({file_grounded_data['total_products']})")
+            log.info(
+                f"🔄 REVERSE GAP DETECTED: Linking map ({file_grounded_data['linking_map_count']}) > Cache ({file_grounded_data['total_products']})"
+            )
 
             # Check if we should preserve existing resume index or reset
             current_resumption_index = self.state_data.get("resumption_index", 0)
             explicit_cache_rebuild = self.state_data.get("force_cache_rebuild", False)
-            
+
             if explicit_cache_rebuild:
                 # Only reset to 0 if explicitly rebuilding cache
                 self.state_data["resumption_index"] = 0
                 self.state_data["resume_reason"] = "reverse_gap_cache_rebuild"
-                log.info(f"✅ REVERSE GAP: Reset resumption_index = 0 (explicit cache rebuild requested)")
+                log.info(
+                    f"✅ REVERSE GAP: Reset resumption_index = 0 (explicit cache rebuild requested)"
+                )
             elif current_resumption_index == 0:
                 # If resumption_index is 0, check if this is truly a fresh start or a restart
                 # 🚨 FIX 1: Use enhanced fresh start detection instead of manual logic
                 is_actual_fresh_start = self._detect_actual_fresh_start()
-                
+
                 if not is_actual_fresh_start:
                     # This appears to be a restart, not a fresh start - preserve some progress
-                    log.warning(f"🔄 REVERSE GAP: Detected restart with resumption_index=0 but previous state exists - preserving index")
+                    log.warning(
+                        f"🔄 REVERSE GAP: Detected restart with resumption_index=0 but previous state exists - preserving index"
+                    )
                     self.state_data["resume_reason"] = "reverse_gap_restart_preserved"
                 else:
                     # Truly fresh start
@@ -334,9 +338,11 @@ class FixedEnhancedStateManager:
                     log.info(f"✅ REVERSE GAP: Fresh start confirmed - resumption_index = 0")
             else:
                 # Preserve existing resume index to avoid restarting from first category
-                log.warning(f"🔄 REVERSE GAP: Preserving existing resumption_index = {current_resumption_index} (no explicit rebuild)")
+                log.warning(
+                    f"🔄 REVERSE GAP: Preserving existing resumption_index = {current_resumption_index} (no explicit rebuild)"
+                )
                 self.state_data["resume_reason"] = "reverse_gap_preserved_resume"
-            
+
             self.state_data["progress_index"] = 0
             self.state_data["processing_status"] = "FRESH_CATEGORIES"
             self.state_data["gap_processing"]["reverse_gap_detected"] = True
@@ -349,8 +355,10 @@ class FixedEnhancedStateManager:
             # Track normal resume path
             self.state_data["resume_reason"] = "normal_startup"
 
-            log.info(f"✅ Normal startup - resumption_index = {file_grounded_data['linking_map_count']}")
-        
+            log.info(
+                f"✅ Normal startup - resumption_index = {file_grounded_data['linking_map_count']}"
+            )
+
         # Log final resume decision for observability (if not already logged)
         if "resume_reason" in self.state_data and "resumption_index" in self.state_data:
             log.info(
@@ -360,25 +368,27 @@ class FixedEnhancedStateManager:
         # Update total products from file-grounded data
         self.state_data["total_products"] = file_grounded_data["total_products"]
         self.state_data["successful_products"] = file_grounded_data["processed_products"]
-        
+
         # Update category completion status
         if file_grounded_data["category_completion_status"]:
-            self.state_data["gap_processing"]["category_completion_status"] = file_grounded_data["category_completion_status"]
-        
+            self.state_data["gap_processing"]["category_completion_status"] = file_grounded_data[
+                "category_completion_status"
+            ]
+
         # Update supplier extraction progress with file-grounded metrics
         current_category_analysis = self._calculate_current_category_metrics(file_grounded_data)
         self.state_data["supplier_extraction_progress"].update(current_category_analysis)
-        
+
         # Mark startup analysis as completed
         self._startup_completed = True
         self.state_data["gap_processing"]["startup_analysis_completed"] = True
-        
+
         # Save the startup analysis results
         self.save_state(preserve_interruption_state=False)
-        
+
         log.info("✅ STARTUP ANALYSIS: Completed comprehensive state analysis")
         return self.state_data.get("gap_processing", {}).get("category_completion_status", {})
-    
+
     def force_cache_rebuild(self, reason: str = "manual_request"):
         """
         🚨 REVERSE GAP POLICY: Explicitly force cache rebuild and reset resume index
@@ -390,47 +400,56 @@ class FixedEnhancedStateManager:
         self.state_data["progress_index"] = 0
         self.state_data["resume_reason"] = f"force_rebuild_{reason}"
         self.state_data["processing_status"] = "FRESH_CATEGORIES"
-        
+
         # Clear startup completion to trigger fresh analysis
         self._startup_completed = False
         self.state_data["gap_processing"]["startup_analysis_completed"] = False
-        
+
         log.info("✅ Cache rebuild forced - resumption_index reset to 0")
-    
+
     def validate_and_repair_state(self) -> Tuple[bool, List[str]]:
         """
         🚨 STATE VALIDATION: Validate state consistency and repair issues
         Returns (is_valid, repairs_made)
         """
         repairs_made = []
-        
+
         # Ensure required keys exist
-        required_keys = ["resumption_index", "progress_index", "total_products", "processing_status"]
+        required_keys = [
+            "resumption_index",
+            "progress_index",
+            "total_products",
+            "processing_status",
+        ]
         for key in required_keys:
             if key not in self.state_data:
-                self.state_data[key] = 0 if key.endswith("_index") or key == "total_products" else "initialized"
+                self.state_data[key] = (
+                    0 if key.endswith("_index") or key == "total_products" else "initialized"
+                )
                 repairs_made.append(f"Added missing key: {key}")
-        
+
         # Ensure resumption_index is within bounds and monotonic
         resumption_index = self.state_data.get("resumption_index", 0)
         total_products = self.state_data.get("total_products", 0)
-        
+
         if resumption_index < 0:
             self.state_data["resumption_index"] = 0
             repairs_made.append("Fixed negative resumption_index")
-        
+
         if total_products > 0 and resumption_index > total_products:
             self.state_data["resumption_index"] = total_products
-            repairs_made.append(f"Fixed resumption_index bounds: {resumption_index} -> {total_products}")
-        
+            repairs_made.append(
+                f"Fixed resumption_index bounds: {resumption_index} -> {total_products}"
+            )
+
         # Ensure gap_processing structure exists
         if "gap_processing" not in self.state_data:
             self.state_data["gap_processing"] = {
                 "reverse_gap_detected": False,
-                "startup_analysis_completed": False
+                "startup_analysis_completed": False,
             }
             repairs_made.append("Added missing gap_processing structure")
-        
+
         # Ensure system_progression exists for breadcrumbs
         if "system_progression" not in self.state_data:
             self.state_data["system_progression"] = {
@@ -441,50 +460,76 @@ class FixedEnhancedStateManager:
                 "current_product_index_in_category": 0,
                 "total_products_in_current_category": 0,
                 "supplier_extraction_resumption_index": resumption_index,
-                "amazon_analysis_resumption_index": 0
+                "amazon_analysis_resumption_index": 0,
             }
             repairs_made.append("Added missing system_progression structure")
-        
+
         # Log repairs if any were made
         if repairs_made:
             log.info(f"State repaired: {', '.join(repairs_made)}")
-        
+
         return len(repairs_made) == 0, repairs_made
-    
+
     def update_discovered_products_in_category(self, category_url: str, discovered_count: int):
         """
         🚨 CRITICAL FIX 4: Update category totals with real-time scraping discoveries
         This method should be called when the scraper discovers more products than expected
         """
-        current_total = self.state_data["supplier_extraction_progress"].get("total_products_in_current_category", 0)
-        
+        current_total = self.state_data["supplier_extraction_progress"].get(
+            "total_products_in_current_category", 0
+        )
+
         if discovered_count > current_total:
-            log.info(f"🔍 REAL-TIME DISCOVERY: Category {category_url[:50]}... discovered {discovered_count} products (was {current_total})")
-            
+            log.info(
+                f"🔍 REAL-TIME DISCOVERY: Category {category_url[:50]}... discovered {discovered_count} products (was {current_total})"
+            )
+
             # Update the current category total
-            self.state_data["supplier_extraction_progress"]["total_products_in_current_category"] = discovered_count
-            self.state_data["supplier_extraction_progress"]["discovered_products_in_current_category"] = discovered_count
+            self.state_data["supplier_extraction_progress"][
+                "total_products_in_current_category"
+            ] = discovered_count
+            self.state_data["supplier_extraction_progress"][
+                "discovered_products_in_current_category"
+            ] = discovered_count
             # Use normalized URL for consistent key comparison
             from utils.normalization import normalize_url
+
             normalized_category_url = normalize_url(category_url)
-            self.state_data["supplier_extraction_progress"]["current_category_url"] = normalized_category_url
+            self.state_data["supplier_extraction_progress"][
+                "current_category_url"
+            ] = normalized_category_url
             self.state_data["supplier_extraction_progress"]["original_category_url"] = category_url
-            
+
             # Update the category completion status if it exists
-            if "gap_processing" in self.state_data and "category_completion_status" in self.state_data["gap_processing"]:
+            if (
+                "gap_processing" in self.state_data
+                and "category_completion_status" in self.state_data["gap_processing"]
+            ):
                 if category_url in self.state_data["gap_processing"]["category_completion_status"]:
-                    self.state_data["gap_processing"]["category_completion_status"][category_url]["extracted"] = discovered_count
+                    self.state_data["gap_processing"]["category_completion_status"][category_url][
+                        "extracted"
+                    ] = discovered_count
                     # Recalculate completion percentage
-                    processed = self.state_data["gap_processing"]["category_completion_status"][category_url].get("processed", 0)
-                    completion_pct = (processed / discovered_count * 100) if discovered_count > 0 else 0
-                    self.state_data["gap_processing"]["category_completion_status"][category_url]["completion_pct"] = completion_pct
-                    
+                    processed = self.state_data["gap_processing"]["category_completion_status"][
+                        category_url
+                    ].get("processed", 0)
+                    completion_pct = (
+                        (processed / discovered_count * 100) if discovered_count > 0 else 0
+                    )
+                    self.state_data["gap_processing"]["category_completion_status"][category_url][
+                        "completion_pct"
+                    ] = completion_pct
+
                     # Update status based on new completion
                     if processed >= discovered_count:
-                        self.state_data["gap_processing"]["category_completion_status"][category_url]["status"] = "FULLY_PROCESSED"
+                        self.state_data["gap_processing"]["category_completion_status"][
+                            category_url
+                        ]["status"] = "FULLY_PROCESSED"
                     else:
-                        self.state_data["gap_processing"]["category_completion_status"][category_url]["status"] = "PARTIALLY_PROCESSED"
-            
+                        self.state_data["gap_processing"]["category_completion_status"][
+                            category_url
+                        ]["status"] = "PARTIALLY_PROCESSED"
+
             # Save the updated discovery using atomic write for safety
             self.save_state_atomic()
 
@@ -496,25 +541,34 @@ class FixedEnhancedStateManager:
         This method 'freezes' the category denominator for consistent tracking throughout the run
         """
         # Update the category total to the discovered count
-        self.state_data["supplier_extraction_progress"]["total_products_in_current_category"] = discovered_count
-        self.state_data["supplier_extraction_progress"]["discovered_products_in_current_category"] = discovered_count
-        
+        self.state_data["supplier_extraction_progress"][
+            "total_products_in_current_category"
+        ] = discovered_count
+        self.state_data["supplier_extraction_progress"][
+            "discovered_products_in_current_category"
+        ] = discovered_count
+
         # Use normalized URL for consistent key comparison
         from utils.normalization import normalize_url
+
         normalized_category_url = normalize_url(category_url)
-        self.state_data["supplier_extraction_progress"]["current_category_url"] = normalized_category_url
+        self.state_data["supplier_extraction_progress"][
+            "current_category_url"
+        ] = normalized_category_url
         self.state_data["supplier_extraction_progress"]["original_category_url"] = category_url
-        
+
         # Update system progression with frozen denominator
         sp = self.state_data.setdefault("system_progression", {})
         sp["total_products_in_current_category"] = discovered_count
         sp["current_category_url"] = normalized_category_url
         sp["original_category_url"] = category_url
-        
+
         # Save the frozen denominator atomically
         self.save_state_atomic()
-        
-        log.info(f"🔒 FROZEN DENOMINATOR: Set to {discovered_count} products for category {category_url[:50]}...")
+
+        log.info(
+            f"🔒 FROZEN DENOMINATOR: Set to {discovered_count} products for category {category_url[:50]}..."
+        )
 
     def correct_category_totals_realtime(self, category_url: str, actual_discovered: int):
         """Public wrapper for real-time category total correction.
@@ -526,7 +580,7 @@ class FixedEnhancedStateManager:
         """
 
         self.update_discovered_products_in_category(category_url, actual_discovered)
-    
+
     def update_processing_progress(self, increment: int = 1, product_url: Optional[str] = None):
         """
         🚨 CRITICAL FIX 5: Update progress tracking AND resumption index for exact recovery
@@ -535,43 +589,56 @@ class FixedEnhancedStateManager:
         # Update progress counters
         # 🚨 CRITICAL FIX: Update ONLY system_progression as single source of truth
         sp = self.state_data.setdefault("system_progression", {})
-        sp["current_product_index_in_category"] = sp.get("current_product_index_in_category", 0) + increment
-        
+        sp["current_product_index_in_category"] = (
+            sp.get("current_product_index_in_category", 0) + increment
+        )
+
         # Update session metrics for user display
         self.state_data["session_products_processed"] += increment
-        
+
         # 🚨 CRITICAL FIX: Update resumption_index continuously for exact interruption recovery
         self.state_data["resumption_index"] += increment
-        
+
         # Legacy compatibility: keep last_processed_index synced with resumption_index
         self.state_data["last_processed_index"] = self.state_data["resumption_index"]
-        
-        log.debug(f"📊 PROGRESS UPDATE: system_progression.current_product_index_in_category={sp['current_product_index_in_category']}, resumption={self.state_data['resumption_index']}, session={self.state_data['session_products_processed']}")
+
+        log.debug(
+            f"📊 PROGRESS UPDATE: system_progression.current_product_index_in_category={sp['current_product_index_in_category']}, resumption={self.state_data['resumption_index']}, session={self.state_data['session_products_processed']}"
+        )
 
     # === NEW PROGRESSION METHODS ===
-    def initialize_category_processing(self, category_index: int, category_url: str, total_categories: int):
+    def initialize_category_processing(
+        self, category_index: int, category_url: str, total_categories: int
+    ):
         """Initialize tracking for a new category"""
         from utils.normalization import normalize_url
+
         normalized_category_url = normalize_url(category_url)
-        
+
         sp = self.state_data.setdefault("system_progression", {})
-        sp.update({
-            "current_phase": "supplier",
-            "current_category_index": category_index,
-            "current_category_url": normalized_category_url,
-            "original_category_url": category_url,  # Keep original for reference
-            "total_categories": total_categories,
-            "current_product_index_in_category": 0,
-            "total_products_in_current_category": 0
-        })
+        sp.update(
+            {
+                "current_phase": "supplier",
+                "current_category_index": category_index,
+                "current_category_url": normalized_category_url,
+                "original_category_url": category_url,  # Keep original for reference
+                "total_categories": total_categories,
+                "current_product_index_in_category": 0,
+                "total_products_in_current_category": 0,
+            }
+        )
         self.save_state_atomic()
 
     def update_supplier_extraction_progress_new(self, product_url: str, increment: int = 1):
         """Update progress during supplier extraction phase"""
         sp = self.state_data.setdefault("system_progression", {})
         sp["current_phase"] = "supplier"
-        sp["supplier_extraction_resumption_index"] = sp.get("supplier_extraction_resumption_index", 0) + increment
-        sp["current_product_index_in_category"] = sp.get("current_product_index_in_category", 0) + increment
+        sp["supplier_extraction_resumption_index"] = (
+            sp.get("supplier_extraction_resumption_index", 0) + increment
+        )
+        sp["current_product_index_in_category"] = (
+            sp.get("current_product_index_in_category", 0) + increment
+        )
 
         ud = self.state_data.setdefault("user_display_metrics", {})
         ud["progress_count"] = ud.get("progress_count", 0) + increment
@@ -585,7 +652,9 @@ class FixedEnhancedStateManager:
         """Update progress during Amazon analysis phase"""
         sp = self.state_data.setdefault("system_progression", {})
         sp["current_phase"] = "amazon_analysis"
-        sp["amazon_analysis_resumption_index"] = sp.get("amazon_analysis_resumption_index", 0) + increment
+        sp["amazon_analysis_resumption_index"] = (
+            sp.get("amazon_analysis_resumption_index", 0) + increment
+        )
 
         ud = self.state_data.setdefault("user_display_metrics", {})
         ud["session_products_processed"] = ud.get("session_products_processed", 0) + increment
@@ -604,7 +673,7 @@ class FixedEnhancedStateManager:
         try:
             # Update timestamp
             self.state_data["last_updated"] = datetime.now(timezone.utc).isoformat()
-            
+
             # 🚨 CRITICAL: Do NOT perform file-grounded recalculation here during processing
             # Only update from file-grounded data if this is not preserving interruption state
             if not preserve_interruption_state and not self._startup_completed:
@@ -612,23 +681,26 @@ class FixedEnhancedStateManager:
                 file_grounded_data = self._calculate_file_grounded_totals()
                 self.state_data["total_products"] = file_grounded_data["total_products"]
                 self.state_data["successful_products"] = file_grounded_data["processed_products"]
-            
+
             # Atomic save using the existing windows save guardian
             try:
                 from utils.windows_save_guardian import WindowsSaveGuardian
+
                 guardian = WindowsSaveGuardian()
                 success = guardian.save_json_atomic(str(self.state_file_path), self.state_data)
-                
+
                 if success:
                     log.debug(f"✅ State saved successfully to {self.state_file_path}")
                 else:
                     log.error(f"❌ Failed to save state to {self.state_file_path}")
-                    
+
             except ImportError:
                 # Atomic fallback: write to temp then replace
                 try:
                     dir_name = os.path.dirname(str(self.state_file_path)) or "."
-                    fd, tmp_path = tempfile.mkstemp(prefix="state_", suffix=".tmp", dir=dir_name, text=True)
+                    fd, tmp_path = tempfile.mkstemp(
+                        prefix="state_", suffix=".tmp", dir=dir_name, text=True
+                    )
                     try:
                         with os.fdopen(fd, "w", encoding="utf-8") as tmp:
                             json.dump(self.state_data, tmp, indent=2, ensure_ascii=False)
@@ -653,52 +725,96 @@ class FixedEnhancedStateManager:
         cpi = sp.get("current_product_index_in_category", 0)
         tpc = sp.get("total_products_in_current_category", 0)
         ccu = sp.get("current_category_url", "")
-        
+
         # Only log breadcrumbs when denominators are non-zero (accurate totals available)
         if tc > 0 and tpc > 0:
-            log.info(
-                f"RESUME PTR: phase={phase} cat_idx={cci}/{tc} url={ccu} prod_idx={cpi}/{tpc}"
-            )
+            log.info(f"RESUME PTR: phase={phase} cat_idx={cci}/{tc} url={ccu} prod_idx={cpi}/{tpc}")
         elif tc > 0:
             # Log with category info only if we have category totals
             log.info(
                 f"RESUME PTR: phase={phase} cat_idx={cci}/{tc} url={ccu} prod_idx={cpi}/pending"
             )
 
-
     def save_state_atomic(self):
         """Atomic save wrapper used by new progression methods"""
         self.save_state(preserve_interruption_state=True)
-    
-    def update_progression_unified(self,
-                                current_category_index=None,
-                                current_product_index_in_category=None,
-                                supplier_resumption_index=None,  # NEW
-                                amazon_resumption_index=None,    # NEW
-                                current_phase=None,
-                                total_products_in_current_category=None,
-                                current_category_url=None,
-                                total_categories=None,
-                                **kwargs):
+
+    @staticmethod
+    def compute_supplier_config_hash(category_urls: List[str]) -> str:
+        joined = "".join(sorted(category_urls or []))
+        return hashlib.sha256(joined.encode("utf-8")).hexdigest()
+
+    def save(self, note: str = "") -> None:
+        """Atomically save state with optional note."""
+        self.save_state(preserve_interruption_state=True)
+        if note:
+            log.info(f"💾 ATOMIC SAVE ({note})")
+        else:
+            log.info("💾 ATOMIC SAVE")
+
+    def save_debounced(self, note: str = "", min_interval: float = 2.0) -> None:
+        now = time.time()
+        if now - getattr(self, "_last_save_time", 0) < min_interval:
+            return
+        self._last_save_time = now
+        self.save(note=note)
+
+    def set_resumption_ptr(self, cat_idx: int, prod_idx: int) -> None:
+        """Set monotonic resumption pointer (category, product)."""
+        sp = self.state_data.setdefault("system_progression", {})
+        prev = sp.get("resumption_ptr", {"cat_idx": 0, "prod_idx": 0})
+        prev_cat = int(prev.get("cat_idx", 0))
+        prev_prod = int(prev.get("prod_idx", 0))
+        inc_cat = int(cat_idx)
+        inc_prod = int(prod_idx)
+        if inc_cat < prev_cat:
+            return
+        if inc_cat == prev_cat:
+            if inc_prod <= prev_prod:
+                return
+            sp["resumption_ptr"] = {"cat_idx": prev_cat, "prod_idx": inc_prod}
+        else:
+            sp["resumption_ptr"] = {"cat_idx": inc_cat, "prod_idx": inc_prod}
+
+    def get_resumption_ptr(self) -> Tuple[int, int]:
+        """Return resumption pointer (category, product)."""
+        sp = self.state_data.get("system_progression", {})
+        ptr = sp.get("resumption_ptr")
+        if isinstance(ptr, dict):
+            return int(ptr.get("cat_idx", 0)), int(ptr.get("prod_idx", 0))
+        return 0, 0
+
+    def update_progression_unified(
+        self,
+        current_category_index=None,
+        current_product_index_in_category=None,
+        supplier_resumption_index=None,  # NEW
+        amazon_resumption_index=None,  # NEW
+        current_phase=None,
+        total_products_in_current_category=None,
+        current_category_url=None,
+        total_categories=None,
+        **kwargs,
+    ):
         """Extended unified progression with dual phase index tracking"""
         sp = self.state_data.setdefault("system_progression", {})
-        
+
         # Update provided fields
         if current_category_index is not None:
             sp["current_category_index"] = current_category_index
-            
+
         if current_product_index_in_category is not None:
             sp["current_product_index_in_category"] = current_product_index_in_category
-            
+
         if total_products_in_current_category is not None:
             sp["total_products_in_current_category"] = total_products_in_current_category
-            
+
         if current_phase is not None:
             old_phase = sp.get("current_phase")
             sp["current_phase"] = current_phase
             if old_phase != current_phase:
                 log.info(f"🔄 PHASE TRANSITION: {old_phase} → {current_phase}")
-        
+
         # 🚨 FIX 3: NEW - Phase-specific resumption indices
         if supplier_resumption_index is not None:
             sp["supplier_resumption_index"] = supplier_resumption_index
@@ -707,75 +823,78 @@ class FixedEnhancedStateManager:
         if amazon_resumption_index is not None:
             sp["amazon_resumption_index"] = amazon_resumption_index
             log.debug(f"📊 AMAZON RESUME INDEX: {amazon_resumption_index}")
-            
+
         if current_category_url is not None:
             # Normalize URL for consistent tracking
             try:
                 from utils.normalization import normalize_url
+
                 sp["current_category_url"] = normalize_url(current_category_url)
                 sp["original_category_url"] = current_category_url
             except ImportError:
                 # Fallback if normalization not available
                 sp["current_category_url"] = current_category_url
-                
+
         if total_categories is not None:
             sp["total_categories"] = total_categories
-            
+
         # Update timestamp
         sp["last_updated"] = datetime.now(timezone.utc).isoformat()
-        
+
         # 🚨 FIX 2: Cross-validate state systems
         drift_magnitude = self._validate_state_synchronization()
-        
+
         # Log the progression update for observability
         cat_idx = sp.get("current_category_index", 0)
         prod_idx = sp.get("current_product_index_in_category", 0)
         total_cats = sp.get("total_categories", 0)
         total_prods = sp.get("total_products_in_current_category", 0)
         phase = sp.get("current_phase", "unknown")
-        
-        log.debug(f"📊 PROGRESSION UPDATE: cat={cat_idx}/{total_cats} prod={prod_idx}/{total_prods} phase={phase}")
-        
+
+        log.debug(
+            f"📊 PROGRESSION UPDATE: cat={cat_idx}/{total_cats} prod={prod_idx}/{total_prods} phase={phase}"
+        )
+
         return drift_magnitude
 
     def _validate_state_synchronization(self):
         """Cross-validate system_progression and supplier_extraction_progress consistency"""
-        
+
         sp = self.state_data.get("system_progression", {})
         legacy = self.state_data.get("supplier_extraction_progress", {})
-        
+
         # Extract comparison values
         sp_category = sp.get("current_category_index", 0)
         legacy_category = legacy.get("current_category_index", 0)
         sp_product = sp.get("current_product_index_in_category", 0)
         legacy_product = legacy.get("current_product_index_in_category", 0)
-        
+
         # Calculate drift magnitude
         category_drift = abs(sp_category - legacy_category)
         product_drift = abs(sp_product - legacy_product)
         total_drift = category_drift + product_drift
-        
+
         # Log significant discrepancies
         if category_drift > 0:
             log.warning(
                 f"⚠️ CATEGORY INDEX DRIFT: SystemProgression={sp_category} "
                 f"Legacy={legacy_category} drift={category_drift}"
             )
-        
+
         if product_drift > 1:  # Allow 1-index tolerance for processing boundaries
             log.warning(
                 f"⚠️ PRODUCT INDEX DRIFT: SystemProgression={sp_product} "
                 f"Legacy={legacy_product} drift={product_drift}"
             )
-        
+
         # Store drift metrics for monitoring
         self.state_data.setdefault("diagnostics", {})["state_drift"] = {
             "category_drift": category_drift,
             "product_drift": product_drift,
             "total_drift": total_drift,
-            "last_checked": datetime.now(timezone.utc).isoformat()
+            "last_checked": datetime.now(timezone.utc).isoformat(),
         }
-        
+
         return total_drift
 
     def validate_loaded_state(self) -> None:
@@ -793,7 +912,9 @@ class FixedEnhancedStateManager:
             ci = 0
         max_cat_index = max(0, total_cats - 1)
         if ci > max_cat_index:
-            log.warning(f"⚠️ State validation: current_category_index {ci} > max_index {max_cat_index}; capping")
+            log.warning(
+                f"⚠️ State validation: current_category_index {ci} > max_index {max_cat_index}; capping"
+            )
             sp["current_category_index"] = max_cat_index
 
         # Clamp product index within category (0..tp-1)
@@ -807,13 +928,20 @@ class FixedEnhancedStateManager:
             pi = 0
         max_prod_index = max(0, tp - 1) if tp > 0 else 0
         if pi > max_prod_index:
-            log.warning(f"⚠️ State validation: product_index {pi} > max_index {max_prod_index}; capping")
+            log.warning(
+                f"⚠️ State validation: product_index {pi} > max_index {max_prod_index}; capping"
+            )
             sp["current_product_index_in_category"] = max_prod_index
 
         # Simple contradiction: fresh-start with non-zero progress
         fs = bool(self.state_data.get("is_fresh_start", False))
-        if fs and ((sp.get("current_category_index", 0) or 0) > 0 or (sp.get("current_product_index_in_category", 0) or 0) > 0):
-            log.warning("⚠️ Contradiction: is_fresh_start=True with non-zero progress; normalizing is_fresh_start=False")
+        if fs and (
+            (sp.get("current_category_index", 0) or 0) > 0
+            or (sp.get("current_product_index_in_category", 0) or 0) > 0
+        ):
+            log.warning(
+                "⚠️ Contradiction: is_fresh_start=True with non-zero progress; normalizing is_fresh_start=False"
+            )
             self.state_data["is_fresh_start"] = False
 
         # Optional phase transition sanity (log-only)
@@ -834,94 +962,105 @@ class FixedEnhancedStateManager:
     def validate_and_repair_state(self) -> Tuple[bool, List[str]]:
         """
         Validate state consistency and repair issues automatically.
-        
+
         Returns:
             Tuple[bool, List[str]]: (is_valid, repairs_made)
         """
         repairs_made = []
         is_valid = True
-        
+
         # Ensure required keys exist
-        required_keys = ["system_progression", "user_display_metrics", "supplier_extraction_progress"]
+        required_keys = [
+            "system_progression",
+            "user_display_metrics",
+            "supplier_extraction_progress",
+        ]
         for key in required_keys:
             if key not in self.state_data:
                 self.state_data[key] = {}
                 repairs_made.append(f"Added missing key: {key}")
                 is_valid = False
-        
+
         # Validate system_progression structure
         sp = self.state_data.setdefault("system_progression", {})
         required_sp_keys = [
-            "current_phase", "current_category_index", "current_category_url",
-            "total_categories", "current_product_index_in_category", 
-            "total_products_in_current_category", "supplier_extraction_resumption_index",
-            "amazon_analysis_resumption_index"
+            "current_phase",
+            "current_category_index",
+            "current_category_url",
+            "total_categories",
+            "current_product_index_in_category",
+            "total_products_in_current_category",
+            "supplier_extraction_resumption_index",
+            "amazon_analysis_resumption_index",
         ]
-        
+
         for key in required_sp_keys:
             if key not in sp:
                 default_value = "" if "url" in key else 0
                 sp[key] = default_value
                 repairs_made.append(f"Added missing system_progression key: {key}")
                 is_valid = False
-        
+
         # Validate bounds and monotonic progression
         total_categories = sp.get("total_categories", 0)
         current_category_index = sp.get("current_category_index", 0)
-        
+
         if current_category_index > total_categories:
             sp["current_category_index"] = max(total_categories - 1, 0)
-            repairs_made.append(f"Fixed category index bounds: {current_category_index} -> {sp['current_category_index']}")
+            repairs_made.append(
+                f"Fixed category index bounds: {current_category_index} -> {sp['current_category_index']}"
+            )
             is_valid = False
-        
+
         total_products_in_category = sp.get("total_products_in_current_category", 0)
         current_product_index = sp.get("current_product_index_in_category", 0)
-        
+
         if current_product_index > total_products_in_category:
             sp["current_product_index_in_category"] = 0
             repairs_made.append(f"Fixed product index bounds: {current_product_index} -> 0")
             is_valid = False
-        
+
         # Ensure resumption indices are monotonic
         supplier_resumption = sp.get("supplier_extraction_resumption_index", 0)
         amazon_resumption = sp.get("amazon_analysis_resumption_index", 0)
-        
+
         if supplier_resumption < 0:
             sp["supplier_extraction_resumption_index"] = 0
             repairs_made.append("Fixed negative supplier resumption index")
             is_valid = False
-            
+
         if amazon_resumption < 0:
             sp["amazon_analysis_resumption_index"] = 0
             repairs_made.append("Fixed negative Amazon resumption index")
             is_valid = False
-        
+
         # Ensure supplier_extraction_progress keys exist
         sep = self.state_data.setdefault("supplier_extraction_progress", {})
         required_sep_keys = [
-            "total_products_in_current_category", "discovered_products_in_current_category",
-            "current_category_url", "current_product_index_in_category"
+            "total_products_in_current_category",
+            "discovered_products_in_current_category",
+            "current_category_url",
+            "current_product_index_in_category",
         ]
-        
+
         for key in required_sep_keys:
             if key not in sep:
                 default_value = "" if "url" in key else 0
                 sep[key] = default_value
                 repairs_made.append(f"Added missing supplier_extraction_progress key: {key}")
                 is_valid = False
-        
+
         # Sync progress counters if they're inconsistent
         if "resumption_index" not in self.state_data:
             self.state_data["resumption_index"] = supplier_resumption
             repairs_made.append("Synced resumption_index with supplier_extraction_resumption_index")
             is_valid = False
-        
+
         # Log repairs if any were made
         if repairs_made:
             log.info(f"State repaired: {'; '.join(repairs_made)}")
-        
-        return is_valid, repairs_made
 
+        return is_valid, repairs_made
 
     def _calculate_file_grounded_totals(self) -> Dict[str, Any]:
         """
@@ -938,68 +1077,92 @@ class FixedEnhancedStateManager:
                 "cache_file_exists": False,
                 "linking_map_exists": False,
                 "total_categories": 0,
-                "current_category_analysis": {}
+                "current_category_analysis": {},
             }
-            
+
             # Calculate project root path relative to current file location
             current_dir = Path(__file__).parent.parent
-            
+
             # Path to product cache file - use hyphenated domain format
-            hyphenated_supplier = self.supplier_name.replace('.', '-')
-            cache_file_path = current_dir / "OUTPUTS" / "cached_products" / f"{hyphenated_supplier}_products_cache.json"
-            
+            hyphenated_supplier = self.supplier_name.replace(".", "-")
+            cache_file_path = (
+                current_dir
+                / "OUTPUTS"
+                / "cached_products"
+                / f"{hyphenated_supplier}_products_cache.json"
+            )
+
             # Path to linking map file - use dotted domain format
-            supplier_domain = self.supplier_name.replace('-', '.')
-            linking_map_path = current_dir / "OUTPUTS" / "FBA_ANALYSIS" / "linking_maps" / supplier_domain / "linking_map.json"
-            
+            supplier_domain = self.supplier_name.replace("-", ".")
+            linking_map_path = (
+                current_dir
+                / "OUTPUTS"
+                / "FBA_ANALYSIS"
+                / "linking_maps"
+                / supplier_domain
+                / "linking_map.json"
+            )
+
             # 🚨 CRITICAL FIX: Exclude metadata entries from product count
             if cache_file_path.exists():
                 file_grounded_data["cache_file_exists"] = True
                 try:
-                    with open(cache_file_path, 'r', encoding='utf-8') as f:
+                    with open(cache_file_path, "r", encoding="utf-8") as f:
                         product_cache = json.load(f)
-                    
+
                     # Filter out metadata entries
-                    actual_products = [p for p in product_cache if isinstance(p, dict) and not p.get('_cache_metadata')]
+                    actual_products = [
+                        p
+                        for p in product_cache
+                        if isinstance(p, dict) and not p.get("_cache_metadata")
+                    ]
                     file_grounded_data["total_products"] = len(actual_products)
-                    
-                    log.info(f"File-grounded calculation: Found {len(actual_products)} actual products in cache (total entries: {len(product_cache)})")
+
+                    log.info(
+                        f"File-grounded calculation: Found {len(actual_products)} actual products in cache (total entries: {len(product_cache)})"
+                    )
                 except Exception as e:
                     log.warning(f"Failed to read product cache: {e}")
-            
+
             # Read linking map to get processed count
             if linking_map_path.exists():
                 file_grounded_data["linking_map_exists"] = True
                 try:
-                    with open(linking_map_path, 'r', encoding='utf-8') as f:
+                    with open(linking_map_path, "r", encoding="utf-8") as f:
                         linking_map = json.load(f)
                     file_grounded_data["linking_map_count"] = len(linking_map)
                     file_grounded_data["processed_products"] = len(linking_map)
-                    log.info(f"File-grounded calculation: Found {len(linking_map)} processed products in linking map")
+                    log.info(
+                        f"File-grounded calculation: Found {len(linking_map)} processed products in linking map"
+                    )
                 except Exception as e:
                     log.warning(f"Failed to read linking map: {e}")
-            
+
             # Calculate category completion from existing files
-            file_grounded_data["category_completion_status"] = self._calculate_startup_category_analysis(
+            file_grounded_data[
+                "category_completion_status"
+            ] = self._calculate_startup_category_analysis(
                 cache_file_path, linking_map_path, current_dir
             )
-            
+
             # Load config to get total categories
             config_path = current_dir / "config" / "poundwholesale_categories.json"
             if config_path.exists():
                 try:
-                    with open(config_path, 'r', encoding='utf-8') as f:
+                    with open(config_path, "r", encoding="utf-8") as f:
                         config_data = json.load(f)
                     if isinstance(config_data, list):
                         file_grounded_data["total_categories"] = len(config_data)
                     elif isinstance(config_data, dict) and "category_urls" in config_data:
                         file_grounded_data["total_categories"] = len(config_data["category_urls"])
-                    log.info(f"File-grounded calculation: Found {file_grounded_data['total_categories']} categories in config")
+                    log.info(
+                        f"File-grounded calculation: Found {file_grounded_data['total_categories']} categories in config"
+                    )
                 except Exception as e:
                     log.warning(f"Failed to read config file: {e}")
-            
+
             return file_grounded_data
-            
+
         except Exception as e:
             log.error(f"Failed to calculate file-grounded totals: {e}")
             return {
@@ -1010,68 +1173,81 @@ class FixedEnhancedStateManager:
                 "cache_file_exists": False,
                 "linking_map_exists": False,
                 "total_categories": 0,
-                "current_category_analysis": {}
+                "current_category_analysis": {},
             }
-    
-    def _calculate_startup_category_analysis(self, cache_file_path: Path, linking_map_path: Path, current_dir: Path) -> Dict[str, Any]:
+
+    def _calculate_startup_category_analysis(
+        self, cache_file_path: Path, linking_map_path: Path, current_dir: Path
+    ) -> Dict[str, Any]:
         """
         Calculate category completion status from existing cache and linking map files
         """
         try:
             category_completion = {}
-            
+
             # Load cache data
             cache_data = []
             if cache_file_path.exists():
-                with open(cache_file_path, 'r', encoding='utf-8') as f:
+                with open(cache_file_path, "r", encoding="utf-8") as f:
                     cache_data = json.load(f)
-                    
-            # Load linking map data  
+
+            # Load linking map data
             linking_data = []
             if linking_map_path.exists():
-                with open(linking_map_path, 'r', encoding='utf-8') as f:
+                with open(linking_map_path, "r", encoding="utf-8") as f:
                     linking_data = json.load(f)
-                    
+
             # Build category extraction status from cache
             extracted_categories = defaultdict(list)
             for product in cache_data:
-                if isinstance(product, dict) and 'source_url' in product and 'url' in product and not product.get('_cache_metadata'):
-                    extracted_categories[product['source_url']].append(product['url'])
-                    
+                if (
+                    isinstance(product, dict)
+                    and "source_url" in product
+                    and "url" in product
+                    and not product.get("_cache_metadata")
+                ):
+                    extracted_categories[product["source_url"]].append(product["url"])
+
             # Build processed product mapping from linking map
             processed_products = set()
             for entry in linking_data:
-                if isinstance(entry, dict) and 'supplier_url' in entry:
-                    processed_products.add(entry['supplier_url'])
-                    
+                if isinstance(entry, dict) and "supplier_url" in entry:
+                    processed_products.add(entry["supplier_url"])
+
             # Calculate category completion status
             for category_url, product_urls in extracted_categories.items():
                 extracted_count = len(product_urls)
                 processed_count = len([url for url in product_urls if url in processed_products])
-                completion_pct = (processed_count / extracted_count * 100) if extracted_count > 0 else 0
-                
+                completion_pct = (
+                    (processed_count / extracted_count * 100) if extracted_count > 0 else 0
+                )
+
                 if processed_count >= extracted_count:
                     status = "FULLY_PROCESSED"
                 elif processed_count > 0:
                     status = "PARTIALLY_PROCESSED"
                 else:
                     status = "EXTRACTED_ONLY"
-                
+
                 category_completion[category_url] = {
                     "extracted": extracted_count,
                     "processed": processed_count,
                     "completion_pct": completion_pct,
-                    "status": status
+                    "status": status,
                 }
-            
-            log.info(f"Startup category analysis: Calculated completion for {len(category_completion)} categories")
+
+            log.info(
+                f"Startup category analysis: Calculated completion for {len(category_completion)} categories"
+            )
             return category_completion
-            
+
         except Exception as e:
             log.warning(f"Failed to calculate startup category analysis: {e}")
             return {}
-    
-    def _calculate_current_category_metrics(self, file_grounded_data: Dict[str, Any]) -> Dict[str, Any]:
+
+    def _calculate_current_category_metrics(
+        self, file_grounded_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """
         🚨 CRITICAL FIX 7: Calculate current category metrics with correct indexing
         Returns metrics for supplier_extraction_progress with proper category index calculation
@@ -1079,20 +1255,20 @@ class FixedEnhancedStateManager:
         try:
             category_completion = file_grounded_data.get("category_completion_status", {})
             total_categories = file_grounded_data.get("total_categories", 0)
-            
+
             # Find the current category that needs processing
             current_category_url = ""
             current_category_index = 0
-            
+
             # 🚨 CRITICAL FIX: Load config file to get proper category order and index
             current_dir = Path(__file__).parent.parent
             config_path = current_dir / "config" / "poundwholesale_categories.json"
-            
+
             if config_path.exists():
                 try:
-                    with open(config_path, 'r', encoding='utf-8') as f:
+                    with open(config_path, "r", encoding="utf-8") as f:
                         config_data = json.load(f)
-                    
+
                     # Get category URLs in config order
                     if isinstance(config_data, list):
                         config_urls = config_data
@@ -1100,41 +1276,48 @@ class FixedEnhancedStateManager:
                         config_urls = config_data["category_urls"]
                     else:
                         config_urls = []
-                    
+
                     # Find current category based on config order and processing status
                     priority_order = ["EXTRACTED_ONLY", "PARTIALLY_PROCESSED", "FULLY_PROCESSED"]
-                    
+
                     for status in priority_order:
                         for i, config_url in enumerate(config_urls):
-                            if config_url in category_completion and category_completion[config_url].get('status') == status:
+                            if (
+                                config_url in category_completion
+                                and category_completion[config_url].get("status") == status
+                            ):
                                 current_category_url = config_url
-                                current_category_index = i  # 🚨 FIXED: Use actual index from config file
+                                current_category_index = (
+                                    i  # 🚨 FIXED: Use actual index from config file
+                                )
                                 break
                         if current_category_url:
                             break
-                            
+
                 except Exception as e:
                     log.warning(f"Failed to read config for category indexing: {e}")
-            
+
             # Calculate current category metrics
             current_category_info = category_completion.get(current_category_url, {})
-            total_products_in_current_category = current_category_info.get('extracted', 0)
-            current_product_index_in_category = current_category_info.get('processed', 0)
-            
+            total_products_in_current_category = current_category_info.get("extracted", 0)
+            current_product_index_in_category = current_category_info.get("processed", 0)
+
             # Count completed categories
             completed_categories = []
             for url, info in category_completion.items():
-                if info.get('status') == 'FULLY_PROCESSED':
+                if info.get("status") == "FULLY_PROCESSED":
                     completed_categories.append(url)
-            
+
             # Determine extraction phase based on state
-            if file_grounded_data.get("linking_map_count", 0) > file_grounded_data.get("total_products", 0):
+            if file_grounded_data.get("linking_map_count", 0) > file_grounded_data.get(
+                "total_products", 0
+            ):
                 extraction_phase = "fresh_categories"
             elif current_product_index_in_category < total_products_in_current_category:
                 extraction_phase = "amazon_analysis"
             else:
                 extraction_phase = "products"
-                
+
             return {
                 "current_category_url": current_category_url,
                 "current_category_index": current_category_index,  # 🚨 FIXED: Correct index from config
@@ -1144,88 +1327,100 @@ class FixedEnhancedStateManager:
                 "extraction_phase": extraction_phase,
                 "last_completed_category": completed_categories[-1] if completed_categories else "",
                 "categories_completed": completed_categories,
-                "last_updated": datetime.now(timezone.utc).isoformat()
+                "last_updated": datetime.now(timezone.utc).isoformat(),
             }
-            
+
         except Exception as e:
             log.error(f"Failed to calculate current category metrics: {e}")
             return {}
-    
+
     def mark_category_completed(self, category_url: str):
         """Mark a category as completed - resumption_index now updates continuously"""
         # Update category completion status
-        if "gap_processing" in self.state_data and "category_completion_status" in self.state_data["gap_processing"]:
+        if (
+            "gap_processing" in self.state_data
+            and "category_completion_status" in self.state_data["gap_processing"]
+        ):
             if category_url in self.state_data["gap_processing"]["category_completion_status"]:
-                self.state_data["gap_processing"]["category_completion_status"][category_url]["status"] = "FULLY_PROCESSED"
-                self.state_data["gap_processing"]["category_completion_status"][category_url]["completion_pct"] = 100.0
-        
+                self.state_data["gap_processing"]["category_completion_status"][category_url][
+                    "status"
+                ] = "FULLY_PROCESSED"
+                self.state_data["gap_processing"]["category_completion_status"][category_url][
+                    "completion_pct"
+                ] = 100.0
+
         # Add to completed categories
-        if category_url not in self.state_data["supplier_extraction_progress"]["categories_completed"]:
-            self.state_data["supplier_extraction_progress"]["categories_completed"].append(category_url)
-        
+        if (
+            category_url
+            not in self.state_data["supplier_extraction_progress"]["categories_completed"]
+        ):
+            self.state_data["supplier_extraction_progress"]["categories_completed"].append(
+                category_url
+            )
+
         # Update last completed category
         self.state_data["supplier_extraction_progress"]["last_completed_category"] = category_url
-        
+
         # Note: resumption_index now updates continuously via update_processing_progress()
         # No need to update it here as it's always current
-        
+
         log.info(f"✅ Category marked as completed: {category_url[:50]}...")
-    
+
     def get_resumption_index(self) -> int:
         """Get the index from which to resume processing"""
         return self.state_data.get("resumption_index", 0)
-    
+
     def get_current_progress(self) -> Dict[str, int]:
         """Get current session progress"""
         return {
             "resumption_index": self.state_data.get("resumption_index", 0),
             "progress_index": self.state_data.get("progress_index", 0),
             "session_products_processed": self.state_data.get("session_products_processed", 0),
-            "last_processed_index": self.state_data.get("last_processed_index", 0)
+            "last_processed_index": self.state_data.get("last_processed_index", 0),
         }
-    
+
     # === WORKFLOW COMPATIBILITY METHODS ===
     # These methods provide compatibility with the existing workflow
-    
+
     def update_processing_index(self, current_index: int, total_products: int):
         """Update processing index (compatibility method)"""
         self.state_data["last_processed_index"] = current_index
         self.state_data["progress_index"] = current_index
         self.state_data["total_products"] = total_products
-        
+
     def start_processing(self, config_hash: str, runtime_settings: Dict[str, Any]):
         """Start processing session"""
         self.state_data["config_hash"] = config_hash
         self.state_data["runtime_settings"] = runtime_settings
         self.state_data["processing_status"] = "active"
         self.state_data["session_start_time"] = datetime.now(timezone.utc).isoformat()
-        
+
     def complete_processing(self):
         """Mark processing as complete"""
         self.state_data["processing_status"] = "completed"
         self.state_data["session_end_time"] = datetime.now(timezone.utc).isoformat()
         self.save_state()
-        
+
     def is_product_processed(self, product_url: str) -> bool:
         """
         🚨 DEPRECATED: This method should not be used - linking map is the source of truth
         Hash lookup should check linking map directly, not processing state
-        
+
         Returns False to ensure products flow through correct filtering workflow
         """
         # 🚨 Always return False - linking map filtering is the correct approach
         return False
-        
+
     def mark_product_processed(self, product_url: str, status: str):
         """
         🚨 DEPRECATED: This method should not be used - linking map entries are the completion signal
         Processing completion is tracked via linking map entries, not processing state
-        
+
         This method is now a no-op to prevent incorrect state tracking
         """
         # 🚨 No-op: completion tracking happens in linking map, not processing state
         pass
-        
+
     def get_state_summary(self) -> Dict[str, Any]:
         """Get summary of current state"""
         return {
@@ -1235,110 +1430,87 @@ class FixedEnhancedStateManager:
             "progress_index": self.state_data.get("progress_index", 0),
             "session_products_processed": self.state_data.get("session_products_processed", 0),
             # 🚨 REMOVED: processed_products count - linking map is source of truth
-            "last_update": self.state_data.get("last_update")
+            "last_update": self.state_data.get("last_update"),
         }
-        
-    def start_gap_processing(self, gap_size: int, linking_map_count: int, supplier_cache_count: int):
+
+    def start_gap_processing(
+        self, gap_size: int, linking_map_count: int, supplier_cache_count: int
+    ):
         """Start gap processing session"""
         self.state_data["gap_processing"] = {
             "status": "active",
             "gap_size": gap_size,
             "linking_map_count": linking_map_count,
             "supplier_cache_count": supplier_cache_count,
-            "start_time": datetime.now(timezone.utc).isoformat()
+            "start_time": datetime.now(timezone.utc).isoformat(),
         }
-        
+
     def complete_gap_processing(self):
         """Complete gap processing session"""
         if "gap_processing" in self.state_data:
             self.state_data["gap_processing"]["status"] = "completed"
             self.state_data["gap_processing"]["end_time"] = datetime.now(timezone.utc).isoformat()
-            
+
     def update_gap_processing_progress(self, processed_count: int, total_gap: int):
         """Update gap processing progress"""
         if "gap_processing" not in self.state_data:
             self.state_data["gap_processing"] = {}
-        
+
         self.state_data["gap_processing"]["processed_count"] = processed_count
         self.state_data["gap_processing"]["total_gap"] = total_gap
         self.state_data["gap_processing"]["last_update"] = datetime.now(timezone.utc).isoformat()
-        
-    def update_supplier_extraction_progress(self, category_index: int, total_categories: int,
-                                            subcategory_index: int = None, total_subcategories: int = None,
-                                            batch_number: int = None, total_batches: int = None,
-                                            category_url: str = None, extraction_phase: str = None):
-        """Normalizing shim: accept legacy progress writes but persist only into system_progression.
 
-        - Clamps indices to sane ranges
-        - Enforces frozen denominator precedence (runtime_settings → system_progression → incoming)
-        - Normalizes phase labels (fresh_categories → supplier)
-        - Leaves supplier_extraction_progress structure as a read-only view (no index mutation)
-        """
-        # Ensure system_progression exists
+    def update_supplier_extraction_progress(
+        self,
+        category_index: int,
+        total_categories: int,
+        subcategory_index: int = None,
+        total_subcategories: int = None,
+        batch_number: int = None,
+        total_batches: int = None,
+        category_url: str = None,
+        extraction_phase: str = None,
+    ):
+        """Update only system_progression; legacy view remains read-only."""
         sp = self.state_data.setdefault("system_progression", {})
-
-        # Clamp category index
-        try:
-            if category_index is not None:
+        if category_index is not None:
+            try:
                 sp["current_category_index"] = max(0, int(category_index))
-        except Exception:
-            sp["current_category_index"] = sp.get("current_category_index", 0)
-
-        # Determine frozen total categories with precedence
-        frozen_total = (
-            self.state_data.get("runtime_settings", {}).get("total_categories")
-            or sp.get("total_categories")
-            or total_categories
-        )
-        try:
-            sp["total_categories"] = max(1, int(frozen_total)) if frozen_total is not None else max(1, int(sp.get("total_categories", 1)))
-        except Exception:
-            sp["total_categories"] = max(1, int(sp.get("total_categories", 1)))
-
-        # Normalize phase
+            except Exception:
+                sp["current_category_index"] = 0
         if extraction_phase is not None:
-            phase_map = {"fresh_categories": "supplier", "amazon_analysis": "amazon_analysis", "completed": "completed"}
+            phase_map = {
+                "fresh_categories": "supplier",
+                "amazon_analysis": "amazon_analysis",
+                "completed": "completed",
+            }
             sp["current_phase"] = phase_map.get(str(extraction_phase), str(extraction_phase))
-
-        # URL passthrough
         if category_url is not None:
             try:
                 from utils.normalization import normalize_url
+
                 sp["current_category_url"] = normalize_url(category_url)
                 sp["original_category_url"] = category_url
             except Exception:
                 sp["current_category_url"] = category_url
+        if total_categories is not None:
+            try:
+                sp["total_categories"] = max(1, int(total_categories))
+            except Exception:
+                sp["total_categories"] = max(1, sp.get("total_categories", 1))
 
-        # Preserve a minimal legacy view without mutating indices (read-only compatibility)
-        legacy = self.state_data.setdefault("supplier_extraction_progress", {})
-        legacy.setdefault("last_update", datetime.now(timezone.utc).isoformat())
-        if category_url is not None:
-            legacy["current_category_url"] = category_url
-        if batch_number is not None:
-            legacy["current_batch_number"] = batch_number
-        if total_batches is not None:
-            legacy["total_batches"] = total_batches
-        if subcategory_index is not None:
-            legacy["current_subcategory_index"] = subcategory_index
-        if total_subcategories is not None:
-            legacy["pages_scraped_in_session"] = total_subcategories
-
-        # Atomic save
-        self.save_state()
-        
     def update_success_metrics(self, amazon_success: bool, profitable: bool, profit: float = 0):
         """Update success metrics"""
-        metrics = self.state_data.get("success_metrics", {
-            "amazon_extractions": 0,
-            "profitable_products": 0,
-            "total_profit": 0
-        })
-        
+        metrics = self.state_data.get(
+            "success_metrics",
+            {"amazon_extractions": 0, "profitable_products": 0, "total_profit": 0},
+        )
+
         if amazon_success:
             metrics["amazon_extractions"] += 1
-            
+
         if profitable:
             metrics["profitable_products"] += 1
             metrics["total_profit"] += profit
-            
+
         self.state_data["success_metrics"] = metrics


### PR DESCRIPTION
## Summary
- freeze supplier category totals at startup and log hash
- add monotonic per-category resumption pointer with debounced saving
- hook supplier scraper progress into state manager saves

## Testing
- `python -m pytest tests/test_state_manager_resume_ptr.py -q`
- `ruff check tools/configurable_supplier_scraper.py tools/passive_extraction_workflow_latest.py utils/fixed_enhanced_state_manager.py tests/test_state_manager_resume_ptr.py`
- `black tools/configurable_supplier_scraper.py tools/passive_extraction_workflow_latest.py utils/fixed_enhanced_state_manager.py tests/test_state_manager_resume_ptr.py`
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'langraph_integration')*

------
https://chatgpt.com/codex/tasks/task_e_68ba2053ddc08332ada86a85877e384e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Real-time updates to category totals and completion percentages.
  - Debounced, observable saves to reduce unnecessary writes.
  - Unified progression updates with drift diagnostics.
  - Enhanced success metrics tracking and gap-processing initiation.

- Bug Fixes
  - More accurate product counts by excluding non-product entries.
  - Consistent behavior regardless of category ordering.
  - Preserves verified completion data during gap handling.

- Refactor
  - More reliable resume behavior and clearer startup decisions.
  - Improved logging for better observability and recovery.

- Tests
  - Added tests for resume pointer stability and configuration hash consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->