### PR TITLE
Improve resume tracking and category gating

### DIFF
--- a/tools/passive_extraction_workflow_latest.py
+++ b/tools/passive_extraction_workflow_latest.py
@@ -69,6 +69,7 @@ import logging
 import os
 import re
 import shutil
+import hashlib
 
 # Import Windows Save Guardian for atomic persistence
 import sys
@@ -1504,6 +1505,29 @@ class PassiveExtractionWorkflow:
         self.log.info(f"✅ Output directory set to: {self.output_dir}")
 
         self._validate_initialization()
+
+    def _authoritative_total_categories(self) -> int:
+        """Return the best-known total category count for resume bookkeeping."""
+        try:
+            supplier_configs = self.full_config.get("supplier_configs", {})
+            supplier_block = supplier_configs.get(self.supplier_name, {})
+            urls = supplier_block.get("category_urls")
+            if isinstance(urls, list) and urls:
+                return len(urls)
+        except Exception as exc:
+            self.log.debug(
+                "Unable to determine category count from supplier config: %s", exc
+            )
+
+        workflow_urls = self.workflow_config.get("category_urls")
+        if isinstance(workflow_urls, list) and workflow_urls:
+            return len(workflow_urls)
+
+        full_urls = self.full_config.get("category_urls")
+        if isinstance(full_urls, list) and full_urls:
+            return len(full_urls)
+
+        return 0
 
     def _add_linking_map_entry_optimized(self, entry: Dict[str, Any]) -> None:
         """
@@ -4747,8 +4771,14 @@ Return ONLY valid JSON, no additional text."""
 
                 # Setup progress callback for individual product tracking
                 if hasattr(self.supplier_scraper, "set_progress_callback"):
+                    absolute_category_index = category_index - 1
                     self.supplier_scraper.set_progress_callback(
-                        self._create_product_progress_callback(category_url, progress_config)
+                        self._create_product_progress_callback(
+                            category_url,
+                            progress_config,
+                            absolute_category_index,
+                            len(category_urls),
+                        )
                     )
                 # Check if we've reached the overall product limit
                 if max_products_to_process and len(all_products) >= max_products_to_process:
@@ -4880,7 +4910,13 @@ Return ONLY valid JSON, no additional text."""
 
         return unprocessed_products
 
-    def _create_product_progress_callback(self, category_url: str, progress_config: Dict[str, Any]):
+    def _create_product_progress_callback(
+        self,
+        category_url: str,
+        progress_config: Dict[str, Any],
+        absolute_category_index: int,
+        total_categories: int,
+    ):
         """Create a progress callback for individual product extraction with proper caching"""
         # Initialize a simple counter if it doesn't exist
         if not hasattr(self, "_supplier_product_counter"):
@@ -4904,15 +4940,22 @@ Return ONLY valid JSON, no additional text."""
 
                 if hasattr(self, "state_manager") and self.state_manager:
                     try:
-                        # Update the main processing index during supplier extraction based on actual cache length
                         actual_cache_count = len(getattr(self, "_current_all_products", []))
-                        self.state_manager.update_processing_index(
-                            actual_cache_count, total_products
+                        safe_total = total_products or actual_cache_count
+                        safe_total = max(safe_total, 0)
+                        safe_index = max(product_index, 0)
+                        if safe_total:
+                            safe_index = min(safe_index, max(safe_total - 1, 0))
+
+                        self.state_manager.commit_supplier_progress(
+                            cat_idx=absolute_category_index,
+                            prod_idx=safe_index,
+                            total_cats=total_categories,
+                            cat_url=category_url,
+                            total_prod_in_cat=safe_total,
                         )
-                        if product_url:
-                            self.state_manager.update_supplier_extraction_progress_new(product_url)
                         self.log.info(
-                            f"🔍 SUPPLIER STATE UPDATE: Index updated to {actual_cache_count}/{total_products}"
+                            f"🔍 SUPPLIER STATE UPDATE: cat={absolute_category_index} prod_idx={safe_index}/{safe_total}"
                         )
                     except Exception as e:
                         self.log.error(f"❌ SUPPLIER STATE UPDATE FAILED: {e}")
@@ -5581,11 +5624,102 @@ Return ONLY valid JSON, no additional text."""
                             f"needs_full={len(filtered['needs_full_extraction'])}"
                         )
 
-                        # Build category-local processing queue
+                        state_mgr = getattr(self, "state_manager", None)
+                        absolute_cat_index = chunk_start + idx_offset
+                        needs_full = list(filtered.get("needs_full_extraction", []))
+                        needs_amazon = list(filtered.get("needs_amazon_only", []))
+                        manifest_urls = needs_full + needs_amazon
+                        discovered_count = len(manifest_urls)
+                        freeze_metadata: Dict[str, Any] = {}
+                        if manifest_urls:
+                            freeze_metadata["manifest_hash"] = hashlib.sha256(
+                                "|".join(sorted(manifest_urls)).encode("utf-8")
+                            ).hexdigest()
+
+                        if state_mgr and discovered_count:
+                            try:
+                                if not state_mgr.is_category_denominator_frozen(category_url):
+                                    state_mgr.set_frozen_denominator(
+                                        category_url, discovered_count, freeze_metadata
+                                    )
+                                    self.log.info(
+                                        f"🔒 SINGLE_POINT_FREEZE: {category_url} → {discovered_count} products"
+                                    )
+                                else:
+                                    frozen_total = state_mgr.get_frozen_denominator(category_url)
+                                    if frozen_total is not None:
+                                        discovered_count = frozen_total
+                                        self.log.info(
+                                            f"🔒 B.3_USING EXISTING FROZEN DENOMINATOR: {category_url} → {discovered_count} products"
+                                        )
+                            except Exception as freeze_error:
+                                self.log.warning(
+                                    f"⚠️ Unable to freeze denominator for {category_url}: {freeze_error}"
+                                )
+
+                        resume_ptr = None
+                        if state_mgr and hasattr(state_mgr, "get_resumption_ptr"):
+                            try:
+                                resume_ptr = state_mgr.get_resumption_ptr()
+                            except Exception as resume_error:
+                                self.log.warning(
+                                    f"⚠️ Unable to obtain resumption pointer: {resume_error}"
+                                )
+                        cat_ptr = resume_ptr.cat_idx if resume_ptr else 0
+                        prod_ptr = (
+                            resume_ptr.prod_idx
+                            if resume_ptr and resume_ptr.phase == "supplier"
+                            else 0
+                        )
+
+                        if resume_ptr and absolute_cat_index < cat_ptr:
+                            self.log.info(
+                                f"📋 Resume skip: category {absolute_cat_index} < {cat_ptr} (already processed)"
+                            )
+                            if state_mgr and hasattr(state_mgr, "mark_category_completed"):
+                                state_mgr.mark_category_completed(absolute_cat_index, category_url)
+                            continue
+
+                        if discovered_count == 0:
+                            self.log.info(
+                                f"📋 Resume skip: category {absolute_cat_index} has no actionable products"
+                            )
+                            if state_mgr and hasattr(state_mgr, "mark_category_completed"):
+                                state_mgr.mark_category_completed(absolute_cat_index, category_url)
+                            continue
+
+                        effective_full = needs_full
+                        effective_amazon = needs_amazon
+                        if resume_ptr and absolute_cat_index == cat_ptr and resume_ptr.phase == "supplier":
+                            prod_ptr = max(prod_ptr, 0)
+                            if prod_ptr >= len(needs_full) and prod_ptr >= len(needs_amazon):
+                                self.log.info(
+                                    f"📋 Resume skip: category {absolute_cat_index} == {cat_ptr} but queues empty after slice from {prod_ptr}"
+                                )
+                                if state_mgr and hasattr(state_mgr, "mark_category_completed"):
+                                    state_mgr.mark_category_completed(absolute_cat_index, category_url)
+                                continue
+                            effective_full = (
+                                needs_full[prod_ptr:] if prod_ptr < len(needs_full) else []
+                            )
+                            effective_amazon = (
+                                needs_amazon[prod_ptr:] if prod_ptr < len(needs_amazon) else []
+                            )
+                            self.log.info(
+                                f"📋 RESUME CATEGORY: category {absolute_cat_index} at resume point, full={len(effective_full)}, amazon={len(effective_amazon)}"
+                            )
+
+                        if not effective_full and not effective_amazon:
+                            self.log.info(
+                                f"📋 Resume skip: category {absolute_cat_index} has no work after filtering"
+                            )
+                            if state_mgr and hasattr(state_mgr, "mark_category_completed"):
+                                state_mgr.mark_category_completed(absolute_cat_index, category_url)
+                            continue
+
                         category_analysis_products: List[Dict[str, Any]] = []
 
-                        # Supplier phase: process needs_full_extraction URLs within this category
-                        for url in filtered["needs_full_extraction"]:
+                        for url in effective_full:
                             prod = next(
                                 (p for p in chunk_products if normalize_url(p.get("url")) == url),
                                 None,
@@ -5593,8 +5727,7 @@ Return ONLY valid JSON, no additional text."""
                             if prod:
                                 category_analysis_products.append(prod)
 
-                        # Amazon phase: process category-local to_amazon queue (needs_amazon_only + newly extracted)
-                        for url in filtered["needs_amazon_only"]:
+                        for url in effective_amazon:
                             prod = next(
                                 (p for p in cached_products if normalize_url(p.get("url")) == url),
                                 None,
@@ -5602,22 +5735,26 @@ Return ONLY valid JSON, no additional text."""
                             if prod:
                                 category_analysis_products.append(prod)
 
-                        # Process this category's products immediately (supplier → Amazon → complete)
                         if category_analysis_products:
                             self.log.info(
                                 f"🔄 Processing category {category_index}: {len(category_analysis_products)} products"
                             )
                             category_results = await self._process_chunk_with_main_workflow_logic(
-                                category_analysis_products, max_products_per_cycle
+                                category_analysis_products,
+                                max_products_per_cycle,
+                                category_index=absolute_cat_index,
+                                category_url=category_url,
                             )
                             profitable_results.extend(category_results)
-
-                            # Log category completion
+                            if state_mgr and hasattr(state_mgr, "mark_category_completed"):
+                                state_mgr.mark_category_completed(absolute_cat_index, category_url)
                             self.log.info(
                                 f"✅ Category {category_index} complete: {len(category_results)} profitable products found"
                             )
                         else:
                             self.log.info("Amazon skipped: nothing to analyze for category")
+                            if state_mgr and hasattr(state_mgr, "mark_category_completed"):
+                                state_mgr.mark_category_completed(absolute_cat_index, category_url)
 
                     # 🚨 CRITICAL FIX: Financial Report Triggering Mechanism - Monitor linking map count as TRIGGER
                     financial_batch_size = self.config_loader.get_financial_batch_size()
@@ -8686,7 +8823,11 @@ Return ONLY valid JSON, no additional text."""
     # Removed duplicate _load_linking_map method - using the one at line 1354
 
     async def _process_chunk_with_main_workflow_logic(
-        self, products: List[Dict[str, Any]], max_products_per_cycle: int
+        self,
+        products: List[Dict[str, Any]],
+        max_products_per_cycle: int,
+        category_index: Optional[int] = None,
+        category_url: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Process products using the same detailed logic as main workflow (not simplified batch processing)"""
         profitable_results = []
@@ -8705,13 +8846,17 @@ Return ONLY valid JSON, no additional text."""
             p for p in valid_products if MIN_PRICE <= p.get("price", 0) <= MAX_PRICE
         ]
 
+        total_to_process = len(price_filtered_products)
+
         self.log.info(
-            f"🔍 Processing {len(price_filtered_products)} products with main workflow logic"
+            f"🔍 Processing {total_to_process} products with main workflow logic"
         )
 
         # Use the same logic as the main workflow
         batch_size = max_products_per_cycle
-        total_batches = (len(price_filtered_products) + batch_size - 1) // batch_size
+        total_batches = (total_to_process + batch_size - 1) // batch_size
+
+        authoritative_total_cats = self._authoritative_total_categories()
 
         for batch_num in range(total_batches):
             start_idx = batch_num * batch_size
@@ -8722,8 +8867,27 @@ Return ONLY valid JSON, no additional text."""
             for i, product_data in enumerate(batch_products):
                 current_index = start_idx + i + 1
                 self.log.info(
-                    f"--- Processing supplier product {current_index}/{len(price_filtered_products)}: '{product_data.get('title')}' ---"
+                    f"--- Processing supplier product {current_index}/{total_to_process}: '{product_data.get('title')}' ---"
                 )
+
+                if (
+                    category_index is not None
+                    and hasattr(self, "state_manager")
+                    and self.state_manager
+                ):
+                    try:
+                        safe_queue_idx = max(current_index - 1, 0)
+                        self.state_manager.commit_amazon_progress(
+                            cat_idx=category_index,
+                            queue_idx=safe_queue_idx,
+                            total_cats=authoritative_total_cats,
+                            cat_url=category_url or product_data.get("source_url", ""),
+                            queue_len=total_to_process,
+                        )
+                    except Exception as commit_err:
+                        self.log.warning(
+                            f"⚠️ AMAZON PROGRESS COMMIT FAILED: {commit_err}"
+                        )
 
                 # 🚨 SURGICAL FIX: Update state manager with product index tracking (gap processing)
                 if hasattr(self, "state_manager") and self.state_manager:

--- a/utils/fixed_enhanced_state_manager.py
+++ b/utils/fixed_enhanced_state_manager.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -44,6 +45,15 @@ except ImportError:
         from utils.path_manager import get_processing_state_path, path_manager
 
 log = logging.getLogger(__name__)
+
+
+@dataclass
+class ResumptionPointer:
+    """Lightweight representation of where category resume should start."""
+
+    phase: str = "supplier"
+    cat_idx: int = 0
+    prod_idx: int = 0
 
 
 class FixedEnhancedStateManager:
@@ -80,6 +90,7 @@ class FixedEnhancedStateManager:
             "created_at": datetime.now(timezone.utc).isoformat(),
             "last_updated": datetime.now(timezone.utc).isoformat(),
             "supplier_name": self.supplier_name,
+            "is_fresh_start": True,
             # 🚨 CRITICAL FIX 1: Separate resumption from progress tracking
             "last_processed_index": 0,  # Legacy field for backward compatibility
             "resumption_index": 0,  # Where to resume after interruption
@@ -92,6 +103,7 @@ class FixedEnhancedStateManager:
             "successful_products": 0,
             "profitable_products": 0,
             "total_profit_found": 0.0,
+            "completed_categories": [],
             "processing_statistics": {
                 "start_time": None,
                 "end_time": None,
@@ -107,6 +119,7 @@ class FixedEnhancedStateManager:
                 "fix_applied": "processing_state_comprehensive_fix_20250730",
             },
             "processed_products": {},  # URL -> status mapping
+            "frozen_category_denominators": {},
             # 🚨 CRITICAL FIX 2: Fixed supplier extraction progress structure
             "supplier_extraction_progress": {
                 "current_category_index": 0,
@@ -136,6 +149,7 @@ class FixedEnhancedStateManager:
                 "category_completion_status": {},
                 "reverse_gap_detected": False,  # 🚨 NEW: Track reverse gap state
                 "startup_analysis_completed": False,  # 🚨 NEW: Track startup completion
+                "categories_completed": 0,
             },
             # ✅ NEW: Separated progression metrics for precise resumption
             "system_progression": {
@@ -147,6 +161,11 @@ class FixedEnhancedStateManager:
                 "total_products_in_current_category": 0,
                 "supplier_extraction_resumption_index": 0,
                 "amazon_analysis_resumption_index": 0,
+                "resumption_ptr": {
+                    "phase": "supplier",
+                    "cat_idx": 0,
+                    "prod_idx": 0,
+                },
             },
             # ✅ NEW: User-facing metrics (not used for resumption logic)
             "user_display_metrics": {
@@ -229,6 +248,22 @@ class FixedEnhancedStateManager:
             self.state_data["progress_index"] = 0
         if "session_products_processed" not in self.state_data:
             self.state_data["session_products_processed"] = 0
+        self.state_data.setdefault("is_fresh_start", True)
+        self.state_data.setdefault("completed_categories", [])
+        self.state_data.setdefault("frozen_category_denominators", {})
+
+        sp = self.state_data.setdefault("system_progression", {})
+        sp.setdefault(
+            "resumption_ptr",
+            {
+                "phase": sp.get("current_phase", "supplier"),
+                "cat_idx": sp.get("current_category_index", 0),
+                "prod_idx": sp.get("current_product_index_in_category", 0),
+            },
+        )
+
+        gp = self.state_data.setdefault("gap_processing", {})
+        gp.setdefault("categories_completed", len(self.state_data.get("completed_categories", [])))
 
     def perform_startup_analysis(self) -> Dict[str, Any]:
         """
@@ -243,6 +278,30 @@ class FixedEnhancedStateManager:
 
         # Calculate file-grounded totals
         file_grounded_data = self._calculate_file_grounded_totals()
+
+        # Determine whether this is a fresh run by inspecting existing artifacts
+        total_processed = file_grounded_data.get("processed_products") or 0
+        if total_processed == 0:
+            total_processed = max(total_processed, self._calculate_total_processed())
+
+        completed_from_file = [
+            url
+            for url, info in file_grounded_data.get("category_completion_status", {}).items()
+            if info.get("status") == "FULLY_PROCESSED"
+        ]
+
+        existing_completed = self.state_data.get("completed_categories", [])
+        if completed_from_file:
+            merged = list(dict.fromkeys(existing_completed + completed_from_file))
+        else:
+            merged = existing_completed
+        self.state_data["completed_categories"] = merged
+        self.state_data.setdefault("gap_processing", {})["categories_completed"] = len(merged)
+
+        if total_processed > 0 or merged or self._has_completed_categories():
+            self.state_data["is_fresh_start"] = False
+        else:
+            self.state_data["is_fresh_start"] = True
 
         # 🚨 REVERSE GAP POLICY FIX: Only perform reverse gap detection on startup
         if file_grounded_data["linking_map_count"] > file_grounded_data["total_products"]:
@@ -291,7 +350,9 @@ class FixedEnhancedStateManager:
 
         # Update total products from file-grounded data
         self.state_data["total_products"] = file_grounded_data["total_products"]
-        self.state_data["successful_products"] = file_grounded_data["processed_products"]
+        self.state_data["successful_products"] = max(
+            self.state_data.get("successful_products", 0), total_processed
+        )
 
         # Update category completion status
         if file_grounded_data["category_completion_status"]:
@@ -302,6 +363,19 @@ class FixedEnhancedStateManager:
         # Update supplier extraction progress with file-grounded metrics
         current_category_analysis = self._calculate_current_category_metrics(file_grounded_data)
         self.state_data["supplier_extraction_progress"].update(current_category_analysis)
+
+        # Ensure the resume pointer is synchronized with analyzed data
+        sp = self.state_data.setdefault("system_progression", {})
+        rp = sp.setdefault("resumption_ptr", {})
+        rp["phase"] = rp.get("phase") or sp.get("current_phase", "supplier")
+        rp["cat_idx"] = max(
+            int(rp.get("cat_idx", 0) or 0),
+            current_category_analysis.get("current_category_index", 0),
+            len(self.state_data.get("completed_categories", [])),
+        )
+        rp["prod_idx"] = max(int(rp.get("prod_idx", 0) or 0), 0)
+        sp["resumption_ptr"] = rp
+        sp.setdefault("total_categories", current_category_analysis.get("total_categories", 0))
 
         # Mark startup analysis as completed
         self._startup_completed = True
@@ -518,6 +592,46 @@ class FixedEnhancedStateManager:
 
         self.update_discovered_products_in_category(category_url, actual_discovered, save=save)
 
+    def is_category_denominator_frozen(self, category_url: str) -> bool:
+        from utils.normalization import normalize_url
+
+        denominators = self.state_data.setdefault("frozen_category_denominators", {})
+        normalized = normalize_url(category_url)
+        return normalized in denominators
+
+    def set_frozen_denominator(
+        self, category_url: str, discovered_count: int, metadata: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        from utils.normalization import normalize_url
+
+        denominators = self.state_data.setdefault("frozen_category_denominators", {})
+        normalized = normalize_url(category_url)
+        if normalized in denominators:
+            return False
+
+        entry: Dict[str, Any] = {
+            "count": int(max(discovered_count, 0)),
+            "frozen_at": datetime.now(timezone.utc).isoformat(),
+            "original_url": category_url,
+        }
+        if metadata:
+            entry.update(metadata)
+
+        denominators[normalized] = entry
+        return True
+
+    def get_frozen_denominator(self, category_url: str) -> Optional[int]:
+        from utils.normalization import normalize_url
+
+        denominators = self.state_data.get("frozen_category_denominators", {})
+        normalized = normalize_url(category_url)
+        entry = denominators.get(normalized)
+        if isinstance(entry, dict):
+            return entry.get("count")
+        if isinstance(entry, (int, float)):
+            return int(entry)
+        return None
+
     def update_processing_progress(self, increment: int = 1, product_url: Optional[str] = None):
         """
         🚨 CRITICAL FIX 5: Update progress tracking AND resumption index for exact recovery
@@ -626,7 +740,119 @@ class FixedEnhancedStateManager:
 
         self.save_state_atomic()
 
-    def save_state(self, preserve_interruption_state: bool = True):
+    def get_resumption_ptr(self) -> ResumptionPointer:
+        sp = self.state_data.setdefault("system_progression", {})
+        rp = sp.setdefault("resumption_ptr", {})
+
+        phase = rp.get("phase") or sp.get("current_phase", "supplier")
+        try:
+            cat_idx = int(rp.get("cat_idx", sp.get("current_category_index", 0)) or 0)
+        except (TypeError, ValueError):
+            cat_idx = 0
+        try:
+            prod_idx = int(rp.get("prod_idx", sp.get("current_product_index_in_category", 0)) or 0)
+        except (TypeError, ValueError):
+            prod_idx = 0
+
+        return ResumptionPointer(phase=phase, cat_idx=max(cat_idx, 0), prod_idx=max(prod_idx, 0))
+
+    def commit_supplier_progress(
+        self,
+        cat_idx: int,
+        prod_idx: int,
+        total_cats: int,
+        cat_url: str,
+        total_prod_in_cat: int,
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        sp = self.state_data.setdefault("system_progression", {})
+        safe_cat_idx = max(int(cat_idx), 0)
+        safe_prod_idx = max(int(prod_idx), 0)
+        total_cats = max(int(total_cats or 0), sp.get("total_categories", 0))
+        total_prod_in_cat = max(int(total_prod_in_cat or 0), 0)
+
+        sp.update(
+            {
+                "current_phase": "supplier",
+                "current_category_index": safe_cat_idx,
+                "current_category_url": cat_url,
+                "total_categories": total_cats,
+                "current_product_index_in_category": safe_prod_idx,
+                "total_products_in_current_category": total_prod_in_cat,
+            }
+        )
+
+        rp = sp.setdefault("resumption_ptr", {})
+        rp["phase"] = "supplier"
+        rp["cat_idx"] = safe_cat_idx
+        rp["prod_idx"] = safe_prod_idx + 1 if total_prod_in_cat else safe_prod_idx
+        sp["resumption_ptr"] = rp
+
+        sep = self.state_data.setdefault("supplier_extraction_progress", {})
+        sep.update(
+            {
+                "current_category_index": safe_cat_idx,
+                "current_category_url": cat_url,
+                "total_categories": total_cats,
+                "current_product_index_in_category": safe_prod_idx,
+                "total_products_in_current_category": total_prod_in_cat,
+            }
+        )
+
+        if total_prod_in_cat and not self.is_category_denominator_frozen(cat_url):
+            freeze_metadata = metadata or {}
+            self.set_frozen_denominator(cat_url, total_prod_in_cat, freeze_metadata)
+
+        self.save_state_atomic(context="supplier-commit")
+        log.info(
+            "✅ SUPPLIER PROGRESS COMMITTED: cat=%s, prod_idx=%s, total=%s",
+            safe_cat_idx,
+            safe_prod_idx,
+            total_prod_in_cat,
+        )
+
+    def commit_amazon_progress(
+        self,
+        cat_idx: int,
+        queue_idx: int,
+        total_cats: int,
+        cat_url: str,
+        queue_len: int,
+    ):
+        sp = self.state_data.setdefault("system_progression", {})
+        safe_cat_idx = max(int(cat_idx), 0)
+        safe_queue_idx = max(int(queue_idx), 0)
+        total_cats = max(int(total_cats or 0), sp.get("total_categories", 0))
+        queue_len = max(int(queue_len or 0), 0)
+
+        sp.update(
+            {
+                "current_phase": "amazon",
+                "current_category_index": safe_cat_idx,
+                "current_category_url": cat_url,
+                "total_categories": total_cats,
+                "current_product_index_in_category": safe_queue_idx,
+                "total_products_in_current_category": queue_len,
+            }
+        )
+
+        rp = sp.setdefault("resumption_ptr", {})
+        rp["phase"] = "amazon"
+        rp["cat_idx"] = safe_cat_idx
+        rp["prod_idx"] = min(safe_queue_idx + 1, max(queue_len, safe_queue_idx + 1))
+        sp["resumption_ptr"] = rp
+
+        self.save_state_atomic(context="amazon-commit")
+        log.info(
+            "✅ AMAZON PROGRESS COMMITTED: cat=%s, queue_idx=%s, queue_len=%s",
+            safe_cat_idx,
+            safe_queue_idx,
+            queue_len,
+        )
+
+    def save_state(
+        self, preserve_interruption_state: bool = True, context: Optional[str] = None
+    ):
         """
         🚨 CRITICAL FIX 6: Save state WITHOUT performing reverse gap detection
         Args:
@@ -665,6 +891,9 @@ class FixedEnhancedStateManager:
         except Exception as e:
             log.error(f"❌ Failed to save state: {e}")
 
+        if context:
+            log.debug("State save context: %s", context)
+
         sp = self.state_data.get("system_progression", {})
         sep = self.state_data.get("supplier_extraction_progress", {})
         phase = sp.get("current_phase", "unknown")
@@ -677,9 +906,41 @@ class FixedEnhancedStateManager:
         ccu = sp.get("current_category_url", "")
         log.info(f"RESUME PTR: phase={phase} cat_idx={cci}/{tc} url={ccu} prod_idx={cpi}/{tpc}")
 
-    def save_state_atomic(self):
+    def save_state_atomic(self, context: Optional[str] = None):
         """Atomic save wrapper used by new progression methods"""
-        self.save_state(preserve_interruption_state=True)
+        self.save_state(preserve_interruption_state=True, context=context)
+
+    def _get_linking_map_path(self) -> Path:
+        supplier_domain = self.supplier_name.replace("-", ".")
+        return (
+            Path(__file__).parent.parent
+            / "OUTPUTS"
+            / "FBA_ANALYSIS"
+            / "linking_maps"
+            / supplier_domain
+            / "linking_map.json"
+        )
+
+    def _calculate_total_processed(self) -> int:
+        """Return the number of processed products based on the linking map."""
+        linking_path = self._get_linking_map_path()
+        try:
+            if linking_path.exists():
+                with open(linking_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                if isinstance(data, list):
+                    return len(data)
+        except Exception as exc:
+            log.warning("Failed to calculate total processed from %s: %s", linking_path, exc)
+        return 0
+
+    def _has_completed_categories(self) -> bool:
+        if self.state_data.get("completed_categories"):
+            return True
+        sep_completed = self.state_data.get("supplier_extraction_progress", {}).get(
+            "categories_completed", []
+        )
+        return bool(sep_completed)
 
     def _calculate_file_grounded_totals(self) -> Dict[str, Any]:
         """
@@ -953,37 +1214,72 @@ class FixedEnhancedStateManager:
             log.error(f"Failed to calculate current category metrics: {e}")
             return {}
 
-    def mark_category_completed(self, category_url: str):
-        """Mark a category as completed - resumption_index now updates continuously"""
-        # Update category completion status
-        if (
-            "gap_processing" in self.state_data
-            and "category_completion_status" in self.state_data["gap_processing"]
-        ):
-            if category_url in self.state_data["gap_processing"]["category_completion_status"]:
-                self.state_data["gap_processing"]["category_completion_status"][category_url][
-                    "status"
-                ] = "FULLY_PROCESSED"
-                self.state_data["gap_processing"]["category_completion_status"][category_url][
-                    "completion_pct"
-                ] = 100.0
+    def mark_category_completed(
+        self, category_index: Union[int, str], category_url: Optional[str] = None
+    ):
+        """Mark a category as completed and advance resume pointers safely."""
 
-        # Add to completed categories
-        if (
-            category_url
-            not in self.state_data["supplier_extraction_progress"]["categories_completed"]
-        ):
-            self.state_data["supplier_extraction_progress"]["categories_completed"].append(
-                category_url
+        if category_url is None and isinstance(category_index, str):
+            category_url = category_index
+            category_index_int: Optional[int] = None
+        else:
+            category_index_int = (
+                int(category_index)
+                if category_index is not None and not isinstance(category_index, str)
+                else None
             )
 
-        # Update last completed category
-        self.state_data["supplier_extraction_progress"]["last_completed_category"] = category_url
+        if not category_url:
+            log.warning("mark_category_completed called without category_url context")
+            return
 
-        # Note: resumption_index now updates continuously via update_processing_progress()
-        # No need to update it here as it's always current
+        from utils.normalization import normalize_url
 
-        log.info(f"✅ Category marked as completed: {category_url[:50]}...")
+        normalized_url = normalize_url(category_url)
+
+        # Update category completion status structures
+        sep = self.state_data.setdefault("supplier_extraction_progress", {})
+        categories_completed = sep.setdefault("categories_completed", [])
+        if normalized_url not in {normalize_url(url) for url in categories_completed}:
+            categories_completed.append(category_url)
+
+        self.state_data.setdefault("completed_categories", [])
+        existing_completed = self.state_data["completed_categories"]
+        if normalized_url not in {normalize_url(url) for url in existing_completed}:
+            existing_completed.append(category_url)
+        self.state_data["completed_categories"] = existing_completed
+
+        sep["last_completed_category"] = category_url
+
+        gap_processing = self.state_data.setdefault("gap_processing", {})
+        gap_processing["categories_completed"] = len(existing_completed)
+        category_status = gap_processing.setdefault("category_completion_status", {})
+        if category_url in category_status:
+            category_status[category_url]["status"] = "FULLY_PROCESSED"
+            category_status[category_url]["completion_pct"] = 100.0
+
+        # Advance progression pointers while keeping resume index coherent
+        sp = self.state_data.setdefault("system_progression", {})
+        rp = sp.setdefault("resumption_ptr", {})
+
+        if category_index_int is not None:
+            if sp.get("current_category_index") == category_index_int:
+                sp["current_category_index"] = category_index_int + 1
+            rp["cat_idx"] = max(rp.get("cat_idx", 0), category_index_int + 1)
+        else:
+            rp["cat_idx"] = max(rp.get("cat_idx", 0), len(existing_completed))
+
+        rp["phase"] = rp.get("phase") or sp.get("current_phase", "supplier")
+        rp["prod_idx"] = 0
+        sp["resumption_ptr"] = rp
+        sp["current_product_index_in_category"] = 0
+
+        self.save_state_atomic(context="category-complete")
+        log.info(
+            "✅ Category marked as completed: %s (resume cat_idx=%s)",
+            category_url[:80],
+            rp.get("cat_idx", 0),
+        )
 
     def get_resumption_index(self) -> int:
         """Get the index from which to resume processing"""


### PR DESCRIPTION
## Summary
- harden the enhanced state manager to record startup progress, freeze category denominators, and expose commit helpers for supplier and Amazon phases
- add authoritative category counting, resume-aware gating, and state commit hooks to the passive extraction workflow so category resumes and completions are persisted correctly

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'langraph_integration')*

------
https://chatgpt.com/codex/tasks/task_e_68c98fe1512c83328558e4b6722daca2